### PR TITLE
feat: Add production startup script with migrations and seeding

### DIFF
--- a/scripts/start-production.sh
+++ b/scripts/start-production.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+npx prisma migrate deploy
+
+echo "Seeding database..."
+npm run prisma:seed
+
+echo "Starting server..."
+npm run start


### PR DESCRIPTION
- Create start-production.sh that runs migrations and seed before server start
- This works with Docker environments where Pre-Deploy Command isn't available
- Script runs: prisma migrate deploy -> prisma:seed -> npm start
- Update Render Docker Command to: sh scripts/start-production.sh