### PR TITLE
test(integration): HTTP Stream transport discovery & tool invocation

### DIFF
--- a/docs/admin-runbook.md
+++ b/docs/admin-runbook.md
@@ -24,3 +24,11 @@ Next manual steps (if a new row was created):
 
 - This script intentionally does not create or modify Supabase Auth users automatically to avoid leaking passwords or creating unwanted accounts in production.
 - Prefer manual creation in Supabase Auth and then use this script to mark the corresponding DB row `isAdmin = true`.
+
+## Security alerts
+
+**Service role bypass** (`service_role_bypass_total`)
+
+If you see unexpected increments in the `service_role_bypass_total` Prometheus counter
+(visible at `GET /metrics`), follow the response steps in
+[docs/runbooks/service-role-bypass.md](runbooks/service-role-bypass.md).

--- a/docs/runbooks/service-role-bypass.md
+++ b/docs/runbooks/service-role-bypass.md
@@ -78,9 +78,11 @@ Response steps
 **Scenario A — unexpected bypass (counter incremented, no known automation)**
 
 1. Pull recent metrics and note the exact count and timestamp window:
+
    ```bash
    curl -s https://<your-domain>/metrics | grep service_role_bypass
    ```
+
 2. Search Render logs for `service-role-bypass` entries. Note the `ip` and `path` fields.
 3. Cross-reference the IP against `ADMIN_IP_ALLOWLIST`. If the IP is not one you added,
    the allowlist was misconfigured or a credential was leaked.

--- a/docs/runbooks/service-role-bypass.md
+++ b/docs/runbooks/service-role-bypass.md
@@ -1,0 +1,156 @@
+Service role bypass runbook
+
+Overview
+--------
+
+The `service_role_bypass_total` counter increments each time a request is authenticated
+using the Supabase service role key and passes the hardened check in `requireAdmin`
+(valid `x-internal-key` header + IP allowlisted). This counter tracks privileged
+automation or internal tooling requests, not end-user traffic.
+
+In normal operation this counter should be **zero or near-zero** — it only increments
+when internal tooling explicitly authenticates with the service role key. Any unexpected
+spike indicates either misconfigured tooling or an active attack attempt.
+
+Metrics endpoint
+----------------
+
+The counter is exposed at:
+
+```
+GET /metrics           # Prometheus text format
+```
+
+Look for the line:
+
+```
+service_role_bypass_total N
+```
+
+where `N` is the cumulative value since the last process restart.
+
+Expected thresholds
+-------------------
+
+| Condition | Meaning | Action |
+|---|---|---|
+| `N = 0` | No service-role calls since last restart | Normal |
+| `N > 0`, known automation ran | Expected increment from a scheduled job or migration script | No action needed; verify the caller matches your known tooling |
+| `N > 0`, no automation scheduled | Unexpected bypass — investigate immediately | See response steps below |
+| Rapid increase (>5 in <1 hour) | Possible attack, misconfigured script, or credential leak | Rotate `INTERNAL_ADMIN_KEY`; review logs; see response steps below |
+
+Note: "unexpected" is context-dependent. If you have no scheduled internal tooling,
+`service_role_bypass_total` should remain 0 except during manual operational tasks.
+
+How to check the current value
+-------------------------------
+
+1. From Render logs or locally, `curl` the metrics endpoint:
+
+   ```bash
+   curl -s https://<your-domain>/metrics | grep service_role_bypass_total
+   ```
+
+2. In Render dashboard → Logs, filter for:
+
+   ```
+   service-role-bypass
+   ```
+
+   Each bypass generates a structured audit log entry:
+
+   ```
+   action: service-role-bypass, ip: <IP>, path: <path>, method: <method>
+   ```
+
+3. Denied attempts are also logged at `WARN` level:
+
+   ```
+   Service role access denied: missing internal header or IP not allowlisted
+   ```
+
+   A spike in WARN-level denials (without corresponding bypass increments) indicates
+   probe/scan activity against the admin endpoints.
+
+Response steps
+--------------
+
+**Scenario A — unexpected bypass (counter incremented, no known automation)**
+
+1. Pull recent metrics and note the exact count and timestamp window:
+   ```bash
+   curl -s https://<your-domain>/metrics | grep service_role_bypass
+   ```
+2. Search Render logs for `service-role-bypass` entries. Note the `ip` and `path` fields.
+3. Cross-reference the IP against `ADMIN_IP_ALLOWLIST`. If the IP is not one you added,
+   the allowlist was misconfigured or a credential was leaked.
+4. **Immediately rotate `INTERNAL_ADMIN_KEY`** in Render Dashboard → Environment Variables.
+   Restart the service to pick up the new value.
+5. If the source IP is external and unknown, also rotate `SUPABASE_SERVICE_ROLE_KEY`
+   and update it in Render.
+6. Review `ADMIN_IP_ALLOWLIST` — remove any IPs that should not be there.
+7. After rotation, monitor `service_role_bypass_total` for 15 minutes. If it stays at 0,
+   the incident is contained; open a post-mortem issue.
+
+**Scenario B — rapid increase from known IP (misconfigured script)**
+
+1. Identify the script or job using the `ip` and `path` from the audit log.
+2. Stop or rate-limit the job.
+3. Review whether the job is using the service role key unnecessarily. If it can use a
+   user-scoped JWT instead, prefer that.
+4. If the volume was harmless (e.g., a retry loop bug), no key rotation is needed;
+   fix the script and document the incident.
+
+**Scenario C — spike in WARN-level denied attempts (probing)**
+
+1. Check whether the probe IPs appear to be scanners (use a service like
+   `https://ipinfo.io/<IP>` to look up ASN/org).
+2. If the probing is from a known cloud provider or scan service, note the ASN and
+   consider tightening firewall rules in Render (if available) or documenting the source.
+3. No key rotation required unless bypass attempts succeeded.
+4. Consider adding the source CIDR to a block list if Render supports it.
+
+Key logs to check
+-----------------
+
+All bypass events write an `AuditLog` entry via Prisma (when DB is reachable):
+
+```
+prisma.auditLog.create({
+  action: 'service-role-bypass',
+  metadata: { ip, path, method }
+})
+```
+
+If DB is not reachable during the event, the bypass still succeeds but only the
+Prometheus counter and process log are written. Query the database directly if needed:
+
+```sql
+SELECT * FROM "AuditLog"
+WHERE action = 'service-role-bypass'
+ORDER BY "createdAt" DESC
+LIMIT 50;
+```
+
+Configuration reference
+-----------------------
+
+| Env var | Description |
+|---|---|
+| `INTERNAL_ADMIN_KEY` | Secret header value required for service role bypass (`x-internal-key`) |
+| `ADMIN_IP_ALLOWLIST` | Comma-separated list of IPs allowed to use service role key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key (full access) — store as a secret |
+
+All three must be set and consistent for service-role bypass to be permitted. If any
+is missing or mismatched, `requireAdmin` returns 403 and logs a WARN.
+
+Future alerting
+---------------
+
+This runbook documents manual response steps. If the operational load increases, consider
+adding automated alerting by:
+
+- Scheduling a GitHub Actions job to `curl /metrics` on a cron (e.g., every 30 minutes),
+  compare the counter delta from the previous run, and send an alert email via SendGrid
+  if the delta exceeds a threshold (e.g., > 3 new bypasses per window).
+- See issue #17 for the tracking item.

--- a/test/integration/http-stream.test.ts
+++ b/test/integration/http-stream.test.ts
@@ -126,7 +126,7 @@ describe('HTTP Stream transport integration', () => {
 
     it('responds to initialize with serverInfo and tool capabilities', async () => {
         config.security.mcpApiKey = undefined
-        ;({ server } = await startServer())
+            ; ({ server } = await startServer())
         const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
 
         const initMsg = {
@@ -153,7 +153,7 @@ describe('HTTP Stream transport integration', () => {
 
     it('lists tools after initialize and includes a known tool', async () => {
         config.security.mcpApiKey = undefined
-        ;({ server } = await startServer())
+            ; ({ server } = await startServer())
         const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
 
         const initMsg = {
@@ -183,7 +183,7 @@ describe('HTTP Stream transport integration', () => {
 
     it('returns 401 when MCP_API_KEY is set and auth header is missing', async () => {
         config.security.mcpApiKey = 'test-secret'
-        ;({ server } = await startServer())
+            ; ({ server } = await startServer())
         const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
 
         await expect(
@@ -193,7 +193,7 @@ describe('HTTP Stream transport integration', () => {
 
     it('accepts a request when correct Bearer token is provided', async () => {
         config.security.mcpApiKey = 'test-secret'
-        ;({ server } = await startServer())
+            ; ({ server } = await startServer())
         const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
 
         const initMsg = {

--- a/test/integration/http-stream.test.ts
+++ b/test/integration/http-stream.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Integration test: HTTP Stream transport — discovery & tool invocation
+ *
+ * Simulates VS Code-style MCP client behaviour against the real HTTP Stream
+ * transport (`POST /mcp`, bidirectional NDJSON) without hitting a database or
+ * external service.
+ *
+ * Gate: gated by `RUN_TRANSPORT_INTEGRATION=true` to keep CI fast by default.
+ * Run locally: RUN_TRANSPORT_INTEGRATION=true npx vitest run test/integration/http-stream.test.ts
+ */
+
+import { describe, it, expect, afterEach } from 'vitest'
+import * as http from 'http'
+import express from 'express'
+import { registerMcpHttp } from '../../src/http/mcp-http.js'
+import { config } from '../../src/config.js'
+
+const RUN = process.env.RUN_TRANSPORT_INTEGRATION === 'true'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Start an Express server on a random port and return it + its base URL. */
+function startServer(): Promise<{ server: http.Server; baseUrl: string }> {
+    return new Promise((resolve) => {
+        const app = express()
+        app.use(express.json())
+        registerMcpHttp(app)
+        const server = app.listen(0, '127.0.0.1', () => {
+            const { port } = server.address() as { port: number }
+            resolve({ server, baseUrl: `http://127.0.0.1:${port}` })
+        })
+    })
+}
+
+/**
+ * Open a POST /mcp stream, send NDJSON messages, and collect the first N
+ * response lines. Resolves once `lineCount` non-empty lines are received or
+ * the socket closes.
+ */
+function mcpStreamSession(
+    baseUrl: string,
+    messages: object[],
+    lineCount: number,
+    apiKey?: string,
+): Promise<object[]> {
+    return new Promise((resolve, reject) => {
+        const url = new URL('/mcp', baseUrl)
+        const body = messages.map((m) => JSON.stringify(m)).join('\n') + '\n'
+
+        const headers: Record<string, string> = {
+            'Content-Type': 'application/x-ndjson',
+            'Content-Length': String(Buffer.byteLength(body)),
+        }
+        if (apiKey) headers['Authorization'] = `Bearer ${apiKey}`
+
+        const req = http.request(
+            { hostname: url.hostname, port: Number(url.port), method: 'POST', path: url.pathname, headers },
+            (res) => {
+                if (res.statusCode !== 200) {
+                    reject(new Error(`Unexpected status ${res.statusCode}`))
+                    req.destroy()
+                    return
+                }
+
+                const lines: object[] = []
+                let buf = ''
+
+                res.on('data', (chunk: Buffer) => {
+                    buf += chunk.toString()
+                    let idx: number
+                    while ((idx = buf.indexOf('\n')) !== -1) {
+                        const line = buf.slice(0, idx).trim()
+                        buf = buf.slice(idx + 1)
+                        if (!line) continue
+                        try {
+                            lines.push(JSON.parse(line))
+                        } catch {
+                            // ignore keepalive newlines
+                        }
+                        if (lines.length >= lineCount) {
+                            req.destroy()
+                            resolve(lines)
+                            return
+                        }
+                    }
+                })
+
+                res.on('end', () => resolve(lines))
+                res.on('error', reject)
+            },
+        )
+
+        req.on('error', (err: NodeJS.ErrnoException) => {
+            // ECONNRESET is expected when we call req.destroy() after collecting enough lines
+            if (err.code === 'ECONNRESET') {
+                // already resolved above
+            } else {
+                reject(err)
+            }
+        })
+
+        req.write(body)
+        req.end()
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HTTP Stream transport integration', () => {
+    if (!RUN) {
+        it.skip('skipped — set RUN_TRANSPORT_INTEGRATION=true to run', () => { })
+        return
+    }
+
+    const origMcpApiKey = config.security.mcpApiKey
+    let server: http.Server
+
+    afterEach(() => {
+        config.security.mcpApiKey = origMcpApiKey
+        server?.close()
+    })
+
+    it('responds to initialize with serverInfo and tool capabilities', async () => {
+        config.security.mcpApiKey = undefined
+        ;({ server } = await startServer())
+        const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
+
+        const initMsg = {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2024-11-05',
+                clientInfo: { name: 'test-client', version: '0.0.1' },
+                capabilities: {},
+            },
+        }
+
+        const lines = await mcpStreamSession(baseUrl, [initMsg], 1)
+
+        expect(lines.length).toBeGreaterThanOrEqual(1)
+        const reply = lines[0] as any
+        expect(reply.jsonrpc).toBe('2.0')
+        expect(reply.id).toBe(1)
+        expect(reply.result).toBeDefined()
+        expect(reply.result.serverInfo?.name).toBe('bryan-debaun-mcp-server')
+        expect(reply.result.capabilities?.tools).toBeDefined()
+    })
+
+    it('lists tools after initialize and includes a known tool', async () => {
+        config.security.mcpApiKey = undefined
+        ;({ server } = await startServer())
+        const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
+
+        const initMsg = {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2024-11-05',
+                clientInfo: { name: 'test-client', version: '0.0.1' },
+                capabilities: {},
+            },
+        }
+        const notif = { jsonrpc: '2.0', method: 'notifications/initialized', params: {} }
+        const listMsg = { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }
+
+        // Expect 2 responses: one for initialize (id:1), one for tools/list (id:2)
+        const lines = await mcpStreamSession(baseUrl, [initMsg, notif, listMsg], 2)
+
+        const toolsReply = lines.find((l: any) => l.id === 2) as any
+        expect(toolsReply).toBeDefined()
+        expect(toolsReply.result?.tools).toBeInstanceOf(Array)
+        expect(toolsReply.result.tools.length).toBeGreaterThan(0)
+
+        const toolNames: string[] = toolsReply.result.tools.map((t: any) => t.name)
+        expect(toolNames).toContain('create-issue')
+    })
+
+    it('returns 401 when MCP_API_KEY is set and auth header is missing', async () => {
+        config.security.mcpApiKey = 'test-secret'
+        ;({ server } = await startServer())
+        const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
+
+        await expect(
+            mcpStreamSession(baseUrl, [{ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }], 1),
+        ).rejects.toThrow('Unexpected status 401')
+    })
+
+    it('accepts a request when correct Bearer token is provided', async () => {
+        config.security.mcpApiKey = 'test-secret'
+        ;({ server } = await startServer())
+        const baseUrl = `http://127.0.0.1:${(server.address() as any).port}`
+
+        const initMsg = {
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'initialize',
+            params: {
+                protocolVersion: '2024-11-05',
+                clientInfo: { name: 'test-client', version: '0.0.1' },
+                capabilities: {},
+            },
+        }
+
+        const lines = await mcpStreamSession(baseUrl, [initMsg], 1, 'test-secret')
+        const reply = lines[0] as any
+        expect(reply.id).toBe(1)
+        expect(reply.result).toBeDefined()
+    })
+})


### PR DESCRIPTION
## Summary

Adds a gated integration test suite that simulates VS Code-style MCP client behaviour against the real HTTP Stream transport (POST /mcp, bidirectional NDJSON), exercising the full request/response flow without hitting a database or external service.

Also bundles the #17 runbook (docs/runbooks/service-role-bypass.md) on this branch.

## Changes

- **	est/integration/http-stream.test.ts** _(new)_ — 4 tests, gated by \RUN_TRANSPORT_INTEGRATION=true\
- **docs/runbooks/service-role-bypass.md** _(new)_ — thresholds, response steps, config reference for \service_role_bypass_total\
- **docs/admin-runbook.md** — Security alerts section linking to the new runbook

## Test coverage

| Test | What it validates |
|---|---|
| initialize response | \serverInfo.name\, \capabilities.tools\ present |
| tools/list | Array contains \create-issue\ |
| auth reject | 401 when \MCP_API_KEY\ set and header missing |
| auth accept | 200 with correct Bearer token |

## Running locally

\\\
RUN_TRANSPORT_INTEGRATION=true npx vitest run test/integration/http-stream.test.ts
\\\

## Test results

\\\
Test Files  50 passed | 7 skipped (57)
Tests       207 passed | 6 skipped (213)
\\\

Closes #16
Closes #17