### PR TITLE
fix: Use export syntax for DATABASE_URL in startup script

### DIFF
--- a/scripts/start-production.sh
+++ b/scripts/start-production.sh
@@ -2,7 +2,6 @@
 set -e
 
 echo "Running database migrations with direct connection..."
-echo "Using session pooler: ${DATABASE_URL_DIRECT}"
 env DATABASE_URL="${DATABASE_URL_DIRECT}" npx prisma migrate deploy
 
 echo "Seeding database with pooled connection..."


### PR DESCRIPTION
- Change from inline env var to explicit export
- Unset DATABASE_URL before seed/start to use default from env
- More reliable for Alpine sh in Docker