### PR TITLE
fix: Copy prisma directory to Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ ENV NODE_ENV=production
 # Copy built artifacts and package files
 COPY --from=build /app/package*.json ./
 COPY --from=build /app/dist ./dist
+COPY --from=build /app/prisma ./prisma
 
 # Install only production deps
 RUN npm ci --only=production


### PR DESCRIPTION
- Add COPY prisma directory to runtime stage
- Required for prisma migrate deploy and prisma:seed commands
- Schema and migrations must be present at runtime