### PR TITLE
feat(itemstatus): expose ItemStatus enum in OpenAPI

### DIFF
--- a/docs/adr/0004-itemstatus-enum.md
+++ b/docs/adr/0004-itemstatus-enum.md
@@ -1,0 +1,53 @@
+# ADR 0004: ItemStatus representation (Postgres ENUM vs lookup table)
+
+Date: 2026-02-03
+
+## Status
+
+Accepted
+
+## Context
+
+A new `status` field was added to the `Book` model. The current implementation uses a Postgres ENUM type (created in migration `20260202173000_add_itemstatus_and_isadmin`) with values `NOT_STARTED`, `IN_PROGRESS`, and `COMPLETED`. The codebase also contains a TypeScript union type `ItemStatus` and helpers (`normalizeStatusInput`, `statusLabel`).
+
+Clients generate client SDKs from the OpenAPI (tsoa) spec. Previously, the OpenAPI spec did not expose the `ItemStatus` enum because controller DTOs typed `status` as `string`.
+
+## Decision
+
+Keep `ItemStatus` as a Postgres ENUM type. Ensure the API surface (tsoa controllers) uses the `ItemStatus` type so the generated OpenAPI spec includes a typed enum for clients.
+
+## Rationale
+
+- Postgres ENUM provides type safety at the DB level and is simple to reason about (values are fixed and enforced by DB).
+- Changing between statuses is infrequent; ENUMs are stable and avoid an extra join for simple lookups.
+- Minimal application code changes are required (controllers and schemas), and we can surface enum to clients by using the shared `ItemStatus` type in controller DTOs.
+
+## Alternatives
+
+1) Use a dedicated `ItemStatus` lookup table and store a foreign key on `Book`.
+   - Pros: Flexible, can add/remove statuses without DB migrations; can store labels/translations; queryable metadata for UI.
+   - Cons: More complexity in queries, join overhead, data migrations for existing enum values.
+
+2) Keep a plain string column with application-side validation.
+   - Pros: Simple schema changes.
+   - Cons: No DB-level enforcement; risk of inconsistent values.
+
+## Consequences
+
+- Implemented change to controllers so `status` surfaces in OpenAPI as enum for client generation (see PR/commit).
+- Tests added/updated to assert swagger has `ItemStatus` and `Book.status` references.
+- Tools-level JSON schemas updated to include `enum` for validation of inputs.
+
+## Migration / Rollout Plan
+
+- For today's change (surface enum to OpenAPI): merge code, regenerate spec (`npm run build:spec`), publish updated spec, and notify client SDK consumers to regenerate if needed.
+- If we later convert to a lookup table: write a migration that creates the table, inserts canonical rows, performs a backfill, and updates application code to use the relationship. Include a rollback to restore previous enum state.
+
+## Observability & Runbook
+
+- Add a post-deploy validation step to confirm `GET /docs/swagger.json` contains `components.schemas.ItemStatus` with the expected enum values.
+- Run DB schema migration tests in CI and confirm `prisma migrate` results.
+
+## Owner
+
+Architect: @bryan-debaun

--- a/src/http/controllers/BooksController.ts
+++ b/src/http/controllers/BooksController.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Post, Put, Delete, Query, Route, Tags, Response, SuccessResponse, Path, Body, Security, Request } from 'tsoa';
 import type { Request as ExpressRequest } from 'express';
+import type { ItemStatus } from '../../tools/db/books/status';
 
 /**
  * Book representation
@@ -10,6 +11,7 @@ export interface Book {
     description?: string;
     isbn?: string;
     publishedAt?: string;
+    status: ItemStatus;
     createdAt: string;
     updatedAt: string;
 }
@@ -37,7 +39,7 @@ export interface ListBooksResponse {
  */
 export interface CreateBookRequest {
     title: string;
-    status?: string;
+    status?: ItemStatus;
     description?: string;
     isbn?: string;
     publishedAt?: string;
@@ -49,7 +51,7 @@ export interface CreateBookRequest {
  */
 export interface UpdateBookRequest {
     title?: string;
-    status?: string;
+    status?: ItemStatus;
     description?: string;
     isbn?: string;
     publishedAt?: string;
@@ -78,7 +80,7 @@ export class BooksController extends Controller {
         @Query() authorId?: number,
         @Query() minRating?: number,
         @Query() search?: string,
-        @Query() status?: string,
+        @Query() status?: ItemStatus,
         @Query() limit?: number,
         @Query() offset?: number
     ): Promise<ListBooksResponse> {

--- a/src/tools/db/books/schemas.ts
+++ b/src/tools/db/books/schemas.ts
@@ -4,7 +4,7 @@ export const CreateBookInputSchema = {
     type: "object",
     properties: {
         title: { type: "string", description: "Book title" },
-        status: { type: "string", description: "Book status (e.g., Not started, In progress, Completed)" },
+        status: { type: "string", description: "Book status (e.g., Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
         description: { type: "string", description: "Book description" },
         isbn: { type: "string", description: "ISBN (optional, must be unique)" },
         publishedAt: { type: "string", description: "Publication date (ISO 8601 format)" },
@@ -23,7 +23,7 @@ export const UpdateBookInputSchema = {
     properties: {
         id: { type: "number", description: "Book ID" },
         title: { type: "string", description: "Book title" },
-        status: { type: "string", description: "Book status (e.g., Not started, In progress, Completed)" },
+        status: { type: "string", description: "Book status (e.g., Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
         description: { type: "string", description: "Book description" },
         isbn: { type: "string", description: "ISBN (must be unique)" },
         publishedAt: { type: "string", description: "Publication date (ISO 8601 format)" },
@@ -58,7 +58,7 @@ export const ListBooksInputSchema = {
         authorId: { type: "number", description: "Filter by author ID" },
         minRating: { type: "number", description: "Minimum average rating (1-10)" },
         search: { type: "string", description: "Search in title and description" },
-        status: { type: "string", description: "Filter by status (Not started, In progress, Completed)" },
+        status: { type: "string", description: "Filter by status (Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
         limit: { type: "number", description: "Maximum number of results (default 50)" },
         offset: { type: "number", description: "Number of results to skip (default 0)" },
     },

--- a/test/http/tsoa-books-controller.test.ts
+++ b/test/http/tsoa-books-controller.test.ts
@@ -58,6 +58,16 @@ describe('tsoa books controller', () => {
         expect(spec.paths).toHaveProperty('/api/authors');
         expect(spec.paths).toHaveProperty('/api/authors/{id}');
         expect(spec.paths).toHaveProperty('/api/ratings');
+
+        // ItemStatus enum should be present and referenced by Book
+        expect(spec).toHaveProperty('components');
+        expect(spec.components).toHaveProperty('schemas');
+        expect(spec.components.schemas).toHaveProperty('ItemStatus');
+        expect(Array.isArray(spec.components.schemas.ItemStatus.enum)).toBe(true);
+        expect(spec.components.schemas.ItemStatus.enum).toEqual(['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED']);
+        expect(spec.components.schemas.Book.properties.status.$ref).toBe('#/components/schemas/ItemStatus');
+        expect(spec.components.schemas.CreateBookRequest.properties.status.$ref).toBe('#/components/schemas/ItemStatus');
+
     });
 
     it('should return book by ID via tsoa controller GET /api/books/:id', async () => {

--- a/tools/postman/mcp-server.postman_collection.json
+++ b/tools/postman/mcp-server.postman_collection.json
@@ -123,6 +123,61 @@
             ]
         },
         {
+            "name": "Docs - Swagger UI",
+            "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                    "raw": "{{base_url}}/docs",
+                    "host": [
+                        "{{base_url}}"
+                    ],
+                    "path": [
+                        "docs"
+                    ]
+                }
+            },
+            "event": [
+                {
+                    "listen": "test",
+                    "script": {
+                        "exec": [
+                            "pm.test('Status is 200', function () { pm.response.to.have.status(200); });",
+                            "pm.test('Body contains Swagger UI', function () { pm.expect(pm.response.text()).to.include('Swagger'); });"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Docs - Swagger JSON",
+            "request": {
+                "method": "GET",
+                "header": [],
+                "url": {
+                    "raw": "{{base_url}}/docs/swagger.json",
+                    "host": [
+                        "{{base_url}}"
+                    ],
+                    "path": [
+                        "docs",
+                        "swagger.json"
+                    ]
+                }
+            },
+            "event": [
+                {
+                    "listen": "test",
+                    "script": {
+                        "exec": [
+                            "pm.test('Status is 200', function () { pm.response.to.have.status(200); });",
+                            "pm.test('Response is JSON or contains json-like', function () { try { var json = pm.response.json(); pm.expect(json).to.be.ok; } catch (e) { pm.expect(pm.response.text()).to.include('{'); } });"
+                        ]
+                    }
+                }
+            ]
+        },
+        {
             "name": "Invite Accept (POST)",
             "request": {
                 "method": "POST",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "compilerOptions": {
         "target": "ES2022",
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
+        "module": "ES2022",
+        "moduleResolution": "node",
         "lib": [
             "ES2022"
         ],


### PR DESCRIPTION
This PR exposes the DB Postgres enum 'ItemStatus' in the OpenAPI spec by typing controller DTOs with ItemStatus, adds enum validation to book input schemas, adds an ADR describing the decision, and adjusts TS config to allow extensionless ESM imports.\n\nChanges: src/http/controllers/BooksController.ts, src/tools/db/books/schemas.ts, test/http/tsoa-books-controller.test.ts, tsconfig.json, docs/adr/0004-itemstatus-enum.md.\n\nPlease review and let me know if you want the enum converted to a lookup table (separate migration PR).