### PR TITLE
feat: make magic-link verify public & fix update-issue comment handling

### DIFF
--- a/src/http/middleware/mcp-auth.ts
+++ b/src/http/middleware/mcp-auth.ts
@@ -6,6 +6,12 @@ export function mcpAuthMiddleware(req: Request, res: Response, next: NextFunctio
     // No-op when key not set
     if (!mcpKey) return next();
 
+    // Allow public magic-link/auth endpoints to remain unauthenticated so
+    // user-facing auth flows (send/register/verify) continue to work even when
+    // MCP_API_KEY is set for other DB-dependent routes.
+    const path = req.path || '';
+    if (path.startsWith('/api/auth/magic-link')) return next();
+
     try {
         const auth = (req.headers.authorization || '').toString();
         if (auth === `Bearer ${mcpKey}`) return next();


### PR DESCRIPTION
Fixes #67, #68

Summary:
- Whitelist /api/auth/magic-link* so verify endpoints remain public when MCP_API_KEY is set
- Use --body-file for multiline/large comments in the update-issue tool to avoid silent failures
- Add unit tests to prevent regressions

Files changed: src/http/middleware/mcp-auth.ts, src/tools/github-issues/update-issue.ts, test/http/magic-link-route.test.ts, test/tools/github-issues/update-issue.test.ts

All unit tests pass locally (run: npm test).