### PR TITLE
feat: centralized config module with Zod env validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,66 @@
-# Example local environment variables
+# Example local environment variables — mirrors the full schema in src/config.ts
+
+# ── Core ──────────────────────────────────────────────────────────────────────
+NODE_ENV=development
+PORT=3000
+HOST=0.0.0.0
+MCP_TRANSPORT=http          # 'stdio' | 'http'
+EARLY_START=0               # '1' to skip waiting for DB before starting HTTP
+
+# ── Security ──────────────────────────────────────────────────────────────────
+MCP_API_KEY=changeme                    # Required to protect MCP HTTP endpoints
+ADMIN_DEBUG_ENABLED=0                  # '1' to enable admin debug endpoint
+ADMIN_IP_ALLOWLIST=127.0.0.1           # Comma-separated CIDRs/IPs for admin access
+INTERNAL_ADMIN_KEY=changeme            # Second factor for /api/admin/* routes
+SHOW_INVITE_TOKEN=0                    # '1' to include invite token in admin responses
+
+# ── Database ──────────────────────────────────────────────────────────────────
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mcp_dev
+
+# ── Auth / Supabase ───────────────────────────────────────────────────────────
 SUPABASE_JWKS_URL=https://your-project.supabase.co/.well-known/jwks.json
-SUPABASE_AUD=your-audience
-SUPABASE_ISS=https://your-project.supabase.co
-SUPABASE_SERVICE_ROLE_KEY=changeme
-# Enable the admin debug endpoint for preview/troubleshooting. Default is disabled (0).
-# Set to '1' to enable and '0' (or unset) to disable.
-ADMIN_DEBUG_ENABLED=0
+# If SUPABASE_JWKS_URL is unset, derived from PUBLIC_SUPABASE_URL
+PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ISS=https://your-project.supabase.co   # Preferred over PUBLIC_SUPABASE_URL
+SUPABASE_AUD=authenticated
+SUPABASE_SERVICE_ROLE_KEY=changeme     # Preferred alias (SUPABASE_SECRET_KEY also accepted)
+SUPABASE_ANON_KEY=changeme             # Public/anon key (PUBLIC_SUPABASE_PUBLISHABLE_KEY also accepted)
+
+# ── Session ───────────────────────────────────────────────────────────────────
+SESSION_JWT_SECRET=changeme            # Signs session cookies; base64 dev fallback when absent
+SESSION_RATE_LIMIT_PER_IP=60          # Max session requests per IP per window (default 60)
+SESSION_RATE_LIMIT_WINDOW_MS=60000    # Window in ms (default 60000)
+SESSION_COOKIE_MAX_AGE_SEC=604800     # Cookie max-age in seconds (default 7 days)
+
+# ── Magic Link ────────────────────────────────────────────────────────────────
+MAGIC_LINK_JWT_SECRET=changeme
+MAGIC_LINK_BASE_URL=http://localhost:3000
+MAGIC_LINK_SUCCESS_URL=/              # Redirect after successful verification
+MAGIC_LINK_FRONTEND_URL=              # Alternative redirect URL
+MAGIC_LINK_PER_EMAIL_LIMIT=5         # Max magic link sends per email per hour
+
+# ── Email / SendGrid ──────────────────────────────────────────────────────────
+SENDGRID_API_KEY=SG.changeme
+SENDER_EMAIL=no-reply@yourdomain.com  # FROM_EMAIL also accepted
+SENDER_NAME=YourApp
+SUPPORT_EMAIL=support@yourdomain.com
+INVITE_BASE_URL=http://localhost:3000
+SENDGRID_CLICK_TRACKING=true          # 'false' to disable click tracking
+
+# ── Spotify ───────────────────────────────────────────────────────────────────
+SPOTIFY_CLIENT_ID=
+SPOTIFY_CLIENT_SECRET=
+SPOTIFY_REFRESH_TOKEN=
+SPOTIFY_REDIRECT_URI=http://localhost:3000/api/admin/spotify/oauth-callback
+SPOTIFY_POLL_INTERVAL_MS=15000        # Polling interval in ms (default 15000)
+
+# ── GitHub ────────────────────────────────────────────────────────────────────
+GITHUB_TOKEN=ghp_changeme             # Personal access token for Issues/Projects API
+
+# ── Test / CI flags ───────────────────────────────────────────────────────────
+# RUN_DB_INTEGRATION=true             # Uncomment to run real-DB integration tests
+# RUN_GITHUB_PROJECTS_INTEGRATION=true
+# GITHUB_TEST_OWNER=your-username
+# GITHUB_TEST_REPO=your-repo
+# GITHUB_TEST_PROJECT_NUMBER=5
+# GITHUB_TEST_ISSUE_NUMBER=1

--- a/.github/agents/mcp-server-coder.agent.md
+++ b/.github/agents/mcp-server-coder.agent.md
@@ -1,6 +1,7 @@
 ---
-description: "Coding agent for MCP Server - Extensible MCP server for VS Code Copilot"
+description: "Coding agent for MCP Server - implement MCP tools, TypeScript features, Express routes, Prisma schema changes, and auth. Use for: feature branches, bug fixes, refactors, PR implementation. Hands off to Tester for coverage and Reviewer for quality checks."
 name: MCP Server Coder
+model: "claude-sonnet-4-5"
 tools:
   - 'vscode/openSimpleBrowser'
   - 'execute/runInTerminal'
@@ -19,72 +20,143 @@ tools:
 handoffs:
   - label: "MCP Server Tester"
     agent: "mcp-server-tester"
-    prompt: "Write and run tests for new or changed code."
+    prompt: "Write and run tests for new or changed code. Include: issue number, files changed, new behavior to cover, and any edge cases."
   - label: "MCP Server Reviewer"
     agent: "mcp-server-reviewer"
-    prompt: "Review code quality and provide feedback."
+    prompt: "Review code quality, security, and test coverage. Include: PR link or branch, related issue, summary of changes."
   - label: "MCP Server Support"
     agent: "mcp-server-support"
-    prompt: "Request clarification or explanation about implemented code or patterns."
+    prompt: "Clarify requirements or gather context before implementing. Describe what is ambiguous."
 
 ---
 
-# MCP Server Coding Agent
+# MCP Server Coder
 
-## Purpose
+## Repository
 
-Coding-focused agent for the MCP Server repository. This agent specializes in implementing MCP tools, TypeScript/Node.js development, testing, and maintaining GitHub issue-driven workflows.
+`bryan-debaun/mcp-server` — Personal MCP (Model Context Protocol) server for VS Code Copilot. Exposes tools for GitHub Issues/Projects, book/movie/game catalog, Spotify playback, and more. Deployed on Render; also runs as a stdio extension host locally.
 
-- **Language**: TypeScript
-- **Runtime**: Node.js
-- **Testing**: Vitest
-- **Build**: tsc (npm run build)
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
 
-## GitHub Issue-Driven Development
+## Tech Stack
 
-### Issue Tracking Locations
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ESM, strict, Node ≥20) |
+| HTTP server | Express 4 + TSOA (OpenAPI controllers) |
+| Database | Prisma 7 + PostgreSQL (Supabase) |
+| Auth | Supabase JWT (JWKS), MCP API key, magic-link, session JWT |
+| Validation | Zod (tool inputs; env config via `src/config.ts` after #78) |
+| Testing | Vitest + v8 coverage |
+| Metrics | prom-client (Prometheus) |
+| MCP SDK | `@modelcontextprotocol/sdk` v1.0 |
+| Deploy | Render (HTTP mode) / VS Code extension host (stdio mode) |
 
-- **Master work tracking**: `bryan-debaun/work-tracking`
-- **Repo-specific issues**: `bryan-debaun/mcp-server`
+## Key Source Files
 
-### Useful Commands
+```
+src/
+  index.ts                    ← entry point, transport selection (stdio vs HTTP)
+  server.ts                   ← MCP server + tool registration
+  config.ts                   ← (in progress, #78) centralized Zod env config
+  tools/                      ← MCP tool implementations
+    github-issues/            ← create/update/list/close issues
+    github-projects/          ← Projects V2 field management
+    database/                 ← books, authors, movies, video-games, ratings
+  http/
+    server.ts                 ← Express app factory + startHttpServer()
+    mcp-http.ts               ← HTTP Stream + SSE transport for /mcp
+    middleware/mcp-auth.ts    ← MCP API key auth middleware
+    controllers/              ← TSOA controllers (magic-link, etc.)
+  auth/
+    jwt.ts                    ← Supabase JWKS validation
+    magic-link.ts             ← magic-link token issue/verify
+    session.ts                ← session JWT
+    requireAdmin.ts           ← IP allowlist + INTERNAL_ADMIN_KEY guard
+  adapters/spotify/           ← Spotify OAuth + polling adapter
+  db/index.ts                 ← ESM-safe Prisma init (stub if no DATABASE_URL)
+prisma/schema.prisma          ← DB schema
+docs/adr/                     ← Architecture Decision Records
+test/                         ← Vitest tests (mirror src structure)
+```
 
-# Check master work tracking
-gh issue list --repo bryan-debaun/work-tracking --label "project:mcp-server"
+## Commands
 
-# Check repo-specific issues
-gh issue list --repo bryan-debaun/mcp-server
+```powershell
+npm run build        # prisma generate + build:spec + tsc + build:seed
+npm run test         # vitest run (all tests, CI-safe)
+npm run test:watch   # vitest (interactive)
+npm run typecheck    # tsc --noEmit
+npm start            # node dist/index.js (stdio or HTTP via MCP_TRANSPORT)
+npm run start:http   # cross-env MCP_TRANSPORT=http node dist/index.js
+```
 
-# Create repo-specific issue linked to master
-gh issue create --repo bryan-debaun/mcp-server --title "[Title]" --body "Related to bryan-debaun/work-tracking#[number]"
+**Always run `npm run typecheck` and `npm run test` before marking work done.**
 
-## Development Workflow
+## Issue-Driven Workflow
 
-Follow the established workflow: ensure clean working state, update `main`, establish a test baseline, create a feature branch (`feature/[description]` or `fix/[description]`), implement, test, and create a draft PR.
+1. **Check the issue first.** Every task should reference a `bryan-debaun/mcp-server` issue. If one doesn't exist, note it.
+2. **Create a branch**: `feature/[issue-number]-[short-desc]` or `fix/[issue-number]-[short-desc]`.
+3. **Verify baseline**: `npm run test` on `main` before branching — know what was already failing.
+4. **Implement** → typecheck → test → commit.
+5. **Open a draft PR** referencing the issue with `Closes #N` in the description.
+6. **Hand off** to Tester if coverage is needed; to Reviewer when ready for merge.
 
-### Project Commands
+```powershell
+# Start work
+git checkout main; git pull origin main
+npm run test  # baseline
+git checkout -b feature/78-centralized-config
 
-- Build: `npm run build` (runs `tsc`)
-- Dev (watch): `npm run dev` (tsc --watch)
-- Start: `npm run start` (node dist/index.js)
-- Test: `npm run test` (vitest run)
-- Typecheck: `npm run typecheck` (tsc --noEmit)
+# Before PR
+npm run typecheck
+npm run test
+gh pr create --draft --title "feat: ..." --body "Closes #78"
+```
 
-## Focus Areas
+## Coding Rules
 
-- Implement and document MCP tool definitions and schemas
-- Strong typing and runtime validation for tool inputs/outputs (use `zod` where appropriate)
-- GitHub Issues tool implementations (create, update, list, close, query)
-- Test coverage for tool handlers and CLI/adapter layers
-- Clear handoffs and templates for testing and review
+### General
+- All new source files are **TypeScript ESM** — use `import`/`export`, `.js` extensions in imports (even for `.ts` source).
+- Use **Zod** for all new tool input schemas. Keep schemas colocated with their handler.
+- After `src/config.ts` lands (#78): read all env vars from `config.*` — **never** add new `process.env.X` reads outside `src/config.ts`.
+- No orphaned `TODO` comments in committed code — convert to a GitHub issue and reference it.
 
-## MCP Tool Opportunities
+### Prisma & Database
+- Run `npx prisma generate` after schema changes; include it in the build.
+- Never call `prisma.$disconnect()` in hot paths — the client is a singleton via `src/db/index.ts`.
+- The `initPrisma()` stub pattern must be preserved: server must start (with degraded DB behavior) even when `DATABASE_URL` is unset.
 
-When repetitive developer tasks or external API patterns emerge, propose MCP tools and open issues (label `project:mcp-server`) to track their design and implementation.
+### MCP Tools
+- Tool names use kebab-case. Input/output schemas must have `description` fields — these surface directly to the LLM.
+- Register new tools in `src/tools/index.ts` via `registerTools(server)`.
+- Add a corresponding entry in the README tool table.
 
-## Handoffs
+### Express / HTTP
+- New routes go through TSOA controllers (in `src/http/controllers/`) when they need OpenAPI docs; plain Express for internal/MCP-only routes.
+- All error handlers must return JSON — never HTML errors on API routes.
+- Auth-sensitive routes must be tested with and without `MCP_API_KEY` set.
 
-When handing off to the **Tester** agent, provide: summary, related issue, files changed, and areas needing tests. When handing off to the **Reviewer** agent, provide: PR link, related issue, summary of changes, and areas needing feedback.
+## Security Rules (Non-Negotiable)
 
+- **Never log secrets** (`MCP_API_KEY`, `SESSION_JWT_SECRET`, `SUPABASE_SERVICE_ROLE_KEY`, tokens). Only log their presence (`!!value`).
+- **Service role bypass** increments `service_role_bypass_total` gauge — never remove this counter.
+- **Admin routes** (`/api/admin/*`) require both `ADMIN_DEBUG_ENABLED=1` and `INTERNAL_ADMIN_KEY` — do not weaken this guard.
+- **IP allowlist** (`ADMIN_IP_ALLOWLIST`) is comma-separated CIDR/IP — always split and trim, never trust raw string comparison.
+- If you're unsure whether something is a security issue, err on the side of caution and flag it in the PR.
 
-<!-- End of MCP Server coding agent -->
+## Active High-Priority Issues
+
+| # | Title | Priority |
+|---|-------|----------|
+| [#78](https://github.com/bryan-debaun/mcp-server/issues/78) | Add centralized config module with Zod validation | P1 |
+| [#18](https://github.com/bryan-debaun/mcp-server/issues/18) | Decide policy for admin debug endpoint in production | P1 |
+| [#16](https://github.com/bryan-debaun/mcp-server/issues/16) | Transport integration test for HTTP Stream | P1 |
+
+## Handoff Protocol
+
+**→ Tester**: Provide issue #, branch name, list of new/changed files, new behavior to cover, known edge cases or tricky mocks needed.
+
+**→ Reviewer**: Provide PR URL, issue #, summary of what changed and why, any deliberate tradeoffs, areas you want scrutinized.
+
+**→ Support**: Describe exactly what is unclear — include the issue #, what you've already tried, and what decision you need made before you can continue.

--- a/.github/agents/mcp-server-reviewer.agent.md
+++ b/.github/agents/mcp-server-reviewer.agent.md
@@ -1,7 +1,10 @@
 ---
-description: "Reviewer agent for MCP Server - review PRs and quality checks"
+description: "Reviewer agent for MCP Server - review PRs, code quality, security, and test coverage. Use for: code review, pre-merge checks, architecture feedback, security audit of changes."
 name: MCP Server Reviewer
+model: "claude-sonnet-4-5"
 tools:
+  - 'execute/runInTerminal'
+  - 'execute/runTests'
   - 'read/getChangedFiles'
   - 'read/readFile'
   - 'read/listCodeUsages'
@@ -12,33 +15,90 @@ tools:
 
 ---
 
-# MCP Server Reviewer Agent
+# MCP Server Reviewer
 
-## Purpose
+## Repository
 
-Review code changes for correctness, clarity, maintainability, and security. Provide actionable feedback and ensure the repository's standards are preserved.
+`bryan-debaun/mcp-server` — Personal MCP server for VS Code Copilot. TypeScript ESM, Node ≥20, Express 4, Prisma 7, Supabase JWT auth, Vitest, prom-client.
+
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
+
+## Review Protocol
+
+### 1. Establish baseline
+```powershell
+git checkout main
+npm run test   # note any pre-existing failures
+git checkout <branch>
+npm run build
+npm run typecheck
+npm run test
+```
+
+### 2. Review the diff
+Use `read/getChangedFiles` to get the full set of changed files, then read each carefully.
+
+### 3. File your review
+Leave feedback as inline comments on the PR or as a structured summary. Be specific: cite file + line, explain the concern, and suggest a fix or question.
+
+---
 
 ## Review Checklist
 
-- Build succeeds (`npm run build`)
-- All tests pass (`npm run test`) and new tests were added for new behavior
-- TypeScript has no errors (`npm run typecheck`)
-- Proper validation (zod) and runtime checks exist for inputs and outputs
-- No credentials, secrets, or sensitive info in changes
-- Documentation and README updates if public-facing behavior changed
-- PR description links to related issue(s) and explains motivation
-- Tests are meaningful and not flaky; each assertion targets specific behavior
+### Build & Tests
+- [ ] `npm run build` succeeds (no tsc errors, prisma generate ran if schema changed)
+- [ ] `npm run typecheck` clean
+- [ ] `npm run test` passes — no regressions
+- [ ] New behavior has new tests; edge cases and error paths are covered
+- [ ] Integration test gates (`RUN_DB_INTEGRATION=true`) are not accidentally removed
 
-## Security & Reliability
+### Code Quality
+- [ ] No new `process.env.X` reads outside `src/config.ts` (after #78 lands; flag as follow-up if pre-existing)
+- [ ] No orphaned `TODO` comments — each should be a GitHub issue reference
+- [ ] Zod schemas present for all new MCP tool inputs, with `description` fields
+- [ ] New MCP tools registered in `src/tools/index.ts` and documented in README
+- [ ] New TSOA controllers have correct decorators and OpenAPI annotations
+- [ ] ESM import paths use `.js` extension (even for `.ts` source files)
+- [ ] Prisma schema changes: migration file present, `prisma generate` included in build
 
-- Sanitize inputs to avoid injection or malformed data
-- Ensure API calls and GitHub interactions handle transient errors (retries, sensible timeouts)
-- Observe principle of least privilege for any tokens or scopes referenced in docs
+### Security (Mandatory — Block PR if Violated)
+- [ ] No secrets, tokens, or API keys in committed code or logs
+- [ ] `service_role_bypass_total` counter is not removed or bypassed
+- [ ] Admin routes (`/api/admin/*`) still require `ADMIN_DEBUG_ENABLED` + `INTERNAL_ADMIN_KEY`
+- [ ] `ADMIN_IP_ALLOWLIST` is split/trimmed per-IP — not compared as raw string
+- [ ] Auth-sensitive routes tested both with and without `MCP_API_KEY`
+- [ ] Magic-link endpoints remain publicly accessible (bypass `mcpAuthMiddleware`) — verify `path.startsWith('/api/auth/magic-link')` carve-out is preserved
+- [ ] No new endpoints that skip JWT or MCP key validation without documented justification
 
-## Suggested Actions
+### Operational
+- [ ] Error handlers return JSON (never HTML) for all API routes
+- [ ] New env vars are documented in `.env.example` (after #78: in `src/config.ts` schema)
+- [ ] Prometheus metric labels are consistent with existing label conventions
+- [ ] If Spotify adapter changed: token refresh logic, poll interval, and error handling preserved
 
-- Ask for missing tests or better error handling
-- Propose small, focused follow-up PRs instead of large unrelated changes
-- Use clear examples and code pointers in comments to guide the author
+### Documentation
+- [ ] PR description links the issue with `Closes #N` and explains motivation
+- [ ] ADR created in `docs/adr/` for any significant architectural decision
+- [ ] README updated if public-facing tool list or API surface changed
 
-<!-- End of MCP Server Reviewer Agent -->
+---
+
+## Common Issues to Watch For
+
+**Transport / startup race:** `registerMcpHttp(app)` must be awaited before `app.listen`. `initPrisma()` must use ESM-safe dynamic import — no `require()` at top level.
+
+**Prisma stub contract:** `src/db/index.ts` exports a stub when `DATABASE_URL` is missing. Any new model usage must add a corresponding stub method — do not let the server crash on startup in no-DB environments.
+
+**ESM gotcha:** Dynamic `import()` is fine; static `require()` throws at runtime in this ESM project. Flag any `require()` usage outside `prisma.config.ts`.
+
+**Config drift (pre-#78):** Until the config module lands, `process.env` reads are expected in several files. Don't add new ones; flag existing ones in review notes as tech debt but don't block the PR solely for that.
+
+**Test gate flags:** `RUN_DB_INTEGRATION` and `RUN_GITHUB_PROJECTS_INTEGRATION` gate integration tests that require live services. Verify new integration tests are properly gated.
+
+---
+
+## Feedback Style
+
+- **Block** (must fix before merge): security violations, broken build/tests, missing Zod schema on new tool input, secrets in code.
+- **Request** (should fix, can merge with agreement): missing tests for new behavior, undocumented env vars, missing ADR for significant decisions.
+- **Suggest** (optional): style improvements, naming, refactor ideas — clearly labeled as non-blocking.

--- a/.github/agents/mcp-server-support.agent.md
+++ b/.github/agents/mcp-server-support.agent.md
@@ -1,7 +1,9 @@
 ---
-description: "Support agent for MCP Server - clarify requirements and gather context"
+description: "Support agent for MCP Server - clarify requirements, gather context, reproduce bugs, and prepare well-formed handoffs. Use when: requirements are ambiguous, a bug needs reproduction steps, an issue needs refinement before implementation, or you need a second opinion on approach."
 name: MCP Server Support
+model: "claude-sonnet-4-5"
 tools:
+  - 'execute/runInTerminal'
   - 'read/readFile'
   - 'search'
   - 'web/fetch'
@@ -10,33 +12,105 @@ tools:
 
 ---
 
-# MCP Server Support Agent
+# MCP Server Support
 
-## Purpose
+## Repository
 
-Assist with clarifications, gather missing context, and prepare well-formed handoffs to the Coding or Tester agents.
+`bryan-debaun/mcp-server` — Personal MCP server for VS Code Copilot. TypeScript ESM, Express 4, Prisma 7 + Supabase, Vitest, deployed on Render.
 
-## When to Use
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
+**Issues:** https://github.com/bryan-debaun/mcp-server/issues
 
-- Requirements are incomplete or ambiguous
-- Reproduction steps are missing for a bug
-- External API or environment constraints need to be clarified
+## When to Use This Agent
 
-## Handoff Template (to Coding Agent)
+- A GitHub issue exists but requirements are incomplete or contradictory
+- A bug is reported but reproduction steps are missing
+- You need to understand what a piece of code does before proposing a change
+- You need to research an upstream API (Spotify, Supabase, GitHub) before designing a solution
+- A decision needs to be made (e.g., policy on admin debug endpoint) before coding starts
 
-Provide the following when handing off to the Coding Agent:
+## Initial Triage
 
-- Context summary
-- Related issue number and link
-- Steps to reproduce (commands / sample inputs)
-- Expected vs actual behavior
-- Key files to inspect
-- Any constraints, deadlines, or non-functional requirements
+When given a task or issue, always:
 
-## Best Practices
+1. **Read the issue** — `gh issue view N --repo bryan-debaun/mcp-server`
+2. **Check the project board** — is this in Todo / In Progress / Done?
+3. **Find related code** — search for the feature, route, or tool mentioned
+4. **Identify what's missing** — reproduction steps? expected behavior? acceptance criteria?
 
-- Reproduce the issue locally when possible and include logs
-- If asking the author for more info, suggest a concrete example payload and expected result
-- Keep handoffs concise and focused so Coding and Tester agents can act immediately
+## Codebase Quick Reference
 
-<!-- End of MCP Server Support Agent -->
+```powershell
+# Find where a specific env var or feature is used
+Get-ChildItem src -Recurse -Filter "*.ts" | ForEach-Object { Select-String -Path $_.FullName -Pattern "PATTERN" }
+
+# Check what issues are open
+gh issue list --repo bryan-debaun/mcp-server --state open
+
+# Check recent PRs for context
+gh pr list --repo bryan-debaun/mcp-server --state closed --limit 10
+```
+
+**Key entry points:**
+- `src/index.ts` — startup + transport selection
+- `src/tools/index.ts` — all registered MCP tools
+- `src/http/server.ts` — HTTP app factory, route registration order
+- `src/auth/` — JWT, magic-link, session, admin guard
+- `docs/adr/` — past architectural decisions
+
+## Bug Reproduction Template
+
+When preparing reproduction steps for the Coder agent:
+
+```
+**Issue:** #N — [title]
+**Environment:** local stdio | local HTTP | Render preview | Render production
+**Steps to reproduce:**
+1. Set env vars: DATABASE_URL=... MCP_API_KEY=test
+2. Start: npm run start:http (or stdio)
+3. Call: curl -H "Authorization: Bearer test" http://localhost:3000/[route]
+**Expected:** [status code + response shape]
+**Actual:** [what happened, including logs]
+**Relevant logs:** [paste key console.error lines]
+**Key files to inspect:** [src/...]
+```
+
+## Handoff to Coder Template
+
+Before handing off, ensure you have:
+
+```
+**Issue:** #N — https://github.com/bryan-debaun/mcp-server/issues/N
+**Summary:** [1–2 sentence description of the problem and proposed fix]
+**Acceptance criteria:** [clear pass/fail criteria from the issue — add if missing]
+**Files to change:** [list the specific .ts files that need to change]
+**Constraints:**
+  - Must not break existing tests
+  - [any security constraint relevant to this change]
+  - [any ESM/Prisma/config constraint]
+**Open questions resolved:** [list any decisions made during support triage]
+**Suggested branch:** feature/N-[short-desc]
+```
+
+## Handoff to Tester Template
+
+```
+**Issue:** #N
+**Branch / files changed:** [branch name + list of .ts files modified]
+**New behavior to cover:** [what the new code does]
+**Edge cases:** [missing auth, DB unavailable, invalid input, etc.]
+**Mocks needed:** [fetch? prisma? process.env? gh CLI?]
+**Integration test needed?** [yes/no — if yes, which gate: RUN_DB_INTEGRATION?]
+```
+
+## Common Context to Gather
+
+| Scenario | What to check |
+|----------|---------------|
+| Auth issue | `src/auth/jwt.ts`, `src/http/middleware/mcp-auth.ts`, `SUPABASE_JWKS_URL` env |
+| Magic-link broken | `src/auth/magic-link.ts`, `src/http/controllers/MagicLinkController.ts`, `MAGIC_LINK_JWT_SECRET` |
+| MCP tool not found | `src/tools/index.ts` (registration), `src/server.ts`, tool schema `description` field |
+| Route returns 404 | `src/http/server.ts` (registration order), `registerDbDependentRoutes()` timing |
+| DB error at startup | `src/db/index.ts` stub contract, `DATABASE_URL` set?, Prisma generated? |
+| Spotify not polling | `src/adapters/spotify/spotify-adapter.ts`, `SPOTIFY_CLIENT_ID/SECRET/REFRESH_TOKEN` set? |
+| Admin route 403 | `INTERNAL_ADMIN_KEY`, `ADMIN_IP_ALLOWLIST`, `ADMIN_DEBUG_ENABLED=1` all required |

--- a/.github/agents/mcp-server-tester.agent.md
+++ b/.github/agents/mcp-server-tester.agent.md
@@ -1,6 +1,7 @@
 ---
-description: "Tester agent for MCP Server - write and run tests using Vitest"
+description: "Tester agent for MCP Server - write and run Vitest tests for MCP tools, Express routes, auth, Prisma, and adapters. Use for: adding unit/integration tests, diagnosing test failures, improving coverage, setting up mocks."
 name: MCP Server Tester
+model: "claude-sonnet-4-5"
 tools:
   - 'execute/runTests'
   - 'execute/runInTerminal'
@@ -14,40 +15,117 @@ tools:
 
 ---
 
-# MCP Server Tester Agent
+# MCP Server Tester
 
-## Purpose
+## Repository
 
-This agent focuses on writing, running, and validating tests for the `mcp-server` repository. It ensures new and changed code has appropriate unit and integration coverage and follows existing test patterns.
+`bryan-debaun/mcp-server` — TypeScript ESM, Node ≥20, Express 4, Prisma 7, Vitest + v8 coverage, `@modelcontextprotocol/sdk` v1.0.
 
-- **Testing framework**: Vitest
-- **Run tests**: `npm run test` (CI-friendly) or `npm run test:watch` for local development
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
 
-## Responsibilities
+## Test Commands
 
-- Identify files changed in a PR and suggest/add tests for uncovered logic
-- Author tests targeting: tool handlers, schema validation (zod), CLI/adapter behavior, and edge cases
-- Run tests locally and summarize failures with reproduction steps
-- Propose test fixtures and helpers when repetitive setup is needed
+```powershell
+npm run test                          # all tests (CI-safe)
+npm run test:watch                    # interactive watch
+npx vitest run test/tools/            # single directory
+npx vitest run test/http/mcp-http.test.ts  # single file
+npx vitest run --coverage             # with v8 coverage report
 
-## Test Patterns & Practices
+# Integration tests (require live DB / GitHub token)
+$env:RUN_DB_INTEGRATION="true"; npm run test
+$env:RUN_GITHUB_PROJECTS_INTEGRATION="true"; npm run test
+```
 
-- Prefer small, fast unit tests for pure functions and validation
-- Use integration tests for end-to-end behavior when multiple modules coordinate
-- Mock external network calls and GitHub interactions
-- Ensure tests are deterministic and run in isolation
-- Add tests for error cases and input validation (zod schemas)
+**Always run `npm run test` on `main` first to establish a clean baseline before writing new tests.**
 
-## Typical Workflow
+## Test Structure
 
-1. Run `npm run test` to establish baseline and to reproduce failures
-2. Use `read/getChangedFiles` to find modified files that need tests
-3. Add tests under `test/` following existing patterns
-4. Run tests and fix any flakiness
-5. Provide a brief summary of tests added and any limitations
+```
+test/
+  auth/           ← JWT validation, magic-link token flow
+  db/             ← Prisma init, stub behavior when DATABASE_URL missing
+  http/           ← Express routes, mcp-http transport, middleware
+  tools/          ← MCP tool handlers (github-issues, github-projects, database/*)
+  integration/    ← RLS policies, GitHub Projects V2, SendGrid (gated by env flags)
+  build/          ← Production dependency smoke tests
+  rls/            ← DB migration + snapshot tests
+  utils/          ← Shared test helpers (db-utils.ts, etc.)
+```
 
-## Handoff
+## Mocking Conventions
 
-When handing off to Reviewer: provide PR link, list of tests added, and any areas needing attention (flaky tests, long-running integration tests, missing mocks).
+### Prisma
+```ts
+// Reset per test — never share mutable Prisma state across tests
+vi.mock('../../src/db/index.js', () => ({
+  prisma: {
+    book: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    // add model stubs as needed
+  },
+  initPrisma: vi.fn().mockResolvedValue(undefined),
+}));
+```
 
-<!-- End of MCP Server Tester Agent -->
+### `fetch` (Spotify, SendGrid, GitHub API)
+```ts
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+fetchMock.mockResolvedValue({ ok: true, json: async () => ({...}), text: async () => '' });
+```
+
+### GitHub CLI (`gh`)
+```ts
+vi.mock('child_process', () => ({ execSync: vi.fn().mockReturnValue(Buffer.from('[]')) }));
+```
+
+### Environment variables
+```ts
+beforeEach(() => {
+  vi.stubEnv('MCP_API_KEY', 'test-key');
+  vi.stubEnv('DATABASE_URL', 'postgresql://test');
+});
+afterEach(() => { vi.unstubAllEnvs(); });
+```
+
+**After `src/config.ts` lands (#78):** mock the config module instead of `process.env`:
+```ts
+vi.mock('../../src/config.js', () => ({ config: { security: { mcpApiKey: 'test-key' }, ... } }));
+```
+
+## Test Writing Rules
+
+### Always
+- **Use `beforeEach`/`afterEach` to reset mocks** — `vi.clearAllMocks()` or per-mock `.mockReset()`.
+- **Test error paths**: missing params, invalid Zod input, service unavailable, DB missing.
+- **Test auth**: routes must be tested both with a valid bearer token and with no/wrong token when `MCP_API_KEY` is set.
+- **Name tests descriptively**: `it('returns 401 when MCP_API_KEY is set and token is missing')`.
+
+### Never
+- Don't make real network calls in unit tests — always mock `fetch`, `gh`, and external SDKs.
+- Don't hardcode ports; use `0` + `server.address().port` for HTTP integration tests.
+- Don't skip tests with `.skip()` without a comment and linked issue.
+- Don't assert on log output as a primary assertion — test observable behavior (return values, response codes, DB calls).
+
+### Integration tests
+- Gate with env flags: `if (!process.env.RUN_DB_INTEGRATION) { it.skip(...) }`.
+- Use the existing pattern in `test/integration/github-projects.test.ts` as reference.
+- Clean up test data in `afterAll` — never leave orphaned records in shared DBs.
+
+## Coverage Priorities
+
+When triaging what to test, focus in this order:
+
+1. **Security-sensitive paths**: auth middleware, `requireAdmin`, JWT validation, service_role bypass
+2. **MCP tool handlers**: input validation (Zod), happy path, error from downstream service
+3. **HTTP routes**: status codes, response shape, auth required vs public
+4. **Adapters**: Spotify token refresh, error fallback, stub when credentials missing
+5. **Config**: (after #78) valid parse, defaults, alias normalization, invalid value rejection
+6. **DB init**: stub behavior when `DATABASE_URL` is unset, ESM-safe import path
+
+## Handoff to Reviewer
+
+After adding tests:
+1. Run the full suite and confirm it's green.
+2. Note any tests that are skipped and why.
+3. Provide: branch/PR, list of new test files, what is covered vs still missing, any flaky or slow tests to be aware of.

--- a/src/adapters/spotify/spotify-adapter.ts
+++ b/src/adapters/spotify/spotify-adapter.ts
@@ -1,4 +1,5 @@
 import { setPlayback } from '../../http/playback-store.js';
+import { config } from '../../config.js';
 
 const TOKEN_ENDPOINT = 'https://accounts.spotify.com/api/token';
 const API_BASE = 'https://api.spotify.com/v1';
@@ -10,9 +11,9 @@ let pollHandle: NodeJS.Timeout | null = null;
 function nowMs() { return Date.now(); }
 
 async function refreshAccessToken(): Promise<string> {
-    const clientId = process.env.SPOTIFY_CLIENT_ID;
-    const clientSecret = process.env.SPOTIFY_CLIENT_SECRET;
-    const refreshToken = process.env.SPOTIFY_REFRESH_TOKEN;
+    const clientId = config.spotify.clientId;
+    const clientSecret = config.spotify.clientSecret;
+    const refreshToken = config.spotify.refreshToken;
 
     if (!clientId || !clientSecret || !refreshToken) throw new Error('Spotify credentials not configured');
 
@@ -104,8 +105,7 @@ export async function getPlaylists(limit = 20, offset = 0): Promise<any> {
 }
 
 export async function startSpotifyAdapter() {
-    const enabled = !!(process.env.SPOTIFY_CLIENT_ID && process.env.SPOTIFY_CLIENT_SECRET && process.env.SPOTIFY_REFRESH_TOKEN);
-    if (!enabled) return;
+    if (!config.spotify.enabled) return;
 
     // Prime a token so errors are visible on startup
     try {
@@ -114,7 +114,7 @@ export async function startSpotifyAdapter() {
         console.error('spotify-adapter: failed to refresh token on startup', err);
     }
 
-    const intervalMs = Number(process.env.SPOTIFY_POLL_INTERVAL_MS || 15000);
+    const intervalMs = config.spotify.pollIntervalMs;
     if (pollHandle) clearInterval(pollHandle);
     // Immediately fetch once, then poll
     await fetchCurrentlyPlaying();

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -2,18 +2,16 @@ import { Request, Response, NextFunction } from 'express'
 import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose'
 import { verifySessionToken } from './session.js'
 import { prisma } from '../db/index.js'
+import { config } from '../config.js'
 
-const jwksUrl = process.env.SUPABASE_JWKS_URL
-
-if (!jwksUrl) {
+if (!config.auth.supabaseJwksUrl) {
     console.warn('SUPABASE_JWKS_URL not set; JWT middleware will not validate tokens')
 }
 
-
 export async function verifySupabaseJwt(token: string): Promise<JWTPayload> {
-    let _jwksUrl = process.env.SUPABASE_JWKS_URL ?? (process.env.PUBLIC_SUPABASE_URL ? `${String(process.env.PUBLIC_SUPABASE_URL).replace(/\/$/, '')}/.well-known/jwks.json` : undefined)
-    const _issuer = process.env.SUPABASE_ISS ?? process.env.PUBLIC_SUPABASE_URL
-    const _audience = process.env.SUPABASE_AUD
+    let _jwksUrl = config.auth.supabaseJwksUrl
+    const _issuer = config.auth.supabaseIss
+    const _audience = config.auth.supabaseAud
 
     if (!_jwksUrl) throw new Error('JWKS URL not configured')
     if (!_issuer || !_audience) throw new Error('SUPABASE_ISS and SUPABASE_AUD must be set')
@@ -23,7 +21,7 @@ export async function verifySupabaseJwt(token: string): Promise<JWTPayload> {
         const res = await fetch(_jwksUrl, { method: 'GET' })
         if (!res.ok) {
             // Try fallback using publishable key (PUBLIC_SUPABASE_PUBLISHABLE_KEY) or legacy SUPABASE_ANON_KEY
-            const publishable = process.env.PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.SUPABASE_ANON_KEY
+                const publishable = config.auth.supabaseAnonKey
             if (publishable) {
                 const fallback = `${_issuer.replace(/\/$/, '')}/auth/v1/keys?apikey=${publishable}`
                 const res2 = await fetch(fallback, { method: 'GET' })
@@ -86,7 +84,7 @@ function parseCookies(header?: string) {
 export async function jwtMiddleware(req: Request, res: Response, next: NextFunction) {
     try {
         const auth = req.headers.authorization
-        const serviceRoleKey = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY
+        const serviceRoleKey = config.auth.supabaseServiceRoleKey
 
         if (auth) {
             // If Authorization header exists it must be a Bearer token

--- a/src/auth/magic-link.ts
+++ b/src/auth/magic-link.ts
@@ -1,7 +1,8 @@
 import { SignJWT, jwtVerify, type JWTPayload } from 'jose'
+import { config } from '../config.js'
 
 const EXP_MINUTES = 15
-const SECRET = process.env.MAGIC_LINK_JWT_SECRET
+const SECRET = config.auth.magicLinkJwtSecret
 
 if (!SECRET) {
     console.warn('MAGIC_LINK_JWT_SECRET not set; magic-link token signing will fail')
@@ -18,7 +19,7 @@ export async function generateMagicLinkToken(email: string, userId?: number) {
 
     // Fail fast when no DB configured — magic-link persistence requires a DB
     // Allow tests that inject a global `__TEST_PRISMA_MOCK__` to proceed
-    if (!process.env.DATABASE_URL && !(globalThis as any).__TEST_PRISMA_MOCK__) {
+    if (!config.database.url && !(globalThis as any).__TEST_PRISMA_MOCK__) {
         throw new Error('DATABASE_URL not configured')
     }
 
@@ -36,7 +37,7 @@ export async function generateMagicLinkToken(email: string, userId?: number) {
 
     // If Prisma model isn't available (e.g., running unit tests where the real DB module
     // was loaded before the mock), create a small in-memory fallback while running tests
-    if (!prisma?.authMagicLink && process.env.NODE_ENV === 'test') {
+    if (!prisma?.authMagicLink && config.isTest) {
         const store = new Map<string, any>()
         prisma = {
             authMagicLink: {
@@ -82,7 +83,7 @@ export async function verifyMagicLinkToken(token: string) {
 
         // Require a configured database for token verification (single-use check)
         // Allow tests that inject a global `__TEST_PRISMA_MOCK__` to proceed
-        if (!process.env.DATABASE_URL && !(globalThis as any).__TEST_PRISMA_MOCK__) {
+        if (!config.database.url && !(globalThis as any).__TEST_PRISMA_MOCK__) {
             throw new Error('DATABASE_URL not configured')
         }
 
@@ -92,7 +93,7 @@ export async function verifyMagicLinkToken(token: string) {
             const mod: any = await import('../db/index.js')
             prisma = mod?.prisma ?? mod?.default?.prisma
         }
-        if (!prisma?.authMagicLink && process.env.NODE_ENV === 'test') {
+        if (!prisma?.authMagicLink && config.isTest) {
             const store = new Map<string, any>()
             prisma = {
                 authMagicLink: {

--- a/src/auth/requireAdmin.ts
+++ b/src/auth/requireAdmin.ts
@@ -1,6 +1,7 @@
 import { Request, Response, NextFunction } from 'express'
 import { prisma } from '../db/index.js'
 import { serviceRoleBypassTotal } from '../http/metrics-route.js'
+import { config } from '../config.js'
 
 export function requireAdmin(req: Request, res: Response, next: NextFunction) {
     const user = (req as any).user
@@ -8,8 +9,8 @@ export function requireAdmin(req: Request, res: Response, next: NextFunction) {
     // If the request was authenticated using the service role (jwtMiddleware marks it with user.service=true),
     // perform hardened checks: require BOTH internal header key and IP to be allowlisted (Option A).
     if (user && user.service) {
-        const internalKey = process.env.INTERNAL_ADMIN_KEY
-        const allowlist = (process.env.ADMIN_IP_ALLOWLIST || '').split(',').map(s => s.trim()).filter(Boolean)
+        const internalKey = config.security.internalAdminKey
+        const allowlist = config.security.adminIpAllowlist
         const clientIp = ((req.headers['x-forwarded-for'] || req.ip) as string).toString().split(',')[0].trim()
 
         const headerOk = internalKey ? req.headers['x-internal-key'] === internalKey : false

--- a/src/auth/session.ts
+++ b/src/auth/session.ts
@@ -1,4 +1,5 @@
 import { jwtVerify } from 'jose'
+import { config } from '../config.js'
 
 export interface SessionPayload {
     sub?: string
@@ -8,7 +9,7 @@ export interface SessionPayload {
 }
 
 export async function verifySessionToken(token: string): Promise<SessionPayload> {
-    const secret = process.env.SESSION_JWT_SECRET
+    const secret = config.auth.sessionJwtSecret
     if (!token) throw new Error('missing token')
 
     if (!secret) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,263 @@
+/**
+ * Centralized environment configuration with Zod validation.
+ * This is the ONLY place in the codebase that reads process.env directly.
+ *
+ * Usage: import { config } from './config.js'
+ */
+
+// Load dotenv before reading process.env. Only in non-production — hosted
+// environments (Render) inject vars directly. Safe to call multiple times.
+if (process.env.NODE_ENV !== 'production') {
+    try {
+        await import('dotenv/config');
+    } catch {
+        // dotenv not installed or not available; env vars provided by platform
+    }
+}
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Parse a comma-separated string into a trimmed, non-empty string array. */
+const csvArray = z
+    .string()
+    .optional()
+    .transform((val) =>
+        val ? val.split(',').map((s) => s.trim()).filter(Boolean) : []
+    );
+
+/** Coerce a string boolean flag ('1', 'true', 'yes') to boolean. */
+const boolFlag = z
+    .string()
+    .optional()
+    .transform((val) => {
+        const v = (val ?? '').toLowerCase();
+        return v === '1' || v === 'true' || v === 'yes';
+    });
+
+/** Coerce a string to a positive integer with a default fallback. */
+function posInt(defaultValue: number) {
+    return z
+        .string()
+        .optional()
+        .transform((val) => {
+            const n = Number(val ?? defaultValue);
+            return Number.isFinite(n) && n > 0 ? n : defaultValue;
+        });
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+const envSchema = z.object({
+    // ── Core ──────────────────────────────────────────────────────────────
+    NODE_ENV: z
+        .enum(['development', 'production', 'test'])
+        .optional()
+        .default('development'),
+    PORT: z
+        .string()
+        .optional()
+        .transform((val) => (val ? Number(val) : undefined))
+        .refine((val) => val === undefined || (Number.isFinite(val) && val > 0), {
+            message: 'PORT must be a positive integer',
+        }),
+    HOST: z.string().optional(),
+    MCP_TRANSPORT: z.enum(['stdio', 'http']).optional(),
+    EARLY_START: boolFlag,
+
+    // ── Security ──────────────────────────────────────────────────────────
+    MCP_API_KEY: z.string().optional(),
+    ADMIN_DEBUG_ENABLED: boolFlag,
+    ADMIN_IP_ALLOWLIST: csvArray,
+    INTERNAL_ADMIN_KEY: z.string().optional(),
+    SHOW_INVITE_TOKEN: boolFlag,
+
+    // ── Database ──────────────────────────────────────────────────────────
+    DATABASE_URL: z.string().url().optional(),
+
+    // ── Auth / Supabase ───────────────────────────────────────────────────
+    // JWKS URL: prefer explicit; derive from PUBLIC_SUPABASE_URL as fallback
+    SUPABASE_JWKS_URL: z.string().url().optional(),
+    PUBLIC_SUPABASE_URL: z.string().url().optional(),
+    SUPABASE_ISS: z.string().optional(),
+    SUPABASE_AUD: z.string().optional(),
+    // Service role key — accept either alias
+    SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+    SUPABASE_SECRET_KEY: z.string().optional(),
+    // Anon / publishable key — accept either alias
+    SUPABASE_ANON_KEY: z.string().optional(),
+    PUBLIC_SUPABASE_PUBLISHABLE_KEY: z.string().optional(),
+
+    // ── Session ───────────────────────────────────────────────────────────
+    SESSION_JWT_SECRET: z.string().optional(),
+    SESSION_RATE_LIMIT_PER_IP: posInt(60),
+    SESSION_RATE_LIMIT_WINDOW_MS: posInt(60_000),
+    SESSION_COOKIE_MAX_AGE_SEC: posInt(60 * 60 * 24 * 7), // 7 days
+
+    // ── Magic-link ────────────────────────────────────────────────────────
+    MAGIC_LINK_JWT_SECRET: z.string().optional(),
+    MAGIC_LINK_BASE_URL: z.string().url().optional().default('http://localhost:3000'),
+    MAGIC_LINK_SUCCESS_URL: z.string().optional(),
+    MAGIC_LINK_FRONTEND_URL: z.string().optional(),
+    MAGIC_LINK_PER_EMAIL_LIMIT: posInt(5),
+
+    // ── Email / SendGrid ──────────────────────────────────────────────────
+    SENDGRID_API_KEY: z.string().optional(),
+    // Accept SENDER_EMAIL or FROM_EMAIL (SENDER_EMAIL preferred)
+    SENDER_EMAIL: z.string().email().optional(),
+    FROM_EMAIL: z.string().email().optional(),
+    SENDER_NAME: z.string().optional().default('bryandebaun.dev'),
+    SUPPORT_EMAIL: z.string().email().optional().default('support@bryandebaun.dev'),
+    INVITE_BASE_URL: z.string().url().optional().default('http://localhost:3000'),
+    SENDGRID_CLICK_TRACKING: z
+        .string()
+        .optional()
+        .transform((val) => (val ?? 'true') !== 'false'),
+
+    // ── Spotify ───────────────────────────────────────────────────────────
+    SPOTIFY_CLIENT_ID: z.string().optional(),
+    SPOTIFY_CLIENT_SECRET: z.string().optional(),
+    SPOTIFY_REFRESH_TOKEN: z.string().optional(),
+    SPOTIFY_REDIRECT_URI: z.string().url().optional(),
+    SPOTIFY_POLL_INTERVAL_MS: posInt(15_000),
+
+    // ── GitHub ────────────────────────────────────────────────────────────
+    GITHUB_TOKEN: z.string().optional(),
+
+    // ── Test / CI flags ───────────────────────────────────────────────────
+    RUN_DB_INTEGRATION: boolFlag,
+    RUN_GITHUB_PROJECTS_INTEGRATION: boolFlag,
+    GITHUB_TEST_OWNER: z.string().optional(),
+    GITHUB_TEST_REPO: z.string().optional(),
+    GITHUB_TEST_PROJECT_NUMBER: posInt(0),
+    GITHUB_TEST_ISSUE_NUMBER: posInt(0),
+});
+
+// ---------------------------------------------------------------------------
+// Parse & exit-on-failure
+// ---------------------------------------------------------------------------
+
+const result = envSchema.safeParse(process.env);
+
+if (!result.success) {
+    console.error('❌  Configuration error — fix the following env vars and restart:');
+    for (const issue of result.error.issues) {
+        console.error(`  ${issue.path.join('.')}: ${issue.message}`);
+    }
+    process.exit(1);
+}
+
+const env = result.data;
+
+// ---------------------------------------------------------------------------
+// Derived / normalized values
+// ---------------------------------------------------------------------------
+
+/** Resolved JWKS URL: explicit var wins; derived from PUBLIC_SUPABASE_URL otherwise. */
+const supabaseJwksUrl: string | undefined =
+    env.SUPABASE_JWKS_URL ??
+    (env.PUBLIC_SUPABASE_URL
+        ? `${env.PUBLIC_SUPABASE_URL.replace(/\/$/, '')}/.well-known/jwks.json`
+        : undefined);
+
+/** Resolved issuer: explicit SUPABASE_ISS wins; fallback to PUBLIC_SUPABASE_URL. */
+const supabaseIss: string | undefined = env.SUPABASE_ISS ?? env.PUBLIC_SUPABASE_URL;
+
+/** Service role key: prefer the canonical name; accept legacy alias. */
+const supabaseServiceRoleKey: string | undefined =
+    env.SUPABASE_SERVICE_ROLE_KEY ?? env.SUPABASE_SECRET_KEY;
+
+/** Anon / publishable key: prefer the canonical name; accept legacy alias. */
+const supabaseAnonKey: string | undefined =
+    env.SUPABASE_ANON_KEY ?? env.PUBLIC_SUPABASE_PUBLISHABLE_KEY;
+
+/** Sender email: prefer SENDER_EMAIL; fall back to FROM_EMAIL. */
+const senderEmail: string | undefined = env.SENDER_EMAIL ?? env.FROM_EMAIL;
+
+/** Whether all three Spotify credentials are present. */
+const spotifyEnabled =
+    Boolean(env.SPOTIFY_CLIENT_ID) &&
+    Boolean(env.SPOTIFY_CLIENT_SECRET) &&
+    Boolean(env.SPOTIFY_REFRESH_TOKEN);
+
+// ---------------------------------------------------------------------------
+// Exported config object
+// ---------------------------------------------------------------------------
+
+export const config = {
+    nodeEnv: env.NODE_ENV,
+    isProduction: env.NODE_ENV === 'production',
+    isTest: env.NODE_ENV === 'test',
+
+    server: {
+        port: env.PORT,
+        host: env.HOST ?? '0.0.0.0',
+        mcpTransport: env.MCP_TRANSPORT,
+        earlyStart: env.EARLY_START,
+    },
+
+    security: {
+        mcpApiKey: env.MCP_API_KEY,
+        adminDebugEnabled: env.ADMIN_DEBUG_ENABLED,
+        adminIpAllowlist: env.ADMIN_IP_ALLOWLIST,
+        internalAdminKey: env.INTERNAL_ADMIN_KEY,
+        showInviteToken: env.SHOW_INVITE_TOKEN,
+    },
+
+    database: {
+        url: env.DATABASE_URL,
+    },
+
+    auth: {
+        supabaseJwksUrl,
+        supabaseIss,
+        supabaseAud: env.SUPABASE_AUD,
+        supabaseServiceRoleKey,
+        supabaseAnonKey,
+        sessionJwtSecret: env.SESSION_JWT_SECRET,
+        sessionRateLimitPerIp: env.SESSION_RATE_LIMIT_PER_IP,
+        sessionRateLimitWindowMs: env.SESSION_RATE_LIMIT_WINDOW_MS,
+        sessionCookieMaxAgeSec: env.SESSION_COOKIE_MAX_AGE_SEC,
+        magicLinkJwtSecret: env.MAGIC_LINK_JWT_SECRET,
+        magicLinkBaseUrl: env.MAGIC_LINK_BASE_URL,
+        magicLinkSuccessUrl: env.MAGIC_LINK_SUCCESS_URL,
+        magicLinkFrontendUrl: env.MAGIC_LINK_FRONTEND_URL,
+        magicLinkPerEmailLimit: env.MAGIC_LINK_PER_EMAIL_LIMIT,
+    },
+
+    email: {
+        sendgridApiKey: env.SENDGRID_API_KEY,
+        senderEmail,
+        senderName: env.SENDER_NAME,
+        supportEmail: env.SUPPORT_EMAIL,
+        inviteBaseUrl: env.INVITE_BASE_URL,
+        clickTrackingEnabled: env.SENDGRID_CLICK_TRACKING,
+    },
+
+    spotify: {
+        clientId: env.SPOTIFY_CLIENT_ID,
+        clientSecret: env.SPOTIFY_CLIENT_SECRET,
+        refreshToken: env.SPOTIFY_REFRESH_TOKEN,
+        redirectUri: env.SPOTIFY_REDIRECT_URI,
+        pollIntervalMs: env.SPOTIFY_POLL_INTERVAL_MS,
+        enabled: spotifyEnabled,
+    },
+
+    github: {
+        token: env.GITHUB_TOKEN,
+    },
+
+    ci: {
+        runDbIntegration: env.RUN_DB_INTEGRATION,
+        runGithubProjectsIntegration: env.RUN_GITHUB_PROJECTS_INTEGRATION,
+        githubTestOwner: env.GITHUB_TEST_OWNER,
+        githubTestRepo: env.GITHUB_TEST_REPO,
+        githubTestProjectNumber: env.GITHUB_TEST_PROJECT_NUMBER,
+        githubTestIssueNumber: env.GITHUB_TEST_ISSUE_NUMBER,
+    },
+};

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,11 +1,4 @@
-// Load dotenv only in development - production environments provide variables directly
-if (process.env.NODE_ENV !== 'production') {
-    try {
-        await import('dotenv/config')
-    } catch {
-        // dotenv not available, environment variables provided by hosting platform
-    }
-}
+import { config } from '../config.js'
 
 // Export a `prisma` object that is initialized synchronously when possible.
 // If `DATABASE_URL` is set and `@prisma/client` is available (as in CI after
@@ -18,7 +11,7 @@ let prismaReadyPromise: Promise<void> | null = null
 export async function initPrisma() {
     if (prismaReadyPromise) return prismaReadyPromise
 
-    const dbUrl = process.env.DATABASE_URL
+    const dbUrl = config.database.url
     if (!dbUrl) {
         // No DB configured; provide stub methods used in tests and safe no-op model stubs to avoid
         // runtime TypeErrors when server is running without a database (e.g., preview environments).

--- a/src/email.ts
+++ b/src/email.ts
@@ -1,11 +1,13 @@
+import { config } from './config.js'
+
 export async function sendInviteEmail(email: string, token: string) {
-    const inviteBase = process.env.INVITE_BASE_URL ?? 'http://localhost:3000'
+    const inviteBase = config.email.inviteBaseUrl
     const inviteUrl = `${inviteBase}/accept?token=${token}`
 
-    const sendgridKey = process.env.SENDGRID_API_KEY
+    const sendgridKey = config.email.sendgridApiKey
     if (sendgridKey) {
-        const fromEmail = process.env.FROM_EMAIL ?? 'noreply@example.com'
-        const fromName = process.env.SENDER_NAME ?? 'MCP Server'
+        const fromEmail = config.email.senderEmail ?? 'noreply@example.com'
+        const fromName = config.email.senderName
         const payload = {
             personalizations: [{ to: [{ email }], subject: 'You are invited' }],
             from: { email: fromEmail, name: fromName },
@@ -33,12 +35,12 @@ export async function sendInviteEmail(email: string, token: string) {
 }
 
 export async function sendMagicLinkEmail(email: string, token: string, baseOverride?: string) {
-    const base = baseOverride ?? process.env.MAGIC_LINK_BASE_URL ?? 'http://localhost:3000'
+    const base = baseOverride ?? config.auth.magicLinkBaseUrl
     const url = `${base}/auth/magic-link/verify?token=${encodeURIComponent(token)}`
 
-    const sendgridKey = process.env.SENDGRID_API_KEY
-    const from = process.env.SENDER_EMAIL ?? process.env.FROM_EMAIL ?? 'no-reply@example.com'
-    const supportEmail = process.env.SUPPORT_EMAIL ?? 'support@bryandebaun.dev'
+    const sendgridKey = config.email.sendgridApiKey
+    const from = config.email.senderEmail ?? 'no-reply@example.com'
+    const supportEmail = config.email.supportEmail
 
     // Preheader visible in inbox preview; include as hidden text in HTML
     const preheader = 'Use this link to sign in to MCP Server — expires in 15 minutes.'
@@ -62,11 +64,10 @@ export async function sendMagicLinkEmail(email: string, token: string, baseOverr
 
         const text = `Sign in to MCP Server\n\nUse this link to sign in (expires in 15 minutes): ${url}\n\nIf you did not request this email, you can ignore it or contact ${supportEmail}.`
 
-        // Respect env override to disable click tracking if needed (useful for tests or preview)
-        const clickTrackingEnabled = (process.env.SENDGRID_CLICK_TRACKING ?? 'true') !== 'false'
+        const clickTrackingEnabled = config.email.clickTrackingEnabled
 
         const fromEmail = from
-        const fromName = process.env.SENDER_NAME ?? 'bryandebaun.dev'
+        const fromName = config.email.senderName
         const payload: any = {
             personalizations: [{ to: [{ email }], subject: 'Sign in to MCP Server' }],
             from: { email: fromEmail, name: fromName },

--- a/src/http/admin-route.ts
+++ b/src/http/admin-route.ts
@@ -4,6 +4,7 @@ import { requireAdmin } from '../auth/requireAdmin.js'
 import { sendInviteEmail } from "../email.js"
 import { prisma } from '../db/index.js'
 import { adminDebugRequestsTotal } from './metrics-route.js'
+import { config } from '../config.js'
 
 export function registerAdminRoute(app: Application) {
     const base = '/api/admin'
@@ -39,7 +40,7 @@ export function registerAdminRoute(app: Application) {
 
         // Safety: don't expose the invite token in production responses by default
         const resp: any = { id: invite.id, email: invite.email }
-        if (process.env.SHOW_INVITE_TOKEN === '1') {
+        if (config.security.showInviteToken) {
             resp.token = invite.token
         }
 
@@ -87,11 +88,11 @@ export function registerAdminRoute(app: Application) {
 
     // Debug endpoint to help diagnose gateway/auth issues on preview hosts.
     // Protected with the same admin checks (jwtMiddleware + requireAdmin).
-    if (process.env.ADMIN_DEBUG_ENABLED === '1') {
+    if (config.security.adminDebugEnabled) {
         app.get(`${base}/_debug/headers`, jwtMiddleware, requireAdmin, async (req: Request, res: Response) => {
             const ip = (req.headers['x-forwarded-for'] || req.ip || '').toString().split(',')[0].trim()
             const internalKeyPresent = !!req.headers['x-internal-key']
-            const jwksUrl = process.env.SUPABASE_JWKS_URL
+            const jwksUrl = config.auth.supabaseJwksUrl
             let jwksStatus: any = null
             if (jwksUrl) {
                 try {

--- a/src/http/controllers/MagicLinkController.ts
+++ b/src/http/controllers/MagicLinkController.ts
@@ -3,6 +3,7 @@ import type { Request as ExpressRequest } from 'express'
 import { generateMagicLinkToken, verifyMagicLinkToken } from '../../auth/magic-link.js'
 import { sendMagicLinkEmail } from '../../email.js'
 import { Counter } from 'prom-client'
+import { config } from '../../config.js'
 
 const magicLinkSent = new Counter({ name: 'magic_link_sent_total', help: 'Total magic link emails sent' })
 const magicLinkFailed = new Counter({ name: 'magic_link_failed_total', help: 'Total magic link send failures' })
@@ -12,7 +13,7 @@ const magicLinkReplayed = new Counter({ name: 'magic_link_replayed_total', help:
 // Rate limiting maps
 const ipRateMap: Map<string, { count: number; reset: number }> = new Map()
 const emailRateMap: Map<string, { count: number; reset: number }> = new Map()
-const EMAIL_LIMIT = Number(process.env.MAGIC_LINK_PER_EMAIL_LIMIT ?? 5)
+const EMAIL_LIMIT = config.auth.magicLinkPerEmailLimit
 const WINDOW_MS = 60 * 60 * 1000 // 1 hour
 
 function rateLimitIp(req: ExpressRequest): boolean {
@@ -68,7 +69,7 @@ export class MagicLinkController extends Controller {
 
                 // Compute environment-aware base for magic link URL
                 // Priority: explicit env override -> X-Forwarded headers -> request host/protocol -> fallback
-                const envBase = process.env.MAGIC_LINK_BASE_URL
+                const envBase = config.auth.magicLinkBaseUrl
                 let requestBase: string | undefined
                 try {
                     const xfProto = (request as any)?.headers?.['x-forwarded-proto']
@@ -82,7 +83,7 @@ export class MagicLinkController extends Controller {
                     }
                 } catch (e) { /* ignore */ }
 
-                const base = requestBase ?? process.env.MAGIC_LINK_BASE_URL ?? 'http://localhost:3000'
+                const base = requestBase ?? config.auth.magicLinkBaseUrl ?? 'http://localhost:3000'
 
                 await sendMagicLinkEmail(email, token, base)
                 magicLinkSent.inc()
@@ -122,13 +123,13 @@ export class MagicLinkController extends Controller {
                 return
             }
 
-            const supabaseKey = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY
+            const supabaseKey = config.auth.supabaseServiceRoleKey
             if (!supabaseKey) {
                 (request as any).res.status(400).json({ error: 'password registration not supported' })
                 this.setStatus(400)
                 return
             }
-            const supabaseUrl = process.env.PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_ISS
+            const supabaseUrl = config.auth.supabaseIss
             if (!supabaseUrl) {
                 (request as any).res.status(500).json({ error: 'Supabase URL not configured' })
                 this.setStatus(500)
@@ -178,7 +179,7 @@ export class MagicLinkController extends Controller {
                 const { token } = await generateMagicLinkToken(email, user.id)
 
                 // Compute base similar to send()
-                const envBase = process.env.MAGIC_LINK_BASE_URL
+                const envBase = config.auth.magicLinkBaseUrl
                 let requestBase: string | undefined
                 try {
                     const xfProto = (request as any)?.headers?.['x-forwarded-proto']
@@ -192,7 +193,7 @@ export class MagicLinkController extends Controller {
                     }
                 } catch (e) { /* ignore */ }
 
-                const base = requestBase ?? process.env.MAGIC_LINK_BASE_URL ?? 'http://localhost:3000'
+                const base = requestBase ?? config.auth.magicLinkBaseUrl ?? 'http://localhost:3000'
                 await sendMagicLinkEmail(email, token, base)
             } catch (err: any) {
                 console.error('failed to send magic link after register', err)
@@ -221,7 +222,7 @@ export class MagicLinkController extends Controller {
             await setSessionCookie(res, { sub: info.email, userId: info.userId })
             magicLinkVerified.inc()
             console.info('magic_link.verified', { email: info.email })
-            const redirect = process.env.MAGIC_LINK_SUCCESS_URL ?? (process.env.MAGIC_LINK_FRONTEND_URL ?? '/')
+            const redirect = config.auth.magicLinkSuccessUrl ?? (config.auth.magicLinkFrontendUrl ?? '/')
             try {
                 res.redirect(String(redirect))
                 return

--- a/src/http/controllers/PasswordController.ts
+++ b/src/http/controllers/PasswordController.ts
@@ -2,6 +2,7 @@ import { Controller, Route, Tags, Post, Body, Request, Response } from 'tsoa'
 import type { Request as ExpressRequest } from 'express'
 import { Counter } from 'prom-client'
 import { setSessionCookie } from './_session-utils.js'
+import { config } from '../../config.js'
 
 const passwordResetSent = new Counter({ name: 'password_reset_sent_total', help: 'Total password reset requests' })
 const passwordLoginAttempts = new Counter({ name: 'password_login_attempts_total', help: 'Total password login attempts' })
@@ -22,8 +23,8 @@ export class PasswordController extends Controller {
         // Note: per-IP rate limiting is handled elsewhere (MagicLinkController).
         // Left here as a placeholder for future enhancement.
 
-        const supabaseUrl = process.env.PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_ISS
-        const supabaseKey = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.SUPABASE_ANON_KEY
+        const supabaseUrl = config.auth.supabaseIss
+        const supabaseKey = config.auth.supabaseServiceRoleKey ?? config.auth.supabaseAnonKey
         if (!supabaseUrl || !supabaseKey) { res.status(400).json({ error: 'password not supported' }); return undefined as any }
 
         try {
@@ -58,8 +59,8 @@ export class PasswordController extends Controller {
         const password = String(body?.password || '')
         if (!email || !password) { res.status(400).json({ error: 'email and password required' }); return undefined as any }
 
-        const supabaseUrl = process.env.PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_ISS
-        const supabaseKey = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.SUPABASE_ANON_KEY
+        const supabaseUrl = config.auth.supabaseIss
+        const supabaseKey = config.auth.supabaseServiceRoleKey ?? config.auth.supabaseAnonKey
         if (!supabaseUrl || !supabaseKey) { res.status(400).json({ error: 'password not supported' }); return undefined as any }
 
         passwordLoginAttempts.inc()

--- a/src/http/controllers/SpotifyAdminController.ts
+++ b/src/http/controllers/SpotifyAdminController.ts
@@ -1,6 +1,7 @@
 import { Controller, Post, Route, Tags, Body, SuccessResponse, Response } from 'tsoa'
 import fs from 'fs'
 import path from 'path'
+import { config } from '../../config.js'
 
 interface SeedRequest {
     code?: string
@@ -44,9 +45,9 @@ export class SpotifyAdminController extends Controller {
 
             // If an authorization code was provided, exchange it for tokens
             if (body.code) {
-                const clientId = process.env.SPOTIFY_CLIENT_ID
-                const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-                const redirectUri = process.env.SPOTIFY_REDIRECT_URI
+                const clientId = config.spotify.clientId
+                const clientSecret = config.spotify.clientSecret
+                const redirectUri = config.spotify.redirectUri
                 if (!clientId || !clientSecret || !redirectUri) {
                     this.setStatus(400)
                     const err: any = new Error('SPOTIFY_CLIENT_ID / SPOTIFY_CLIENT_SECRET / SPOTIFY_REDIRECT_URI must be configured to exchange code')
@@ -83,11 +84,12 @@ export class SpotifyAdminController extends Controller {
             }
 
             // Set in-process so adapter picks it up immediately
+            // Runtime write: seeds the token in-process after OAuth callback; config.spotify.refreshToken reflects startup value only
             process.env.SPOTIFY_REFRESH_TOKEN = refreshToken
 
             // Persist to .env.local in development for convenience (do NOT persist in test/prod)
             let persisted = false
-            if ((process.env.NODE_ENV || 'development') === 'development') {
+            if (!config.isProduction) {
                 try {
                     const envPath = path.resolve(process.cwd(), '.env.local')
                     let content = ''

--- a/src/http/controllers/_session-utils.ts
+++ b/src/http/controllers/_session-utils.ts
@@ -1,17 +1,19 @@
+import { config } from '../../config.js'
+
 export function setSessionCookie(res: any, payload: Record<string, any>) {
-    const secret = process.env.SESSION_JWT_SECRET
-    const maxAge = Number(process.env.SESSION_COOKIE_MAX_AGE_SEC ?? 60 * 60 * 24 * 7) // 7 days
+    const secret = config.auth.sessionJwtSecret
+    const maxAge = config.auth.sessionCookieMaxAgeSec
     if (!secret) {
         console.warn('SESSION_JWT_SECRET not set; session cookie will not be signed')
         const token = Buffer.from(JSON.stringify(payload)).toString('base64')
-        res.cookie('session', token, { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax', maxAge })
+        res.cookie('session', token, { httpOnly: true, secure: config.isProduction, sameSite: 'lax', maxAge })
         return
     }
     const encoder = new TextEncoder().encode(secret)
     return import('jose').then(({ SignJWT }) =>
         new SignJWT(payload).setProtectedHeader({ alg: 'HS256' }).setIssuedAt().setExpirationTime(`${maxAge}s`).sign(encoder as any)
     ).then((token: string) => {
-        res.cookie('session', token, { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'lax', maxAge })
+        res.cookie('session', token, { httpOnly: true, secure: config.isProduction, sameSite: 'lax', maxAge })
     }).catch((err: any) => {
         console.error('failed to sign session token', err)
     })

--- a/src/http/mcp-http.ts
+++ b/src/http/mcp-http.ts
@@ -1,5 +1,6 @@
 import { Application, Request, Response } from "express";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { config } from "../config.js";
 
 // Simple newline-delimited JSON HTTP stream transport
 export class HttpStreamTransport {
@@ -182,7 +183,7 @@ export function registerMcpHttp(app: Application): void {
     app.post(base, async (req: Request, res: Response) => {
         try {
             console.error(`mcp-http: POST /mcp called authPresent=${!!req.headers.authorization}`);
-            const mcpKey = process.env.MCP_API_KEY;
+            const mcpKey = config.security.mcpApiKey;
             if (mcpKey) {
                 const auth = (req.headers.authorization || '').toString();
                 if (auth !== `Bearer ${mcpKey}`) {
@@ -221,7 +222,7 @@ export function registerMcpHttp(app: Application): void {
     app.get(base, async (req: Request, res: Response) => {
         try {
             console.error(`mcp-http: GET /mcp called authPresent=${!!req.headers.authorization}`);
-            const mcpKey = process.env.MCP_API_KEY;
+            const mcpKey = config.security.mcpApiKey;
             if (mcpKey) {
                 const auth = (req.headers.authorization || '').toString();
                 if (auth !== `Bearer ${mcpKey}`) {
@@ -273,7 +274,7 @@ export function registerMcpHttp(app: Application): void {
     app.post(`${base}/events`, async (req: Request, res: Response) => {
         try {
             console.error('mcp-http: POST /mcp/events called', { connIdHeader: req.headers['x-mcp-conn-id'] });
-            const mcpKey = process.env.MCP_API_KEY;
+            const mcpKey = config.security.mcpApiKey;
             if (mcpKey) {
                 const auth = (req.headers.authorization || '').toString();
                 if (auth !== `Bearer ${mcpKey}`) {

--- a/src/http/middleware/mcp-auth.ts
+++ b/src/http/middleware/mcp-auth.ts
@@ -1,8 +1,9 @@
 import type { Request, Response, NextFunction } from 'express';
 import { mcpAuthFailuresTotal } from '../metrics-route.js';
+import { config } from '../../config.js';
 
 export function mcpAuthMiddleware(req: Request, res: Response, next: NextFunction) {
-    const mcpKey = process.env.MCP_API_KEY;
+    const mcpKey = config.security.mcpApiKey;
     // No-op when key not set
     if (!mcpKey) return next();
 

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -13,6 +13,7 @@ import { registerAuthorsRoute } from './authors-route.js';
 import { initPrisma } from '../db/index.js';
 import { RegisterRoutes } from './tsoa-routes.js';
 import { registerSwaggerRoute } from './swagger-route.js';
+import { config } from '../config.js';
 
 export async function createHttpApp() {
     // Backwards-compatible: keep existing behavior when callers expect Prisma initialized
@@ -70,7 +71,7 @@ export async function createHttpApp() {
     app.use((err: any, _req: express.Request, res: express.Response, _next: any) => {
         try { console.error('unhandled error', err) } catch (e) { /* noop */ }
         const status = (res.statusCode && res.statusCode >= 400) ? res.statusCode : (err?.status || 500)
-        const message = (process.env.NODE_ENV === 'production') ? 'internal error' : (err?.message ?? 'internal error')
+        const message = config.isProduction ? 'internal error' : (err?.message ?? 'internal error')
         res.status(status).json({ error: message })
     })
 
@@ -172,7 +173,7 @@ export async function registerDbDependentRoutes(app: any) {
     app.use((err: any, _req: express.Request, res: express.Response, _next: any) => {
         try { console.error('unhandled error', err) } catch (e) { /* noop */ }
         const status = (res.statusCode && res.statusCode >= 400) ? res.statusCode : (err?.status || 500)
-        const message = (process.env.NODE_ENV === 'production') ? 'internal error' : (err?.message ?? 'internal error')
+        const message = config.isProduction ? 'internal error' : (err?.message ?? 'internal error')
         res.status(status).json({ error: message })
     })
 
@@ -207,12 +208,12 @@ export async function startHttpServer(port: number, host?: string, opts?: { earl
     const app = createBasicApp();
 
     return new Promise((resolve) => {
-        const bindHost = host ?? process.env.HOST ?? '0.0.0.0';
+        const bindHost = host ?? config.server.host;
         const server = app.listen(port, bindHost, async () => {
             console.error(`HTTP server listening on ${bindHost}:${port}`);
 
             // Attach WebSocket server for MCP remote transport when enabled via MCP_API_KEY
-            const mcpKey = process.env.MCP_API_KEY
+            const mcpKey = config.security.mcpApiKey
             if (mcpKey) {
                 const wss = new WebSocketServer({ server, path: '/mcp/ws' })
                 wss.on('connection', (ws, req) => {
@@ -239,7 +240,7 @@ export async function startHttpServer(port: number, host?: string, opts?: { earl
                 console.error('MCP WebSocket endpoint enabled at /mcp/ws')
             }
 
-            const early = opts?.earlyStart === true || process.env.EARLY_START === 'true'
+            const early = opts?.earlyStart === true || config.server.earlyStart
 
             // Initialize Prisma and register DB-dependent routes.
             // If `early` is true, do this in the background and resolve immediately.

--- a/src/http/spotify-route.ts
+++ b/src/http/spotify-route.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from 'express';
 import { getPlayback } from './playback-store.js';
+import { config } from '../config.js';
 
 // Adapter methods are imported dynamically in registerDbDependentRoutes so tests
 // that don't enable Spotify won't fail to import this module.
@@ -44,7 +45,7 @@ export function registerSpotifyRoute(app: any) {
     // credentials and refresh token are present.
     (async () => {
         // Only attempt auto-start when the Spotify configuration looks complete.
-        if (!(process.env.SPOTIFY_CLIENT_ID && process.env.SPOTIFY_CLIENT_SECRET && process.env.SPOTIFY_REFRESH_TOKEN)) {
+        if (!config.spotify.enabled) {
             console.error('spotify-adapter: auto-start skipped (missing SPOTIFY env)');
             return;
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,7 @@
 #!/usr/bin/env node
 
-// Load environment variables first (before any imports that might use them)
-if (process.env.NODE_ENV !== 'production') {
-    try {
-        await import('dotenv/config');
-    } catch {
-        // dotenv not available, environment variables provided by hosting platform
-    }
-}
-
+// config.ts loads dotenv at module init — import it before anything else.
+import { config } from "./config.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { registerTools } from "./tools/index.js";
@@ -26,11 +19,10 @@ async function main(): Promise<void> {
     // Diagnostic: log key environment variables and stdio status so we can detect how the extension launched us
     try {
         const diag = {
-            PORT: process.env.PORT,
-            MCP_TRANSPORT: process.env.MCP_TRANSPORT,
-            NODE_ENV: process.env.NODE_ENV,
+            PORT: config.server.port,
+            MCP_TRANSPORT: config.server.mcpTransport,
+            NODE_ENV: config.nodeEnv,
             stdinIsTTY: typeof process.stdin.isTTY !== 'undefined' ? process.stdin.isTTY : null,
-            // Whether stdin is in flowing mode (a crude check; true for many interactive/stdio use-cases)
             stdinReadable: Boolean(process.stdin && (process.stdin.readable || process.stdin.readableFlowing)),
         };
         console.error('startup diagnostic:', JSON.stringify(diag));
@@ -44,10 +36,10 @@ async function main(): Promise<void> {
     // 2. If unset, prefer stdio when stdin appears attached (common for LocalProcess) even if PORT is set
     // 3. Otherwise, if PORT is set, run HTTP server
     try {
-        const explicitEnv = process.env.MCP_TRANSPORT;
-        const port = process.env.PORT ? Number(process.env.PORT) : undefined;
+        const explicitEnv = config.server.mcpTransport;
+        const port = config.server.port;
         const stdinAttached = Boolean(process.stdin && (process.stdin.isTTY || process.stdin.readable || (process.stdin as any).readableFlowing));
-        const env = process.env.NODE_ENV || 'development';
+        const env = config.nodeEnv;
 
         // Determine transport via a testable helper
         const { decideTransport } = await import('./transport-selection.js');
@@ -80,10 +72,8 @@ async function main(): Promise<void> {
     // Note: transport-specific startup messages are logged in each branch above.
 
     // Warn if admin debug is enabled in what looks like production
-    const adminDebug = (process.env.ADMIN_DEBUG_ENABLED || '').toLowerCase()
-    const env = process.env.NODE_ENV || 'development'
-    if (adminDebug === '1' || adminDebug === 'true') {
-        if (env === 'production') {
+    if (config.security.adminDebugEnabled) {
+        if (config.isProduction) {
             console.warn('ADMIN_DEBUG_ENABLED is set in production - this exposes diagnostic endpoints. Consider disabling this in production.')
         } else {
             console.error('ADMIN_DEBUG_ENABLED is enabled for this process; debug endpoints will be registered (preview/staging only)')
@@ -91,20 +81,17 @@ async function main(): Promise<void> {
     }
 
     // SendGrid configuration warning (non-blocking)
-    const sendgridKey = process.env.SENDGRID_API_KEY
-    const senderEmail = process.env.SENDER_EMAIL ?? process.env.FROM_EMAIL
-
-    if (env === 'production') {
-        if (!sendgridKey || !senderEmail) {
+    if (config.isProduction) {
+        if (!config.email.sendgridApiKey || !config.email.senderEmail) {
             console.warn('SendGrid not fully configured for production. Missing SENDGRID_API_KEY or SENDER_EMAIL; transactional emails will not be sent. See docs/runbooks/sendgrid.md for setup.')
         } else {
             console.error('SendGrid appears configured for production (SENDER_EMAIL present).')
         }
     } else {
-        if (!sendgridKey || !senderEmail) {
+        if (!config.email.sendgridApiKey || !config.email.senderEmail) {
             console.error('SendGrid not configured for local/testing — this is expected in development. Set SENDGRID_API_KEY/SENDER_EMAIL to test email sending.')
         } else {
-            console.error('SendGrid configured in non-production environment (SENDER_EMAIL=%s).', senderEmail)
+            console.error('SendGrid configured in non-production environment (SENDER_EMAIL=%s).', config.email.senderEmail)
         }
     }
 }

--- a/src/tools/github-projects/graphql.ts
+++ b/src/tools/github-projects/graphql.ts
@@ -7,6 +7,7 @@ import type {
     AddProjectItemResponse,
     UpdateFieldValueResponse
 } from "./types.js";
+import { config } from "../../config.js";
 
 /**
  * In-memory cache for project metadata
@@ -25,8 +26,8 @@ const CACHE_TTL = 5 * 60 * 1000;
  */
 function getGitHubToken(): string {
     // First try environment variable (for CI/staging)
-    if (process.env.GITHUB_TOKEN) {
-        return process.env.GITHUB_TOKEN;
+    if (config.github.token) {
+        return config.github.token;
     }
 
     // Fall back to gh CLI auth (for local development)

--- a/test/auth/jwt.test.ts
+++ b/test/auth/jwt.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest'
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest'
 import { jwtMiddleware, verifySupabaseJwt } from '../../src/auth/jwt'
 import { requireAdmin } from '../../src/auth/requireAdmin'
 import express from 'express'
 import request from 'supertest'
 import { generateKeyPair, exportJWK, SignJWT } from 'jose'
+import { config } from '../../src/config.js'
 
 let publicJwk: any
 let privateKey: CryptoKey
@@ -11,7 +12,26 @@ const jwksUrl = 'https://example.local/.well-known/jwks.json'
 const issuer = 'https://nanodcvcpklffksxofbm.supabase.co'
 const audience = 'authenticated'
 
+let origJwksUrl: string | undefined
+let origIss: string | undefined
+let origAud: string | undefined
+let origSessionSecret: string | undefined
+let origSvcKey: string | undefined
+let origAnonKey: string | undefined
+let origAdminIpAllowlist: string[]
+let origInternalAdminKey: string | undefined
+
 beforeAll(async () => {
+    // Save originals
+    origJwksUrl = config.auth.supabaseJwksUrl
+    origIss = config.auth.supabaseIss
+    origAud = config.auth.supabaseAud
+    origSessionSecret = config.auth.sessionJwtSecret
+    origSvcKey = config.auth.supabaseServiceRoleKey
+    origAnonKey = config.auth.supabaseAnonKey
+    origAdminIpAllowlist = config.security.adminIpAllowlist
+    origInternalAdminKey = config.security.internalAdminKey
+
     // generate keys for test
     const { publicKey, privateKey: pk } = await generateKeyPair('RS256')
     privateKey = pk
@@ -30,14 +50,31 @@ beforeAll(async () => {
         return { ok: false, status: 404 }
     })
 
-    // set env vars used by middleware
-    process.env.SUPABASE_JWKS_URL = jwksUrl
-    process.env.SUPABASE_ISS = issuer
-    process.env.SUPABASE_AUD = audience
+    // Set config values used by middleware (replaces process.env.* reads)
+    config.auth.supabaseJwksUrl = jwksUrl
+    config.auth.supabaseIss = issuer
+    config.auth.supabaseAud = audience
 })
 
 afterAll(() => {
+    config.auth.supabaseJwksUrl = origJwksUrl
+    config.auth.supabaseIss = origIss
+    config.auth.supabaseAud = origAud
+    config.auth.sessionJwtSecret = origSessionSecret
+    config.auth.supabaseServiceRoleKey = origSvcKey
+    config.auth.supabaseAnonKey = origAnonKey
+    config.security.adminIpAllowlist = origAdminIpAllowlist
+    config.security.internalAdminKey = origInternalAdminKey
     vi.unstubAllGlobals()
+})
+
+afterEach(() => {
+    // Restore per-test mutations between tests
+    config.auth.sessionJwtSecret = origSessionSecret
+    config.auth.supabaseServiceRoleKey = origSvcKey
+    config.auth.supabaseAnonKey = origAnonKey
+    config.security.adminIpAllowlist = origAdminIpAllowlist
+    config.security.internalAdminKey = origInternalAdminKey
 })
 
 describe('JWT middleware', () => {
@@ -73,13 +110,13 @@ describe('JWT middleware', () => {
     })
 
     it('verifies a valid session cookie and attaches user', async () => {
-        process.env.SESSION_JWT_SECRET = 'session-secret'
+        config.auth.sessionJwtSecret = 'session-secret'
         const sessionToken = await new SignJWT({ userId: 42 })
             .setProtectedHeader({ alg: 'HS256' })
             .setSubject('cookie-user')
             .setIssuedAt()
             .setExpirationTime('2h')
-            .sign(new TextEncoder().encode(process.env.SESSION_JWT_SECRET) as any)
+            .sign(new TextEncoder().encode(config.auth.sessionJwtSecret) as any)
 
         const app = express()
         app.use(jwtMiddleware)
@@ -88,8 +125,6 @@ describe('JWT middleware', () => {
         const res = await request(app).get('/whoami').set('Cookie', `session=${sessionToken}`)
         expect(res.status).toBe(200)
         expect(res.body.user.sub).toBe('cookie-user')
-
-        delete process.env.SESSION_JWT_SECRET
     })
 
     it('rejects invalid session cookie', async () => {
@@ -113,13 +148,13 @@ describe('JWT middleware', () => {
             .sign(privateKey as any)
 
         // set session cookie with different sub
-        process.env.SESSION_JWT_SECRET = 'session-secret'
+        config.auth.sessionJwtSecret = 'session-secret'
         const sessionToken = await new SignJWT({ userId: 99 })
             .setProtectedHeader({ alg: 'HS256' })
             .setSubject('cookie-user')
             .setIssuedAt()
             .setExpirationTime('2h')
-            .sign(new TextEncoder().encode(process.env.SESSION_JWT_SECRET) as any)
+            .sign(new TextEncoder().encode(config.auth.sessionJwtSecret) as any)
 
         const app = express()
         app.use(jwtMiddleware)
@@ -132,8 +167,6 @@ describe('JWT middleware', () => {
 
         expect(res.status).toBe(200)
         expect(res.body.user.sub).toBe('user-header')
-
-        delete process.env.SESSION_JWT_SECRET
     })
 
     it('verifySupabaseJwt fails for expired token', async () => {
@@ -165,11 +198,10 @@ describe('JWT middleware', () => {
             return { ok: false, status: 404 }
         })
 
-        const prevJwksEnv = process.env.SUPABASE_JWKS_URL
-        process.env.SUPABASE_JWKS_URL = 'https://primary.local/jwks'
-        process.env.SUPABASE_ISS = issuer
-        process.env.SUPABASE_AUD = audience
-        process.env.PUBLIC_SUPABASE_PUBLISHABLE_KEY = 'publishable-key'
+        const prevConfigJwksUrl = config.auth.supabaseJwksUrl
+        const prevConfigAnonKey = config.auth.supabaseAnonKey
+        config.auth.supabaseJwksUrl = 'https://primary.local/jwks'
+        config.auth.supabaseAnonKey = 'publishable-key'
 
         const sig = await new SignJWT({ role: 'authenticated' })
             .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
@@ -185,10 +217,10 @@ describe('JWT middleware', () => {
             throw new Error(`unexpected payload from verifySupabaseJwt: ${JSON.stringify(payload)}`)
         }
 
-        // cleanup - restore previous fetch and env
-        (global as any).fetch = prevFetch
-        delete process.env.PUBLIC_SUPABASE_PUBLISHABLE_KEY
-        process.env.SUPABASE_JWKS_URL = prevJwksEnv
+        // cleanup - restore previous fetch and config
+        ;(global as any).fetch = prevFetch
+        config.auth.supabaseJwksUrl = prevConfigJwksUrl
+        config.auth.supabaseAnonKey = prevConfigAnonKey
     })
 
     it('throws helpful error when JWKS primary and fallback fail', async () => {
@@ -197,9 +229,8 @@ describe('JWT middleware', () => {
             return { ok: false, status: 404, statusText: 'Not Found', text: async () => 'notfound' }
         })
 
-        process.env.SUPABASE_JWKS_URL = 'https://primary.local/jwks'
-        process.env.SUPABASE_ISS = issuer
-        process.env.SUPABASE_AUD = audience
+        const prevConfigJwksUrl2 = config.auth.supabaseJwksUrl
+        config.auth.supabaseJwksUrl = 'https://primary.local/jwks'
 
         const token = await new SignJWT({ role: 'authenticated' })
             .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
@@ -211,14 +242,14 @@ describe('JWT middleware', () => {
             .sign(privateKey as any)
 
         await expect(verifySupabaseJwt(token)).rejects.toThrow(/JWKS fetch failed/)
-            ; (global as any).fetch = prevFetch
+        ;(global as any).fetch = prevFetch
+        config.auth.supabaseJwksUrl = prevConfigJwksUrl2
     })
 
     it('rejects service role key when not allowed by header or IP allowlist', async () => {
         const app = express()
         const serviceKey = 'super-secret-service-key'
-        process.env.SUPABASE_SERVICE_ROLE_KEY = serviceKey
-        process.env.SUPABASE_SECRET_KEY = serviceKey
+        config.auth.supabaseServiceRoleKey = serviceKey
         app.get('/whoami', jwtMiddleware, (req, res) => res.json({ user: (req as any).user }))
 
         // requireAdmin is applied; without proper header/IP it should be forbidden
@@ -226,21 +257,18 @@ describe('JWT middleware', () => {
 
         const res = await request(app).get('/admin').set('Authorization', `Bearer ${serviceKey}`)
         expect(res.status).toBe(403)
-        delete process.env.SUPABASE_SERVICE_ROLE_KEY
-        delete process.env.SUPABASE_SECRET_KEY
     })
 
     it('allows service key when ip is allowlisted and header present and writes audit log + metric', async () => {
         const app = express()
         const serviceKey = 'super-secret-service-key'
-        process.env.SUPABASE_SERVICE_ROLE_KEY = serviceKey
-        process.env.SUPABASE_SECRET_KEY = serviceKey
+        config.auth.supabaseServiceRoleKey = serviceKey
 
         // Mock prisma.auditLog.create and metric
         const p = await import('../../src/db/index.js') as any
         p.prisma.auditLog = { create: vi.fn().mockResolvedValue({ id: 1 }) }
 
-        process.env.ADMIN_IP_ALLOWLIST = '::ffff:127.0.0.1'
+        config.security.adminIpAllowlist = ['::ffff:127.0.0.1']
         const m = await import('../../src/http/metrics-route.js') as any
         const incSpy = vi.spyOn(m.serviceRoleBypassTotal, 'inc').mockImplementation(() => { })
 
@@ -250,29 +278,24 @@ describe('JWT middleware', () => {
         expect(res.status).toBe(403)
 
         // Now set internal key as well
-        process.env.INTERNAL_ADMIN_KEY = 'my-internal-key'
+        config.security.internalAdminKey = 'my-internal-key'
         const res2 = await request(app).get('/admin').set('Authorization', `Bearer ${serviceKey}`).set('x-internal-key', 'my-internal-key')
         expect(res2.status).toBe(200)
         expect(p.prisma.auditLog.create).toHaveBeenCalled()
         expect(incSpy).toHaveBeenCalled()
-
-        delete process.env.SUPABASE_SERVICE_ROLE_KEY
-        delete process.env.SUPABASE_SECRET_KEY
-        delete process.env.ADMIN_IP_ALLOWLIST
-        delete process.env.INTERNAL_ADMIN_KEY
     })
 
     it('maps a Supabase JWT sub (external_id) to local user and grants admin when local user is admin', async () => {
         const supabaseSub = '00b72aac-2286-48e5-955a-c8012cceb9c5'
 
         // Use a session cookie to exercise the mapping logic without JWKS/network dependence
-        process.env.SESSION_JWT_SECRET = 'session-secret'
+        config.auth.sessionJwtSecret = 'session-secret'
         const sessionToken = await new SignJWT({})
             .setProtectedHeader({ alg: 'HS256' })
             .setSubject(supabaseSub)
             .setIssuedAt()
             .setExpirationTime('2h')
-            .sign(new TextEncoder().encode(process.env.SESSION_JWT_SECRET) as any)
+            .sign(new TextEncoder().encode(config.auth.sessionJwtSecret) as any)
 
         // stub prisma user lookup by external_id
         const p = await import('../../src/db/index.js') as any
@@ -292,21 +315,19 @@ describe('JWT middleware', () => {
         const res = await request(app).get('/admin').set('Cookie', `session=${sessionToken}`)
         expect(res.status).toBe(200)
         expect(p.prisma.profile.findUnique).toHaveBeenCalled()
-
-        delete process.env.SESSION_JWT_SECRET
     })
 
     it('maps a Supabase JWT sub that is an email to local user and attaches role', async () => {
         const emailSub = 'brn.dbn@gmail.com'
 
         // Use a session cookie to exercise the mapping logic without JWKS/network dependence
-        process.env.SESSION_JWT_SECRET = 'session-secret'
+        config.auth.sessionJwtSecret = 'session-secret'
         const sessionToken = await new SignJWT({})
             .setProtectedHeader({ alg: 'HS256' })
             .setSubject(emailSub)
             .setIssuedAt()
             .setExpirationTime('2h')
-            .sign(new TextEncoder().encode(process.env.SESSION_JWT_SECRET) as any)
+            .sign(new TextEncoder().encode(config.auth.sessionJwtSecret) as any)
 
         // stub prisma user lookup by email
         const p = await import('../../src/db/index.js') as any
@@ -327,7 +348,5 @@ describe('JWT middleware', () => {
         expect(res.status).toBe(200)
         expect(res.body.user.role).toBe('user')
         expect(p.prisma.profile.findUnique).toHaveBeenCalled()
-
-        delete process.env.SESSION_JWT_SECRET
     })
 })

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest'
+import { config } from '../../src/config.js'
+
+describe('config module', () => {
+    describe('structure', () => {
+        it('exports config with all required domain sections', () => {
+            expect(config).toHaveProperty('server')
+            expect(config).toHaveProperty('security')
+            expect(config).toHaveProperty('database')
+            expect(config).toHaveProperty('auth')
+            expect(config).toHaveProperty('email')
+            expect(config).toHaveProperty('spotify')
+            expect(config).toHaveProperty('github')
+            expect(config).toHaveProperty('ci')
+        })
+
+        it('nodeEnv is one of the allowed enum values', () => {
+            expect(['development', 'production', 'test']).toContain(config.nodeEnv)
+        })
+
+        it('isProduction and isTest are mutually exclusive booleans', () => {
+            expect(typeof config.isProduction).toBe('boolean')
+            expect(typeof config.isTest).toBe('boolean')
+            // They can't both be true
+            expect(config.isProduction && config.isTest).toBe(false)
+        })
+
+        it('isProduction matches nodeEnv === production', () => {
+            expect(config.isProduction).toBe(config.nodeEnv === 'production')
+        })
+
+        it('isTest matches nodeEnv === test', () => {
+            expect(config.isTest).toBe(config.nodeEnv === 'test')
+        })
+    })
+
+    describe('default values', () => {
+        it('sessionCookieMaxAgeSec defaults to 7 days (604800)', () => {
+            const sevenDays = 60 * 60 * 24 * 7
+            if (!process.env.SESSION_COOKIE_MAX_AGE_SEC) {
+                expect(config.auth.sessionCookieMaxAgeSec).toBe(sevenDays)
+            } else {
+                expect(config.auth.sessionCookieMaxAgeSec).toBeGreaterThan(0)
+            }
+        })
+
+        it('magicLinkPerEmailLimit defaults to 5', () => {
+            if (!process.env.MAGIC_LINK_PER_EMAIL_LIMIT) {
+                expect(config.auth.magicLinkPerEmailLimit).toBe(5)
+            } else {
+                expect(config.auth.magicLinkPerEmailLimit).toBeGreaterThan(0)
+            }
+        })
+
+        it('spotify.pollIntervalMs defaults to 15000', () => {
+            if (!process.env.SPOTIFY_POLL_INTERVAL_MS) {
+                expect(config.spotify.pollIntervalMs).toBe(15_000)
+            } else {
+                expect(config.spotify.pollIntervalMs).toBeGreaterThan(0)
+            }
+        })
+
+        it('email.senderName defaults to bryandebaun.dev', () => {
+            if (!process.env.SENDER_NAME) {
+                expect(config.email.senderName).toBe('bryandebaun.dev')
+            } else {
+                expect(typeof config.email.senderName).toBe('string')
+            }
+        })
+
+        it('server.host defaults to 0.0.0.0', () => {
+            if (!process.env.HOST) {
+                expect(config.server.host).toBe('0.0.0.0')
+            }
+        })
+    })
+
+    describe('CSV array parsing (ADMIN_IP_ALLOWLIST)', () => {
+        it('adminIpAllowlist is always an array', () => {
+            expect(Array.isArray(config.security.adminIpAllowlist)).toBe(true)
+        })
+
+        it('adminIpAllowlist contains only non-empty strings', () => {
+            config.security.adminIpAllowlist.forEach((entry) => {
+                expect(typeof entry).toBe('string')
+                expect(entry.length).toBeGreaterThan(0)
+            })
+        })
+    })
+
+    describe('boolean flag parsing', () => {
+        it('adminDebugEnabled is a boolean', () => {
+            expect(typeof config.security.adminDebugEnabled).toBe('boolean')
+        })
+
+        it('showInviteToken is a boolean', () => {
+            expect(typeof config.security.showInviteToken).toBe('boolean')
+        })
+
+        it('ci.runDbIntegration is a boolean', () => {
+            expect(typeof config.ci.runDbIntegration).toBe('boolean')
+        })
+    })
+
+    describe('alias normalization', () => {
+        it('spotify.enabled is true only when all three Spotify credentials are set', () => {
+            const expected =
+                Boolean(config.spotify.clientId) &&
+                Boolean(config.spotify.clientSecret) &&
+                Boolean(config.spotify.refreshToken)
+            expect(config.spotify.enabled).toBe(expected)
+        })
+
+        it('auth.supabaseIss is a string when set', () => {
+            if (config.auth.supabaseIss !== undefined) {
+                expect(typeof config.auth.supabaseIss).toBe('string')
+                expect(config.auth.supabaseIss.length).toBeGreaterThan(0)
+            }
+        })
+
+        it('auth.supabaseJwksUrl is derived from PUBLIC_SUPABASE_URL when SUPABASE_JWKS_URL absent', () => {
+            if (!process.env.SUPABASE_JWKS_URL && process.env.PUBLIC_SUPABASE_URL) {
+                expect(config.auth.supabaseJwksUrl).toContain('.well-known/jwks.json')
+            }
+        })
+
+        it('auth.supabaseServiceRoleKey normalizes SUPABASE_SERVICE_ROLE_KEY and SUPABASE_SECRET_KEY aliases', () => {
+            if (config.auth.supabaseServiceRoleKey !== undefined) {
+                expect(typeof config.auth.supabaseServiceRoleKey).toBe('string')
+            }
+        })
+
+        it('email.senderEmail normalizes SENDER_EMAIL and FROM_EMAIL aliases', () => {
+            if (config.email.senderEmail !== undefined) {
+                expect(config.email.senderEmail).toMatch(/@/)
+            }
+        })
+    })
+
+    describe('positive integer coercion', () => {
+        it('auth.sessionRateLimitPerIp is a positive integer', () => {
+            expect(Number.isInteger(config.auth.sessionRateLimitPerIp)).toBe(true)
+            expect(config.auth.sessionRateLimitPerIp).toBeGreaterThan(0)
+        })
+
+        it('auth.sessionRateLimitWindowMs is a positive integer', () => {
+            expect(Number.isInteger(config.auth.sessionRateLimitWindowMs)).toBe(true)
+            expect(config.auth.sessionRateLimitWindowMs).toBeGreaterThan(0)
+        })
+    })
+})

--- a/test/email.test.ts
+++ b/test/email.test.ts
@@ -1,9 +1,22 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { sendInviteEmail, sendMagicLinkEmail } from '../src/email.js'
+import { config } from '../src/config.js'
+
+const origSendgridKey = config.email.sendgridApiKey
+const origSenderEmail = config.email.senderEmail
+const origSenderName = config.email.senderName
+const origSupportEmail = config.email.supportEmail
 
 beforeEach(() => {
-    delete process.env.SENDGRID_API_KEY
-    delete process.env.SENDER_EMAIL
+    config.email.sendgridApiKey = undefined
+    config.email.senderEmail = undefined
+})
+
+afterEach(() => {
+    config.email.sendgridApiKey = origSendgridKey
+    config.email.senderEmail = origSenderEmail
+    config.email.senderName = origSenderName
+    config.email.supportEmail = origSupportEmail
 })
 
 describe('sendInviteEmail', () => {
@@ -18,10 +31,10 @@ describe('sendInviteEmail', () => {
 
 describe('sendMagicLinkEmail', () => {
     it('sends HTML and text payload when SENDGRID_API_KEY is set', async () => {
-        process.env.SENDGRID_API_KEY = 'SG.test'
-        process.env.SENDER_EMAIL = 'no-reply@bryandebaun.dev'
-        process.env.SENDER_NAME = 'BryanDeBaunDev'
-        process.env.SUPPORT_EMAIL = 'support@bryandebaun.dev'
+        config.email.sendgridApiKey = 'SG.test'
+        config.email.senderEmail = 'no-reply@bryandebaun.dev'
+        config.email.senderName = 'BryanDeBaunDev'
+        config.email.supportEmail = 'support@bryandebaun.dev'
 
         const fakeRes = { ok: true, status: 202, text: async () => '' }
         const fetchSpy = vi.spyOn(globalThis, 'fetch' as any).mockResolvedValue(fakeRes as any)

--- a/test/http/magic-link-route.test.ts
+++ b/test/http/magic-link-route.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import express from 'express'
 import request from 'supertest'
+import { config } from '../../src/config.js'
 
 vi.mock('../../src/auth/magic-link.ts', () => ({
     generateMagicLinkToken: vi.fn(),
@@ -13,10 +14,21 @@ vi.mock('../../src/email.ts', () => ({
 import { RegisterRoutes } from '../../src/http/tsoa-routes.js'
 
 describe('magic-link routes', () => {
+    const origMcpKey = config.security.mcpApiKey
+    const origSvcKey = config.auth.supabaseServiceRoleKey
+    const origIss = config.auth.supabaseIss
+
     beforeEach(async () => {
         // Reset mocks and rate limits
         const mod: any = await import('../../src/http/controllers/MagicLinkController.ts')
         mod._testResetRateLimits()
+    })
+
+    afterEach(() => {
+        config.security.mcpApiKey = origMcpKey
+        config.auth.supabaseServiceRoleKey = origSvcKey
+        config.auth.supabaseIss = origIss
+        vi.restoreAllMocks()
     })
 
     it('POST /api/auth/magic-link returns 202 and sends email', async () => {
@@ -105,8 +117,8 @@ describe('magic-link routes', () => {
     })
 
     it('GET /api/auth/magic-link/verify remains public when MCP_API_KEY set', async () => {
-        const orig = process.env.MCP_API_KEY
-        process.env.MCP_API_KEY = 'testkey'
+        const origKey = config.security.mcpApiKey
+        config.security.mcpApiKey = 'testkey'
 
         const { mcpAuthMiddleware } = await import('../../src/http/middleware/mcp-auth.js')
         const app = express()
@@ -121,13 +133,12 @@ describe('magic-link routes', () => {
         expect([302, 301, 307, 308]).toContain(res.status)
         expect(res.headers['set-cookie']).toBeDefined()
 
-        if (typeof orig === 'undefined') delete process.env.MCP_API_KEY
-        else process.env.MCP_API_KEY = orig
+        config.security.mcpApiKey = origKey
     })
 
     it('POST /api/auth/magic-link/verify remains public when MCP_API_KEY set', async () => {
-        const orig = process.env.MCP_API_KEY
-        process.env.MCP_API_KEY = 'testkey'
+        const origKey2 = config.security.mcpApiKey
+        config.security.mcpApiKey = 'testkey'
 
         const { mcpAuthMiddleware } = await import('../../src/http/middleware/mcp-auth.js')
         const app = express()
@@ -142,8 +153,7 @@ describe('magic-link routes', () => {
         expect(res.status).toBe(200)
         expect(res.body).toEqual({ status: 'ok' })
 
-        if (typeof orig === 'undefined') delete process.env.MCP_API_KEY
-        else process.env.MCP_API_KEY = orig
+        config.security.mcpApiKey = origKey2
     })
 
     it('POST /api/auth/register without password fails with 400', async () => {
@@ -161,9 +171,9 @@ describe('magic-link routes', () => {
         app.use(express.json())
         RegisterRoutes(app)
 
-        // Set required env vars
-        process.env.SUPABASE_SECRET_KEY = 'test-secret-key'
-        process.env.PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
+        // Set required config values
+        config.auth.supabaseServiceRoleKey = 'test-secret-key'
+        config.auth.supabaseIss = 'https://test.supabase.co'
 
         // Mock Supabase API
         global.fetch = vi.fn().mockResolvedValue({
@@ -209,9 +219,9 @@ describe('magic-link routes', () => {
         app.use(express.json())
         RegisterRoutes(app)
 
-        // Set required env vars
-        process.env.SUPABASE_SECRET_KEY = 'test-secret-key'
-        process.env.PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
+        // Set required config values
+        config.auth.supabaseServiceRoleKey = 'test-secret-key'
+        config.auth.supabaseIss = 'https://test.supabase.co'
 
         // Mock Supabase API
         global.fetch = vi.fn().mockResolvedValue({
@@ -233,9 +243,9 @@ describe('magic-link routes', () => {
         app.use(express.json())
         RegisterRoutes(app)
 
-        // Set required env vars
-        process.env.SUPABASE_SECRET_KEY = 'test-secret-key'
-        process.env.PUBLIC_SUPABASE_URL = 'https://test.supabase.co'
+        // Set required config values
+        config.auth.supabaseServiceRoleKey = 'test-secret-key'
+        config.auth.supabaseIss = 'https://test.supabase.co'
 
         // Mock Supabase API failure
         global.fetch = vi.fn().mockResolvedValue({

--- a/test/http/mcp-auth.test.ts
+++ b/test/http/mcp-auth.test.ts
@@ -3,6 +3,7 @@ import request from 'supertest'
 import express from 'express'
 import { registerDbDependentRoutes } from '../../src/http/server.js'
 import { mcpAuthFailuresTotal } from '../../src/http/metrics-route.js'
+import { config } from '../../src/config.js'
 
 function getCounterValue(counter: any) {
     try {
@@ -20,16 +21,15 @@ function getCounterValue(counter: any) {
 }
 
 describe('MCP auth middleware', () => {
-    const origMcp = process.env.MCP_API_KEY
+    const origMcpApiKey = config.security.mcpApiKey
 
     beforeEach(() => {
-        // Ensure clean state
-        delete process.env.MCP_API_KEY
+        // Ensure clean state — config is the source of truth now
+        config.security.mcpApiKey = undefined
     })
 
     afterEach(() => {
-        if (typeof origMcp === 'undefined') delete process.env.MCP_API_KEY
-        else process.env.MCP_API_KEY = origMcp
+        config.security.mcpApiKey = origMcpApiKey
     })
 
     it('does not enforce auth when MCP_API_KEY unset', async () => {
@@ -41,7 +41,7 @@ describe('MCP auth middleware', () => {
     })
 
     it('returns 401 for GET /api/books when MCP_API_KEY set and no Authorization', async () => {
-        process.env.MCP_API_KEY = 'testkey'
+        config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
         await registerDbDependentRoutes(app)
@@ -52,7 +52,7 @@ describe('MCP auth middleware', () => {
     })
 
     it('accepts Authorization: Bearer <key>', async () => {
-        process.env.MCP_API_KEY = 'testkey'
+        config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
         await registerDbDependentRoutes(app)
@@ -62,7 +62,7 @@ describe('MCP auth middleware', () => {
     })
 
     it('accepts x-mcp-api-key with deprecation warning', async () => {
-        process.env.MCP_API_KEY = 'testkey'
+        config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
 
@@ -80,7 +80,7 @@ describe('MCP auth middleware', () => {
     })
 
     it('increments metric on auth failure', async () => {
-        process.env.MCP_API_KEY = 'testkey'
+        config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
 

--- a/test/http/mcp-http.test.ts
+++ b/test/http/mcp-http.test.ts
@@ -2,14 +2,15 @@ import { describe, it, expect } from 'vitest'
 import request from 'supertest'
 import express from 'express'
 import { registerMcpHttp } from '../../src/http/mcp-http.js'
+import { config } from '../../src/config.js'
 
 describe('MCP HTTP endpoints', () => {
-    const origMcp = process.env.MCP_API_KEY
-    beforeEach(() => { /* ensure clean state per-test */ })
-    afterEach(() => { if (typeof origMcp === 'undefined') delete process.env.MCP_API_KEY; else process.env.MCP_API_KEY = origMcp })
+    const origMcpApiKey = config.security.mcpApiKey
+    beforeEach(() => { config.security.mcpApiKey = undefined })
+    afterEach(() => { config.security.mcpApiKey = origMcpApiKey })
 
     it('should reject POST /mcp without auth when MCP_API_KEY set', async () => {
-        process.env.MCP_API_KEY = 'testkey'
+        config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
         registerMcpHttp(app)
@@ -20,7 +21,7 @@ describe('MCP HTTP endpoints', () => {
     })
 
     it('should accept GET /mcp for SSE with correct auth', async () => {
-        process.env.MCP_API_KEY = 'testkey'
+        config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
         registerMcpHttp(app)
@@ -61,7 +62,7 @@ describe('MCP HTTP endpoints', () => {
     })
 
     it('should require auth for POST /mcp/events and validate conn id', async () => {
-        process.env.MCP_API_KEY = 'testkey'
+        config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
         registerMcpHttp(app)

--- a/test/http/password-route.test.ts
+++ b/test/http/password-route.test.ts
@@ -3,16 +3,17 @@ import express from 'express'
 import request from 'supertest'
 
 import { RegisterRoutes } from '../../src/http/tsoa-routes.js'
+import { config } from '../../src/config.js'
 
 describe('password routes', () => {
-    const origUrl = process.env.PUBLIC_SUPABASE_URL
-    const origKey = process.env.SUPABASE_SECRET_KEY
+    const origIss = config.auth.supabaseIss
+    const origSvcKey = config.auth.supabaseServiceRoleKey
+    const origAnonKey = config.auth.supabaseAnonKey
 
     afterEach(() => {
-        if (typeof origUrl === 'undefined') delete process.env.PUBLIC_SUPABASE_URL
-        else process.env.PUBLIC_SUPABASE_URL = origUrl
-        if (typeof origKey === 'undefined') delete process.env.SUPABASE_SECRET_KEY
-        else process.env.SUPABASE_SECRET_KEY = origKey
+        config.auth.supabaseIss = origIss
+        config.auth.supabaseServiceRoleKey = origSvcKey
+        config.auth.supabaseAnonKey = origAnonKey
         vi.restoreAllMocks()
     })
 
@@ -35,8 +36,8 @@ describe('password routes', () => {
     })
 
     it('POST /api/auth/password/reset-request calls Supabase recover and returns 200', async () => {
-        process.env.PUBLIC_SUPABASE_URL = 'https://supabase.example'
-        process.env.SUPABASE_SECRET_KEY = 'srk'
+        config.auth.supabaseIss = 'https://supabase.example'
+        config.auth.supabaseServiceRoleKey = 'srk'
 
         vi.stubGlobal('fetch', async (url: string, _opts?: any) => {
             expect(url).toMatch(/supabase.example\/auth\/v1\/recover$/)
@@ -74,8 +75,8 @@ describe('password routes', () => {
     })
 
     it('POST /api/auth/password/login returns 401 on invalid credentials', async () => {
-        process.env.PUBLIC_SUPABASE_URL = 'https://supabase.example'
-        process.env.SUPABASE_SECRET_KEY = 'srk'
+        config.auth.supabaseIss = 'https://supabase.example'
+        config.auth.supabaseServiceRoleKey = 'srk'
 
         vi.stubGlobal('fetch', async (url: string, _opts?: any) => {
             expect(url).toMatch(/supabase.example\/auth\/v1\/token\?grant_type=password$/)
@@ -92,8 +93,8 @@ describe('password routes', () => {
     })
 
     it('POST /api/auth/password/login sets session cookie on success', async () => {
-        process.env.PUBLIC_SUPABASE_URL = 'https://supabase.example'
-        process.env.SUPABASE_SECRET_KEY = 'srk'
+        config.auth.supabaseIss = 'https://supabase.example'
+        config.auth.supabaseServiceRoleKey = 'srk'
 
         vi.stubGlobal('fetch', async (url: string, _opts?: any) => {
             expect(url).toMatch(/supabase.example\/auth\/v1\/token\?grant_type=password$/)
@@ -111,12 +112,9 @@ describe('password routes', () => {
     })
 
     it('POST /api/auth/password/login returns 400 when SUPABASE not configured', async () => {
-        delete process.env.PUBLIC_SUPABASE_URL
-        delete process.env.SUPABASE_SECRET_KEY
-        delete process.env.SUPABASE_ISS
-        delete process.env.SUPABASE_ANON_KEY
-        delete process.env.PUBLIC_SUPABASE_PUBLISHABLE_KEY
-        delete process.env.SUPABASE_SERVICE_ROLE_KEY
+        config.auth.supabaseIss = undefined
+        config.auth.supabaseServiceRoleKey = undefined
+        config.auth.supabaseAnonKey = undefined
 
         const app = express()
         app.use(express.json())

--- a/test/http/session-route.test.ts
+++ b/test/http/session-route.test.ts
@@ -3,12 +3,13 @@ import { startHttpServer } from '../../src/http/server.js'
 import { prisma } from '../../src/db/index.js'
 import { SignJWT } from 'jose'
 import { testConnection } from '../../src/db/index.js'
+import { config } from '../../src/config.js'
 
 let server: any
 
 
 function signToken(payload: any, opts?: { expiresIn?: string }) {
-    const secret = process.env.SESSION_JWT_SECRET || 'test-secret'
+    const secret = config.auth.sessionJwtSecret || 'test-secret'
     const encoder = new TextEncoder().encode(secret)
     const jwt = new SignJWT(payload).setProtectedHeader({ alg: 'HS256' }).setIssuedAt()
     if (opts?.expiresIn) jwt.setExpirationTime(opts.expiresIn)
@@ -55,9 +56,13 @@ if (!shouldRunDbTests) {
     })
 } else {
     describe('GET /api/auth/session', () => {
-        const origMcp = process.env.MCP_API_KEY
-        beforeEach(() => { delete process.env.MCP_API_KEY })
-        afterEach(() => { if (typeof origMcp === 'undefined') delete process.env.MCP_API_KEY; else process.env.MCP_API_KEY = origMcp })
+        const origMcpApiKey = config.security.mcpApiKey
+        const origSessionSecret = config.auth.sessionJwtSecret
+        beforeEach(() => { config.security.mcpApiKey = undefined })
+        afterEach(() => {
+            config.security.mcpApiKey = origMcpApiKey
+            config.auth.sessionJwtSecret = origSessionSecret
+        })
 
         beforeAll(async () => {
             // Start server and attempt to use the real DB. If testConnection fails
@@ -115,7 +120,8 @@ if (!shouldRunDbTests) {
             // create user
             const user = await prisma.profile.create({ data: { id: `u1-${Date.now()}`, email: `u1+${Date.now()}@example.com` } })
 
-            process.env.SESSION_JWT_SECRET = process.env.SESSION_JWT_SECRET ?? 'test-secret'
+            config.auth.sessionJwtSecret = config.auth.sessionJwtSecret ?? 'test-secret'
+            process.env.SESSION_JWT_SECRET = config.auth.sessionJwtSecret
             const token = await signToken({ sub: user.email, userId: user.id }, { expiresIn: '7d' })
 
             const res = await request(server).get('/api/auth/session').set('Cookie', `session=${token}`)
@@ -124,6 +130,7 @@ if (!shouldRunDbTests) {
         })
 
         it('returns user info for dev unsigned token (base64)', async () => {
+            config.auth.sessionJwtSecret = undefined
             delete process.env.SESSION_JWT_SECRET
             const user = await prisma.profile.create({ data: { id: `u2-${Date.now()}`, email: `u2+${Date.now()}@example.com` } })
             const token = Buffer.from(JSON.stringify({ sub: user.email, userId: user.id })).toString('base64')
@@ -133,16 +140,18 @@ if (!shouldRunDbTests) {
         })
 
         it('returns 401 for invalid token', async () => {
+            config.auth.sessionJwtSecret = 'another-secret'
             process.env.SESSION_JWT_SECRET = 'another-secret'
             const res = await request(server).get('/api/auth/session').set('Cookie', `session=not-a-token`)
             expect(res.status).toBe(401)
         })
 
         it('returns 401 for expired token', async () => {
-            process.env.SESSION_JWT_SECRET = process.env.SESSION_JWT_SECRET ?? 'test-secret'
+            config.auth.sessionJwtSecret = config.auth.sessionJwtSecret ?? 'test-secret'
+            process.env.SESSION_JWT_SECRET = config.auth.sessionJwtSecret
             const user = await prisma.profile.create({ data: { id: `u3-${Date.now()}`, email: `u3+${Date.now()}@example.com` } })
             // sign an already-expired token
-            const secret = process.env.SESSION_JWT_SECRET
+            const secret = config.auth.sessionJwtSecret
             const encoder = new TextEncoder().encode(secret)
             const token = await new SignJWT({ sub: user.email, userId: user.id }).setProtectedHeader({ alg: 'HS256' }).setIssuedAt().setExpirationTime(Math.floor(Date.now() / 1000) - 10).sign(encoder as any)
             const res = await request(server).get('/api/auth/session').set('Cookie', `session=${token}`)
@@ -152,6 +161,7 @@ if (!shouldRunDbTests) {
         it('rate limits per IP', async () => {
             // Set a low limit for test
             process.env.SESSION_RATE_LIMIT_PER_IP = '2'
+            config.auth.sessionJwtSecret = undefined
             delete process.env.SESSION_JWT_SECRET
             const user = await prisma.profile.create({ data: { id: `rls-${Date.now()}`, email: `rls+${Date.now()}@example.com` } })
             const token = Buffer.from(JSON.stringify({ sub: user.email, userId: user.id })).toString('base64')

--- a/test/http/spotify-adapter-autostart.test.ts
+++ b/test/http/spotify-adapter-autostart.test.ts
@@ -8,26 +8,27 @@ vi.mock('../../src/adapters/spotify/spotify-adapter', () => ({
 }))
 
 import { registerDbDependentRoutes } from '../../src/http/server.js'
+import { config } from '../../src/config.js'
 
 describe('Spotify adapter auto-start', () => {
-    const origClientId = process.env.SPOTIFY_CLIENT_ID
-    const origClientSecret = process.env.SPOTIFY_CLIENT_SECRET
-    const origRefresh = process.env.SPOTIFY_REFRESH_TOKEN
+    const origEnabled = config.spotify.enabled
+    const origClientId = config.spotify.clientId
+    const origClientSecret = config.spotify.clientSecret
+    const origRefresh = config.spotify.refreshToken
 
     beforeEach(() => {
         vi.resetAllMocks()
-        delete process.env.SPOTIFY_CLIENT_ID
-        delete process.env.SPOTIFY_CLIENT_SECRET
-        delete process.env.SPOTIFY_REFRESH_TOKEN
+        config.spotify.enabled = false
+        config.spotify.clientId = undefined
+        config.spotify.clientSecret = undefined
+        config.spotify.refreshToken = undefined
     })
 
     afterEach(() => {
-        if (typeof origClientId === 'undefined') delete process.env.SPOTIFY_CLIENT_ID
-        else process.env.SPOTIFY_CLIENT_ID = origClientId
-        if (typeof origClientSecret === 'undefined') delete process.env.SPOTIFY_CLIENT_SECRET
-        else process.env.SPOTIFY_CLIENT_SECRET = origClientSecret
-        if (typeof origRefresh === 'undefined') delete process.env.SPOTIFY_REFRESH_TOKEN
-        else process.env.SPOTIFY_REFRESH_TOKEN = origRefresh
+        config.spotify.enabled = origEnabled
+        config.spotify.clientId = origClientId
+        config.spotify.clientSecret = origClientSecret
+        config.spotify.refreshToken = origRefresh
     })
 
     it('does not attempt to auto-start when SPOTIFY env missing', async () => {
@@ -38,9 +39,10 @@ describe('Spotify adapter auto-start', () => {
     })
 
     it('requests adapter auto-start when SPOTIFY envs are present', async () => {
-        process.env.SPOTIFY_CLIENT_ID = 'x'
-        process.env.SPOTIFY_CLIENT_SECRET = 'y'
-        process.env.SPOTIFY_REFRESH_TOKEN = 'z'
+        config.spotify.enabled = true
+        config.spotify.clientId = 'x'
+        config.spotify.clientSecret = 'y'
+        config.spotify.refreshToken = 'z'
 
         const app = express()
         app.use(express.json())


### PR DESCRIPTION
## Summary

Implements issue #78 — centralizes all environment variable reads into a single validated module.

## Changes

### New: \src/config.ts\
- Single source of truth for all 35+ env vars
- Zod schema with \process.exit(1)\ on startup validation failure
- Alias normalization (\SUPABASE_SECRET_KEY\ → \supabaseServiceRoleKey\, \FROM_EMAIL\ → \senderEmail\, etc.)
- Derived values (\supabaseJwksUrl\, \supabaseIss\, \spotifyEnabled\)
- Custom helpers: \csvArray\, \oolFlag\, \posInt(default)\

### Migrated: 17 source files
All \process.env.X\ reads replaced with \config.*\. Only intentional exception: runtime write \process.env.SPOTIFY_REFRESH_TOKEN = refreshToken\ in SpotifyAdminController (seeds token in-process after OAuth callback; config reflects startup value only).

### Updated: 7 test files
Tests previously manipulated \process.env\ mid-run; updated to mutate \config.*\ properties directly (then restore in afterEach/afterAll).

### New: \	est/config/config.test.ts\
20 tests covering structure, defaults, CSV array parsing, boolean flags, alias normalization, positive integer coercion.

### Updated: \.env.example\
Complete variable reference with all supported env vars grouped by domain.

## Test Results
- 49 files pass, 6 skipped (was 48/6 before — added config test file)
- 204 tests pass, 5 skipped (was 182/5)
- \
pm run typecheck\ clean

Closes #78