### PR TITLE
Prefer HTTP in production when PORT present; add transport selection helper and tests

### DIFF
--- a/src/transport-selection.ts
+++ b/src/transport-selection.ts
@@ -1,0 +1,39 @@
+export type TransportDecisionOptions = {
+    mcpTransport?: string | undefined;
+    port?: number | undefined;
+    nodeEnv?: string | undefined;
+    stdinAttached?: boolean | undefined;
+};
+
+export type TransportDecision = {
+    useStdio: boolean;
+    reason?: string;
+};
+
+export function decideTransport(opts: TransportDecisionOptions): TransportDecision {
+    const explicit = (opts.mcpTransport || '').toLowerCase();
+    const port = opts.port;
+    const env = (opts.nodeEnv || 'development');
+    const stdinAttached = Boolean(opts.stdinAttached);
+
+    if (explicit === 'stdio') {
+        return { useStdio: true, reason: 'explicit-mcp-stdio' };
+    }
+    if (explicit === 'http') {
+        return { useStdio: false, reason: 'explicit-mcp-http' };
+    }
+
+    if (env === 'production' && port) {
+        return { useStdio: false, reason: 'production-port-prefers-http' };
+    }
+
+    if (stdinAttached && port) {
+        return { useStdio: true, reason: 'stdin-attached-port-prefers-stdio' };
+    }
+
+    if (port) {
+        return { useStdio: false, reason: 'port-present-http' };
+    }
+
+    return { useStdio: true, reason: 'no-port-stdio' };
+}

--- a/test/transport-selection.test.ts
+++ b/test/transport-selection.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { decideTransport } from '../src/transport-selection'
+
+describe('decideTransport', () => {
+    it('forces HTTP in production when PORT is present', () => {
+        const d = decideTransport({ port: 8080, nodeEnv: 'production', stdinAttached: true })
+        expect(d.useStdio).toBe(false)
+        expect(d.reason).toBe('production-port-prefers-http')
+    })
+
+    it('respects explicit MCP_TRANSPORT=stdio', () => {
+        const d = decideTransport({ mcpTransport: 'stdio', port: 8080, nodeEnv: 'production', stdinAttached: false })
+        expect(d.useStdio).toBe(true)
+        expect(d.reason).toBe('explicit-mcp-stdio')
+    })
+
+    it('prefers stdio when stdin attached in development', () => {
+        const d = decideTransport({ port: 8080, nodeEnv: 'development', stdinAttached: true })
+        expect(d.useStdio).toBe(true)
+        expect(d.reason).toBe('stdin-attached-port-prefers-stdio')
+    })
+
+    it('uses HTTP when PORT is set and no stdin attached', () => {
+        const d = decideTransport({ port: 8080, nodeEnv: 'development', stdinAttached: false })
+        expect(d.useStdio).toBe(false)
+        expect(d.reason).toBe('port-present-http')
+    })
+
+    it('uses stdio when no port present', () => {
+        const d = decideTransport({ nodeEnv: 'development', stdinAttached: false })
+        expect(d.useStdio).toBe(true)
+        expect(d.reason).toBe('no-port-stdio')
+    })
+})


### PR DESCRIPTION
Title: Prefer HTTP in production to avoid stdio handshake issues

What:
- Force HTTP transport when `NODE_ENV=production` and `PORT` is present to avoid stdio-based protocol conflicts with process managers (Render, CI, etc.).
- Extract transport decision logic to `src/transport-selection.ts` and add unit tests to cover key decision branches.

Why:
- Render and similar platforms attach stdin and set `PORT`, which previously caused the server to prefer stdio and fail the localprocess handshake when not speaking MCP protocol on stdio.

Acceptance criteria (AC):
- [ ] Logs show `production-port-prefers-http` decision when `NODE_ENV=production` and `PORT` exists.
- [ ] /healthz returns 200 OK after deploying to Render (service does not exit early).
- [ ] Unit tests cover production and development transport decisions and pass on CI.

Files changed:
- `src/index.ts` — use the testable decision helper and keep logging for notable cases
- `src/transport-selection.ts` — new helper
- `test/transport-selection.test.ts` — tests for decision matrix

Testing notes:
- `npm test` passes locally (added tests included)
- Manual verification: start the app with `NODE_ENV=production` and a `PORT` set and confirm HTTP mode starts and listens (e.g., curl /healthz)

Rollback: revert the branch or set `MCP_TRANSPORT=stdio` env if you need to force stdio for debugging.
