### PR TITLE
fix: Run Prisma migrations before seeding in Render deploy

### DIFF
--- a/deploy/render.yaml
+++ b/deploy/render.yaml
@@ -4,7 +4,7 @@ services:
     env: docker
     plan: starter
     branch: main
-    buildCommand: npm ci && npm run build && npm run prisma:seed
+    buildCommand: npm ci && npm run build && npx prisma migrate deploy && npm run prisma:seed
     startCommand: npm run start
     autoDeploy: true
     envVars:


### PR DESCRIPTION
## Problem

Database tables were not being created in production, causing empty database despite seeding attempt.

## Solution

Added \
px prisma migrate deploy\ to the build command before seeding.

## Build sequence now:
1. \
pm ci\ - Install dependencies
2. \
pm run build\ - Compile TypeScript (includes \prisma generate\)
3. \
px prisma migrate deploy\ - **Create database tables**
4. \
pm run prisma:seed\ - Insert seed data

## Testing
- This will fix the production database initialization
- Tables will be created and seeded on next deploy