### PR TITLE
chore: add SendGrid runbook, CI check, integration test, and session endpoint (issues #50, #54)

### DIFF
--- a/.github/workflows/sendgrid-check.yml
+++ b/.github/workflows/sendgrid-check.yml
@@ -1,0 +1,37 @@
+name: SendGrid Config Check
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  sendgrid-check:
+    name: SendGrid config and integration check
+    runs-on: ubuntu-latest
+    if: github.repository == 'bryan-debaun/mcp-server'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Ensure SendGrid secrets are present
+        env:
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          SENDER_EMAIL: ${{ secrets.SENDER_EMAIL }}
+        run: |
+          if [ -z "$SENDGRID_API_KEY" ]; then echo 'Missing SENDGRID_API_KEY'; exit 1; fi
+          if [ -z "$SENDER_EMAIL" ]; then echo 'Missing SENDER_EMAIL'; exit 1; fi
+          echo 'SendGrid secrets present.'
+
+      - name: Run SendGrid integration test (gated)
+        env:
+          CI_SENDGRID_CHECK: 'true'
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+          SENDER_EMAIL: ${{ secrets.SENDER_EMAIL }}
+        run: npx vitest run test/integration/sendgrid-config.test.ts

--- a/docs/mcp-http.md
+++ b/docs/mcp-http.md
@@ -41,6 +41,11 @@ This document describes the new HTTP-based transports for the MCP server.
 - SSE is a fallback when an HTTP Stream client is not available; it requires clients to POST events separately to `/mcp/events`.
 - The endpoints are guarded by `MCP_API_KEY` to protect hosted servers.
 
+### Email / SendGrid
+
+- The application uses SendGrid for transactional email when `SENDGRID_API_KEY` is present. Set `SENDER_EMAIL` (or `FROM_EMAIL`) to a verified address (recommended: `no-reply@bryandebaun.dev`).
+- See `docs/runbooks/sendgrid.md` for verification, DNS checks, key rotation, and CI gating details.
+
 ### Auth session endpoint
 
 The server exposes `GET /api/auth/session` which reads the `session` cookie and returns a minimal authenticated user object. The cookie is signed using `SESSION_JWT_SECRET` in production; when `SESSION_JWT_SECRET` is not set (development), a base64-encoded JSON payload is accepted for convenience. Response shape:

--- a/docs/runbooks/sendgrid.md
+++ b/docs/runbooks/sendgrid.md
@@ -1,0 +1,77 @@
+# SendGrid Runbook
+
+This runbook documents SendGrid setup, verification, key rotation, and troubleshooting for MCP Server.
+
+## Summary
+
+- Domain: `send.bryandebaun.dev` (link branding)
+- Return path: `rp.send.bryandebaun.dev`
+- Environment variables used by the application: `SENDGRID_API_KEY`, `SENDER_EMAIL` (or `FROM_EMAIL`)
+
+## Verification steps
+
+1. In SendGrid UI: go to **Settings → Sender Authentication → Domain Authentication → Get Started**.
+   - Use `send` for the link subdomain label and `rp` for the return path label.
+   - Choose your DNS provider and follow the wizard to obtain CNAME records.
+2. Add the provided **CNAME** records to your DNS provider (Cloudflare recommended).
+   - **Important:** set the Cloudflare proxy status to **DNS only (grey cloud)** for these records.
+3. Wait for DNS propagation and click **Verify** in the SendGrid UI.
+4. Send a controlled test email to a mailbox you control and inspect the message headers for `DKIM=pass` and `SPF=pass`.
+
+### DNS check commands
+
+- PowerShell:
+
+```powershell
+Resolve-DnsName -Name s1._domainkey.send.bryandebaun.dev -Type CNAME
+Resolve-DnsName -Name s2._domainkey.send.bryandebaun.dev -Type CNAME
+Resolve-DnsName -Name rp.send.bryandebaun.dev -Type CNAME
+```
+
+- dig (WSL/macOS):
+
+```bash
+dig +short CNAME s1._domainkey.send.bryandebaun.dev
+dig +short CNAME s2._domainkey.send.bryandebaun.dev
+dig +short CNAME rp.send.bryandebaun.dev
+```
+
+- nslookup:
+
+```bash
+nslookup -type=CNAME s1._domainkey.send.bryandebaun.dev 8.8.8.8
+```
+
+## Secrets and rotation
+
+- Store the SendGrid API key only in Render (or your host secret manager) and in GitHub Actions secrets (`SENDGRID_API_KEY`).
+- To rotate a key:
+  1. In SendGrid, create a new API key with the same minimal permissions (email sending).
+  2. Update the `SENDGRID_API_KEY` secret in Render and in GitHub repo secrets.
+  3. Trigger the SendGrid config check (see CI section) or run a manual test send.
+  4. Revoke the old key after verification.
+
+## CI / Verification
+
+- A GitHub Actions workflow `sendgrid-check.yml` runs on `push` to `main` and `workflow_dispatch` and ensures the `SENDGRID_API_KEY` and `SENDER_EMAIL` secrets are present. It also runs a short integration test when manually dispatched.
+- The integration test is feature-flagged and only runs when `CI_SENDGRID_CHECK=true`.
+
+## Troubleshooting
+
+- If SendGrid verification fails:
+  - Ensure CNAME entries exist and are **DNS only** (no Cloudflare proxy).
+  - Confirm the zone is `bryandebaun.dev` and that the left-hand labels in Cloudflare match (e.g., `s1._domainkey.send`).
+  - Wait for TTL propagation (can take up to 1 hour or more depending on provider).
+
+- If emails land in spam:
+  - Ensure DKIM and SPF pass in message headers.
+  - Verify `SENDER_EMAIL` is a verified sender or aligns with your authenticated domain.
+  - Check SendGrid suppression lists and bounce/complaint webhooks.
+
+## Manual e2e test (manual job)
+
+- Use the `workflow_dispatch` job `SendGrid Config Check` to run a safe verification or to manually run a single test send. Use this in production only — it uses the real secret and should be run by a repo admin.
+
+---
+
+Maintainers: @bryan-debaun

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,24 @@ async function main(): Promise<void> {
             console.error('ADMIN_DEBUG_ENABLED is enabled for this process; debug endpoints will be registered (preview/staging only)')
         }
     }
+
+    // SendGrid configuration warning (non-blocking)
+    const sendgridKey = process.env.SENDGRID_API_KEY
+    const senderEmail = process.env.SENDER_EMAIL ?? process.env.FROM_EMAIL
+
+    if (env === 'production') {
+        if (!sendgridKey || !senderEmail) {
+            console.warn('SendGrid not fully configured for production. Missing SENDGRID_API_KEY or SENDER_EMAIL; transactional emails will not be sent. See docs/runbooks/sendgrid.md for setup.')
+        } else {
+            console.error('SendGrid appears configured for production (SENDER_EMAIL present).')
+        }
+    } else {
+        if (!sendgridKey || !senderEmail) {
+            console.error('SendGrid not configured for local/testing — this is expected in development. Set SENDGRID_API_KEY/SENDER_EMAIL to test email sending.')
+        } else {
+            console.error('SendGrid configured in non-production environment (SENDER_EMAIL=%s).', senderEmail)
+        }
+    }
 }
 
 main().catch((error) => {

--- a/test/integration/sendgrid-config.test.ts
+++ b/test/integration/sendgrid-config.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest'
+
+const enabled = process.env.CI_SENDGRID_CHECK === 'true'
+
+    ; (enabled ? describe : describe.skip)('SendGrid configuration (CI gated)', () => {
+        it('has SENDGRID_API_KEY and SENDER_EMAIL', () => {
+            expect(process.env.SENDGRID_API_KEY, 'SENDGRID_API_KEY must be present').toBeDefined()
+            expect(process.env.SENDGRID_API_KEY!.length, 'SENDGRID_API_KEY looks too short').toBeGreaterThan(20)
+            expect(process.env.SENDER_EMAIL, 'SENDER_EMAIL must be present').toBeDefined()
+            expect(process.env.SENDER_EMAIL, 'SENDER_EMAIL should include an @').toMatch(/@/)
+        })
+    })


### PR DESCRIPTION
This draft PR implements work for issues #50 and #54:

- Add SendGrid runbook: `docs/runbooks/sendgrid.md` (verification, rotation, DNS checks)
- Add gated integration test: `test/integration/sendgrid-config.test.ts`
- Add GitHub Actions job: `.github/workflows/sendgrid-check.yml` to verify secrets and run the gated test
- Update docs: `docs/mcp-http.md` references SendGrid
- Add non-blocking startup warning when SendGrid config is missing (`src/index.ts`)
- Misc: small test adjustments

Testing steps:
1. Locally: `npm ci && npm test` (note: some integration tests require DB/JWKS envs and are skipped unless configured)
2. SendGrid check workflow: go to Actions → "SendGrid Config Check" → Run workflow (or use `gh workflow run sendgrid-check.yml`)

Notes:
- The gated integration test runs only when `CI_SENDGRID_CHECK=true`, and the workflow injects `SENDGRID_API_KEY` and `SENDER_EMAIL` from repo secrets.
- Do not commit secrets to the repo; keep them in Render/GitHub Secrets.

Closes: #50, #54
