### PR TITLE
feat(github): migrate issue tools to Octokit REST, add 4 new tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,12 @@
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.0.0",
                 "@octokit/graphql": "^9.0.3",
+                "@octokit/rest": "^22.0.1",
                 "@prisma/adapter-pg": "^7.3.0",
                 "@prisma/client": "^7.3.0",
                 "@tsoa/runtime": "^7.0.0-alpha.0",
                 "cors": "^2.8.5",
+                "dotenv": "^17.3.1",
                 "express": "^4.18.2",
                 "jose": "^6.1.3",
                 "pg": "^8.11.3",
@@ -36,7 +38,6 @@
                 "@types/ws": "^8.18.1",
                 "@typescript-eslint/eslint-plugin": "^6.12.0",
                 "@typescript-eslint/parser": "^6.12.0",
-                "dotenv": "^17.3.1",
                 "eslint": "^8.48.0",
                 "prisma": "^7.3.0",
                 "supertest": "^6.3.3",
@@ -1651,6 +1652,34 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/@octokit/auth-token": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+            "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+            "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@octokit/auth-token": "^6.0.0",
+                "@octokit/graphql": "^9.0.3",
+                "@octokit/request": "^10.0.6",
+                "@octokit/request-error": "^7.0.2",
+                "@octokit/types": "^16.0.0",
+                "before-after-hook": "^4.0.0",
+                "universal-user-agent": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
         "node_modules/@octokit/endpoint": {
             "version": "11.0.3",
             "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
@@ -1684,6 +1713,48 @@
             "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
             "license": "MIT"
         },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+            "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/plugin-request-log": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
+            "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "17.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+            "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=6"
+            }
+        },
         "node_modules/@octokit/request": {
             "version": "10.0.7",
             "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.7.tgz",
@@ -1707,6 +1778,21 @@
             "license": "MIT",
             "dependencies": {
                 "@octokit/types": "^16.0.0"
+            },
+            "engines": {
+                "node": ">= 20"
+            }
+        },
+        "node_modules/@octokit/rest": {
+            "version": "22.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
+            "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+            "license": "MIT",
+            "dependencies": {
+                "@octokit/core": "^7.0.6",
+                "@octokit/plugin-paginate-rest": "^14.0.0",
+                "@octokit/plugin-request-log": "^6.0.0",
+                "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
             },
             "engines": {
                 "node": ">= 20"
@@ -3279,6 +3365,12 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "license": "MIT"
         },
+        "node_modules/before-after-hook": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+            "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+            "license": "Apache-2.0"
+        },
         "node_modules/bintrees": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bintrees/-/bintrees-1.0.2.tgz",
@@ -3896,7 +3988,6 @@
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
             "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
-            "dev": true,
             "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -42,10 +42,12 @@
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
         "@octokit/graphql": "^9.0.3",
+        "@octokit/rest": "^22.0.1",
         "@prisma/adapter-pg": "^7.3.0",
         "@prisma/client": "^7.3.0",
         "@tsoa/runtime": "^7.0.0-alpha.0",
         "cors": "^2.8.5",
+        "dotenv": "^17.3.1",
         "express": "^4.18.2",
         "jose": "^6.1.3",
         "pg": "^8.11.3",
@@ -53,8 +55,7 @@
         "swagger-ui-express": "^5.0.1",
         "tsoa": "^7.0.0-alpha.0",
         "ws": "^8.19.0",
-        "zod": "^3.23.0",
-        "dotenv": "^17.3.1"
+        "zod": "^3.23.0"
     },
     "devDependencies": {
         "@types/cors": "^2.8.19",

--- a/src/tools/github-issues/close-issue.ts
+++ b/src/tools/github-issues/close-issue.ts
@@ -1,16 +1,13 @@
-import fs from "fs";
-import os from "os";
-import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CloseIssueInputSchema } from "./schemas.js";
-import { runGhCommand } from "./gh-cli.js";
+import { createOctokitClient, parseRepo } from "./octokit.js";
 import { createSuccessResult, createErrorResult } from "./results.js";
 
 const name = "close-issue";
-const config = {
+const toolConfig = {
     title: "Close Issue",
-    description: "Close a GitHub issue with an optional comment (supports Markdown/file)",
+    description: "Close a GitHub issue with an optional comment (supports Markdown)",
     inputSchema: CloseIssueInputSchema
 };
 
@@ -20,10 +17,8 @@ const config = {
 export function registerCloseIssueTool(server: McpServer): void {
     (server as any).registerTool(
         name,
-        config,
+        toolConfig,
         async (args: any): Promise<CallToolResult> => {
-            let tempFile: string | undefined;
-
             try {
                 const { repo, issueNumber, comment } = args as {
                     repo: string;
@@ -31,52 +26,35 @@ export function registerCloseIssueTool(server: McpServer): void {
                     comment?: string;
                 };
 
+                const { owner, repo: repoName } = parseRepo(repo);
+                const octokit = createOctokitClient();
+
                 // Add comment first if provided
                 if (comment) {
-                    if (comment.includes("\n")) {
-                        tempFile = path.join(os.tmpdir(), `mcp-issue-comment-${Date.now()}.md`);
-                        fs.writeFileSync(tempFile, comment, "utf8");
-                        const commentArgs = [
-                            "issue", "comment",
-                            String(issueNumber),
-                            "--repo", repo,
-                            "--body-file", tempFile
-                        ];
-
-                        await runGhCommand(commentArgs);
-                    } else {
-                        const commentArgs = [
-                            "issue", "comment",
-                            String(issueNumber),
-                            "--repo", repo,
-                            "--body", `"${comment.replace(/"/g, '\\"')}"`
-                        ];
-
-                        await runGhCommand(commentArgs);
-                    }
+                    await octokit.rest.issues.createComment({
+                        owner,
+                        repo: repoName,
+                        issue_number: issueNumber,
+                        body: comment,
+                    });
                 }
 
                 // Close the issue
-                const closeArgs = [
-                    "issue", "close",
-                    String(issueNumber),
-                    "--repo", repo
-                ];
-
-                await runGhCommand(closeArgs);
+                await octokit.rest.issues.update({
+                    owner,
+                    repo: repoName,
+                    issue_number: issueNumber,
+                    state: "closed",
+                });
 
                 return createSuccessResult({
                     message: `Issue #${issueNumber} closed successfully`,
                     repository: repo,
-                    commentAdded: !!comment
+                    commentAdded: !!comment,
                 });
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
                 return createErrorResult(message);
-            } finally {
-                if (tempFile) {
-                    try { fs.unlinkSync(tempFile); } catch { /* ignore */ }
-                }
             }
         }
     );

--- a/src/tools/github-issues/create-issue.ts
+++ b/src/tools/github-issues/create-issue.ts
@@ -1,16 +1,14 @@
 import fs from "fs";
-import os from "os";
-import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateIssueInputSchema } from "./schemas.js";
-import { runGhCommand } from "./gh-cli.js";
+import { createOctokitClient, parseRepo } from "./octokit.js";
 import { createSuccessResult, createErrorResult } from "./results.js";
 import { jsonToMarkdown } from "./json-to-markdown.js";
 import { ensureLabelsExist } from "./label-helper.js";
 
 const name = "create-issue";
-const config = {
+const toolConfig = {
     title: "Create Issue",
     description: "Create a new GitHub issue with title, body (Markdown allowed), file, or JSON payload",
     inputSchema: CreateIssueInputSchema
@@ -22,71 +20,66 @@ const config = {
 export function registerCreateIssueTool(server: McpServer): void {
     (server as any).registerTool(
         name,
-        config,
+        toolConfig,
         async (args: any): Promise<CallToolResult> => {
-            let tempFile: string | undefined;
-
             try {
-                const { repo, title, body, bodyFile, bodyJson, labels } = args as {
+                const { repo, title, body, bodyFile, bodyJson, labels, assignees, milestone } = args as {
                     repo: string;
                     title: string;
                     body?: string;
                     bodyFile?: string;
                     bodyJson?: any;
                     labels?: string;
+                    assignees?: string;
+                    milestone?: number;
                 };
 
-                const ghArgs = [
-                    "issue", "create",
-                    "--repo", repo,
-                    "--title", `"${title.replace(/"/g, '\\"')}"`
-                ];
+                const { owner, repo: repoName } = parseRepo(repo);
+                const octokit = createOctokitClient();
 
-                // Ensure labels exist before attempting to assign them
-                if (labels) {
-                    const requested = labels.split(",").map(s => s.trim()).filter(Boolean);
-                    await ensureLabelsExist(repo, requested);
-                }
-
-                // Determine how to provide the body to gh: prefer file when multi-line, when
-                // `bodyFile` is provided, or when caller passed `bodyJson`.
+                // Resolve body content
+                let resolvedBody: string | undefined;
                 if (bodyFile) {
-                    ghArgs.push("--body-file", bodyFile);
+                    resolvedBody = fs.readFileSync(bodyFile, "utf8");
                 } else if (bodyJson !== undefined) {
-                    const md = jsonToMarkdown(bodyJson);
-                    tempFile = path.join(os.tmpdir(), `mcp-issue-body-${Date.now()}.md`);
-                    fs.writeFileSync(tempFile, md, "utf8");
-                    ghArgs.push("--body-file", tempFile);
-                } else if (body && body.includes("\n")) {
-                    tempFile = path.join(os.tmpdir(), `mcp-issue-body-${Date.now()}.md`);
-                    fs.writeFileSync(tempFile, body, "utf8");
-                    ghArgs.push("--body-file", tempFile);
-                } else if (body) {
-                    ghArgs.push("--body", `"${body.replace(/"/g, '\\"')}"`);
+                    resolvedBody = jsonToMarkdown(bodyJson);
+                } else {
+                    resolvedBody = body;
                 }
 
+                // Ensure labels exist before assigning
                 if (labels) {
-                    ghArgs.push("--label", labels);
+                    const requested = labels.split(",").map((s) => s.trim()).filter(Boolean);
+                    await ensureLabelsExist(octokit, owner, repoName, requested);
                 }
 
-                const output = await runGhCommand(ghArgs);
+                const labelList = labels
+                    ? labels.split(",").map((s) => s.trim()).filter(Boolean)
+                    : undefined;
+                const assigneeList = assignees
+                    ? assignees.split(",").map((s) => s.trim()).filter(Boolean)
+                    : undefined;
 
-                // gh issue create returns the URL of the created issue
-                const issueUrl = output.trim();
-                const issueNumber = issueUrl.split("/").pop();
+                const response = await octokit.rest.issues.create({
+                    owner,
+                    repo: repoName,
+                    title,
+                    body: resolvedBody,
+                    labels: labelList,
+                    assignees: assigneeList,
+                    milestone: milestone,
+                });
 
+                const issue = response.data;
                 return createSuccessResult({
-                    message: `Issue #${issueNumber} created successfully`,
-                    url: issueUrl,
-                    title: title
+                    message: `Issue #${issue.number} created successfully`,
+                    url: issue.html_url,
+                    number: issue.number,
+                    title: issue.title,
                 });
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
                 return createErrorResult(message);
-            } finally {
-                if (tempFile) {
-                    try { fs.unlinkSync(tempFile); } catch { /* ignore */ }
-                }
             }
         }
     );

--- a/src/tools/github-issues/get-issue.ts
+++ b/src/tools/github-issues/get-issue.ts
@@ -1,11 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { GetIssueInputSchema, type GitHubIssue } from "./schemas.js";
-import { runGhCommand, parseGhJson } from "./gh-cli.js";
+import { GetIssueInputSchema } from "./schemas.js";
+import { createOctokitClient, parseRepo } from "./octokit.js";
 import { createSuccessResult, createErrorResult } from "./results.js";
 
 const name = "get-issue";
-const config = {
+const toolConfig = {
     title: "Get Issue",
     description: "Get full details of a specific GitHub issue by number",
     inputSchema: GetIssueInputSchema
@@ -17,7 +17,7 @@ const config = {
 export function registerGetIssueTool(server: McpServer): void {
     (server as any).registerTool(
         name,
-        config,
+        toolConfig,
         async (args: any): Promise<CallToolResult> => {
             try {
                 const { repo, issueNumber } = args as {
@@ -25,27 +25,28 @@ export function registerGetIssueTool(server: McpServer): void {
                     issueNumber: number;
                 };
 
-                const ghArgs = [
-                    "issue", "view",
-                    String(issueNumber),
-                    "--repo", repo,
-                    "--json", "number,title,state,body,url,createdAt,updatedAt,author,labels,assignees"
-                ];
+                const { owner, repo: repoName } = parseRepo(repo);
+                const octokit = createOctokitClient();
 
-                const output = await runGhCommand(ghArgs);
-                const issue = parseGhJson<GitHubIssue>(output);
+                const response = await octokit.rest.issues.get({
+                    owner,
+                    repo: repoName,
+                    issue_number: issueNumber,
+                });
 
+                const issue = response.data;
                 return createSuccessResult({
                     number: issue.number,
                     title: issue.title,
                     state: issue.state,
-                    url: issue.url,
-                    author: issue.author.login,
-                    labels: issue.labels.map((l) => l.name),
-                    assignees: issue.assignees.map((a) => a.login),
-                    createdAt: issue.createdAt,
-                    updatedAt: issue.updatedAt,
-                    body: issue.body
+                    url: issue.html_url,
+                    author: issue.user?.login ?? "unknown",
+                    labels: issue.labels.map((l) => (typeof l === "string" ? l : l.name ?? "")),
+                    assignees: issue.assignees?.map((a) => a.login) ?? [],
+                    milestone: issue.milestone ? { number: issue.milestone.number, title: issue.milestone.title } : null,
+                    createdAt: issue.created_at,
+                    updatedAt: issue.updated_at,
+                    body: issue.body ?? "",
                 });
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/github-issues/get-open-issues.ts
+++ b/src/tools/github-issues/get-open-issues.ts
@@ -1,11 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { GetOpenIssuesInputSchema, type GitHubIssue } from "./schemas.js";
-import { runGhCommand, parseGhJson } from "./gh-cli.js";
+import { GetOpenIssuesInputSchema } from "./schemas.js";
+import { createOctokitClient, parseRepo } from "./octokit.js";
 import { createSuccessResult, createErrorResult } from "./results.js";
 
 const name = "get-open-issues";
-const config = {
+const toolConfig = {
     title: "Get Open Issues",
     description: "List open issues from a GitHub repository, optionally filtered by labels",
     inputSchema: GetOpenIssuesInputSchema
@@ -17,7 +17,7 @@ const config = {
 export function registerGetOpenIssuesTool(server: McpServer): void {
     (server as any).registerTool(
         name,
-        config,
+        toolConfig,
         async (args: any): Promise<CallToolResult> => {
             try {
                 const { repo, labels, limit } = args as {
@@ -26,39 +26,40 @@ export function registerGetOpenIssuesTool(server: McpServer): void {
                     limit: number;
                 };
 
-                const ghArgs = [
-                    "issue", "list",
-                    "--repo", repo,
-                    "--state", "open",
-                    "--limit", String(limit),
-                    "--json", "number,title,state,body,url,createdAt,updatedAt,author,labels,assignees"
-                ];
+                const { owner, repo: repoName } = parseRepo(repo);
+                const octokit = createOctokitClient();
 
-                if (labels) {
-                    ghArgs.push("--label", labels);
-                }
+                const labelList = labels
+                    ? labels.split(",").map((s) => s.trim()).filter(Boolean)
+                    : undefined;
 
-                const output = await runGhCommand(ghArgs);
-                const issues = parseGhJson<GitHubIssue[]>(output);
+                const response = await octokit.rest.issues.listForRepo({
+                    owner,
+                    repo: repoName,
+                    state: "open",
+                    labels: labelList?.join(","),
+                    per_page: Math.min(limit, 100),
+                });
+
+                const issues = response.data;
 
                 if (issues.length === 0) {
                     return createSuccessResult(`No open issues found in ${repo}`);
                 }
 
-                // Format issues for display
                 const formatted = issues.map((issue) => ({
                     number: issue.number,
                     title: issue.title,
-                    url: issue.url,
-                    author: issue.author.login,
-                    labels: issue.labels.map((l) => l.name),
-                    createdAt: issue.createdAt
+                    url: issue.html_url,
+                    author: issue.user?.login ?? "unknown",
+                    labels: issue.labels.map((l) => (typeof l === "string" ? l : l.name ?? "")),
+                    createdAt: issue.created_at,
                 }));
 
                 return createSuccessResult({
                     repository: repo,
                     count: issues.length,
-                    issues: formatted
+                    issues: formatted,
                 });
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);

--- a/src/tools/github-issues/index.ts
+++ b/src/tools/github-issues/index.ts
@@ -4,6 +4,7 @@ import { registerGetIssueTool } from "./get-issue.js";
 import { registerCreateIssueTool } from "./create-issue.js";
 import { registerUpdateIssueTool } from "./update-issue.js";
 import { registerCloseIssueTool } from "./close-issue.js";
+import { registerListLabelsTool } from "./list-labels.js";
 
 /**
  * Registers all GitHub Issues tools with the MCP server.
@@ -14,4 +15,5 @@ export function registerGitHubIssuesTools(server: McpServer): void {
     registerCreateIssueTool(server);
     registerUpdateIssueTool(server);
     registerCloseIssueTool(server);
+    registerListLabelsTool(server);
 }

--- a/src/tools/github-issues/label-helper.ts
+++ b/src/tools/github-issues/label-helper.ts
@@ -1,25 +1,22 @@
-import { runGhCommand, parseGhJson } from "./gh-cli.js";
+import type { Octokit } from "@octokit/rest";
 
 /**
  * Ensure the provided labels exist in the target repo. Creates any missing labels
  * with a sensible default color and returns when complete.
  */
-export async function ensureLabelsExist(repo: string, labels: string[]): Promise<void> {
+export async function ensureLabelsExist(
+    octokit: Octokit,
+    owner: string,
+    repo: string,
+    labels: string[]
+): Promise<void> {
     if (!labels || labels.length === 0) return;
 
-    // Get existing labels from the repo
-    const listOutput = await runGhCommand(["label", "list", "--repo", repo, "--json", "name"]);
-    let existing: string[] = [];
-    try {
-        const parsed = parseGhJson<{ name: string }[]>(listOutput || "[]");
-        existing = parsed.map(p => p.name);
-    } catch {
-        existing = [];
-    }
+    const response = await octokit.rest.issues.listLabelsForRepo({ owner, repo, per_page: 100 });
+    const existing = response.data.map((l) => l.name);
 
-    const missing = labels.map(l => l.trim()).filter(l => l && !existing.includes(l));
+    const missing = labels.map((l) => l.trim()).filter((l) => l && !existing.includes(l));
     for (const name of missing) {
-        // Create with a default yellow color (fbca04)
-        await runGhCommand(["label", "create", "--repo", repo, "--name", `"${name.replace(/"/g, '\\"')}"`, "--color", "fbca04"]);
+        await octokit.rest.issues.createLabel({ owner, repo, name, color: "fbca04" });
     }
 }

--- a/src/tools/github-issues/list-labels.ts
+++ b/src/tools/github-issues/list-labels.ts
@@ -1,0 +1,50 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ListLabelsInputSchema } from "./schemas.js";
+import { createOctokitClient, parseRepo } from "./octokit.js";
+import { createSuccessResult, createErrorResult } from "./results.js";
+
+const name = "list-labels";
+const toolConfig = {
+    title: "List Labels",
+    description: "List all labels defined in a GitHub repository, including their name, color, and description",
+    inputSchema: ListLabelsInputSchema
+};
+
+/**
+ * Registers the list-labels tool with the MCP server.
+ */
+export function registerListLabelsTool(server: McpServer): void {
+    (server as any).registerTool(
+        name,
+        toolConfig,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { repo } = args as { repo: string };
+                const { owner, repo: repoName } = parseRepo(repo);
+                const octokit = createOctokitClient();
+
+                const response = await octokit.rest.issues.listLabelsForRepo({
+                    owner,
+                    repo: repoName,
+                    per_page: 100,
+                });
+
+                const labels = response.data.map((l) => ({
+                    name: l.name,
+                    color: l.color,
+                    description: l.description ?? "",
+                }));
+
+                return createSuccessResult({
+                    repository: repo,
+                    count: labels.length,
+                    labels,
+                });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return createErrorResult(message);
+            }
+        }
+    );
+}

--- a/src/tools/github-issues/octokit.ts
+++ b/src/tools/github-issues/octokit.ts
@@ -1,0 +1,27 @@
+import { Octokit } from "@octokit/rest";
+import { config } from "../../config.js";
+
+/**
+ * Create an authenticated Octokit REST client using GITHUB_TOKEN from config.
+ * Throws if GITHUB_TOKEN is not configured — REST calls require explicit auth.
+ */
+export function createOctokitClient(): Octokit {
+    const token = config.github.token;
+    if (!token) {
+        throw new Error(
+            "GITHUB_TOKEN is not configured. Set GITHUB_TOKEN to enable GitHub issue tools."
+        );
+    }
+    return new Octokit({ auth: token });
+}
+
+/**
+ * Parse "owner/repo" string into separate owner and repo components.
+ */
+export function parseRepo(repo: string): { owner: string; repo: string } {
+    const [owner, repoName] = repo.split("/");
+    if (!owner || !repoName) {
+        throw new Error(`Invalid repo format: "${repo}". Expected "owner/repo".`);
+    }
+    return { owner, repo: repoName };
+}

--- a/src/tools/github-issues/schemas.ts
+++ b/src/tools/github-issues/schemas.ts
@@ -51,7 +51,9 @@ export const CreateIssueInputSchema = {
     body: z.string().optional().describe("Issue body/description (Markdown allowed)"),
     bodyFile: z.string().optional().describe("Path to a Markdown file to use as the issue body"),
     bodyJson: z.any().optional().describe("JSON payload to convert to Markdown for the issue body"),
-    labels: z.string().optional().describe("Comma-separated labels to add")
+    labels: z.string().optional().describe("Comma-separated labels to add"),
+    assignees: z.string().optional().describe("Comma-separated GitHub usernames to assign to the issue"),
+    milestone: z.number().int().positive().optional().describe("Milestone number to assign to the issue")
 };
 
 /**
@@ -64,7 +66,12 @@ export const UpdateIssueInputSchema = {
     body: z.string().optional().describe("New issue body (Markdown allowed)"),
     bodyFile: z.string().optional().describe("Path to a Markdown file to use as the issue body"),
     bodyJson: z.any().optional().describe("JSON payload to convert to Markdown for the issue body"),
-    labels: z.string().optional().describe("Comma-separated labels to set"),
+    labels: z.string().optional().describe("Comma-separated labels to add to the issue"),
+    removeLabels: z.string().optional().describe("Comma-separated labels to remove from the issue"),
+    assignees: z.string().optional().describe("Comma-separated GitHub usernames to assign to the issue"),
+    milestone: z.number().int().positive().optional().describe("Milestone number to assign (use 0 to clear)"),
+    state: z.enum(["open", "closed"]).optional().describe("Set issue state to open or closed"),
+    stateReason: z.enum(["completed", "not_planned", "reopened"]).optional().describe("Reason for closing: completed or not_planned (ignored when opening)"),
     comment: z.string().optional().describe("Comment to add to the issue")
 };
 
@@ -75,6 +82,13 @@ export const CloseIssueInputSchema = {
     repo: RepoSchema,
     issueNumber: IssueNumberSchema,
     comment: z.string().optional().describe("Comment to add before closing")
+};
+
+/**
+ * Schema for list-labels tool input.
+ */
+export const ListLabelsInputSchema = {
+    repo: RepoSchema
 };
 
 /**

--- a/src/tools/github-issues/update-issue.ts
+++ b/src/tools/github-issues/update-issue.ts
@@ -1,18 +1,16 @@
 import fs from "fs";
-import os from "os";
-import path from "path";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateIssueInputSchema } from "./schemas.js";
-import { runGhCommand } from "./gh-cli.js";
+import { createOctokitClient, parseRepo } from "./octokit.js";
 import { createSuccessResult, createErrorResult } from "./results.js";
 import { jsonToMarkdown } from "./json-to-markdown.js";
 import { ensureLabelsExist } from "./label-helper.js";
 
 const name = "update-issue";
-const config = {
+const toolConfig = {
     title: "Update Issue",
-    description: "Update a GitHub issue's title, body (Markdown allowed), labels, or add a comment",
+    description: "Update a GitHub issue's title, body, labels, assignees, milestone, state, or add a comment",
     inputSchema: UpdateIssueInputSchema
 };
 
@@ -22,12 +20,13 @@ const config = {
 export function registerUpdateIssueTool(server: McpServer): void {
     (server as any).registerTool(
         name,
-        config,
+        toolConfig,
         async (args: any): Promise<CallToolResult> => {
-            let tempFile: string | undefined;
-
             try {
-                const { repo, issueNumber, title, body, bodyFile, bodyJson, labels, comment } = args as {
+                const {
+                    repo, issueNumber, title, body, bodyFile, bodyJson,
+                    labels, removeLabels, assignees, milestone, state, stateReason, comment
+                } = args as {
                     repo: string;
                     issueNumber: number;
                     title?: string;
@@ -35,102 +34,96 @@ export function registerUpdateIssueTool(server: McpServer): void {
                     bodyFile?: string;
                     bodyJson?: any;
                     labels?: string;
+                    removeLabels?: string;
+                    assignees?: string;
+                    milestone?: number;
+                    state?: "open" | "closed";
+                    stateReason?: "completed" | "not_planned" | "reopened";
                     comment?: string;
                 };
 
+                const { owner, repo: repoName } = parseRepo(repo);
+                const octokit = createOctokitClient();
                 const updates: string[] = [];
 
-                // Update issue fields if provided
-                if (title || body || labels || bodyFile || bodyJson) {
-                    const editArgs = [
-                        "issue", "edit",
-                        String(issueNumber),
-                        "--repo", repo
-                    ];
-
-                    if (title) {
-                        editArgs.push("--title", `"${title.replace(/"/g, '\\"')}"`);
-                        updates.push("title");
-                    }
-
-                    // Ensure labels exist before assigning
-                    if (labels) {
-                        const requested = labels.split(",").map(s => s.trim()).filter(Boolean);
-                        await ensureLabelsExist(repo, requested);
-                        editArgs.push("--add-label", labels);
-                        updates.push("labels");
-                    }
-
-                    // Body handling: prefer file when provided / multi-line / JSON
-                    if (bodyFile) {
-                        editArgs.push("--body-file", bodyFile);
-                        updates.push("body");
-                    } else if (bodyJson !== undefined) {
-                        const md = jsonToMarkdown(bodyJson);
-                        tempFile = path.join(os.tmpdir(), `mcp-issue-body-${Date.now()}.md`);
-                        fs.writeFileSync(tempFile, md, "utf8");
-                        editArgs.push("--body-file", tempFile);
-                        updates.push("body");
-                    } else if (body && body.includes("\n")) {
-                        tempFile = path.join(os.tmpdir(), `mcp-issue-body-${Date.now()}.md`);
-                        fs.writeFileSync(tempFile, body, "utf8");
-                        editArgs.push("--body-file", tempFile);
-                        updates.push("body");
-                    } else if (body) {
-                        editArgs.push("--body", `"${body.replace(/"/g, '\\"')}"`);
-                        updates.push("body");
-                    }
-
-                    await runGhCommand(editArgs);
+                // Resolve body content
+                let resolvedBody: string | undefined;
+                if (bodyFile) {
+                    resolvedBody = fs.readFileSync(bodyFile, "utf8");
+                    updates.push("body");
+                } else if (bodyJson !== undefined) {
+                    resolvedBody = jsonToMarkdown(bodyJson);
+                    updates.push("body");
+                } else if (body !== undefined) {
+                    resolvedBody = body;
+                    updates.push("body");
                 }
 
-                // Add comment if provided. Use --body-file for multiline/large comments
-                if (comment) {
-                    if (comment.includes('\n') || comment.length > 1000) {
-                        tempFile = path.join(os.tmpdir(), `mcp-issue-comment-${Date.now()}.md`);
-                        fs.writeFileSync(tempFile, comment, 'utf8');
+                if (title) updates.push("title");
+                if (state) updates.push("state");
+                if (milestone !== undefined) updates.push("milestone");
 
-                        const commentArgs = [
-                            "issue", "comment",
-                            String(issueNumber),
-                            "--repo", repo,
-                            "--body-file", tempFile
-                        ];
+                // Ensure labels exist before adding
+                if (labels) {
+                    const requested = labels.split(",").map((s) => s.trim()).filter(Boolean);
+                    await ensureLabelsExist(octokit, owner, repoName, requested);
+                    updates.push("labels");
+                }
 
-                        await runGhCommand(commentArgs);
-                    } else {
-                        const commentArgs = [
-                            "issue", "comment",
-                            String(issueNumber),
-                            "--repo", repo,
-                            "--body", `"${comment.replace(/"/g, '\\"')}"`
-                        ];
+                // Step 1: Update issue fields (title, body, state, milestone, assignees, stateReason)
+                const hasIssueUpdate = title !== undefined || resolvedBody !== undefined ||
+                    state !== undefined || milestone !== undefined || assignees !== undefined;
 
-                        await runGhCommand(commentArgs);
+                if (hasIssueUpdate) {
+                    await octokit.rest.issues.update({
+                        owner,
+                        repo: repoName,
+                        issue_number: issueNumber,
+                        ...(title !== undefined && { title }),
+                        ...(resolvedBody !== undefined && { body: resolvedBody }),
+                        ...(state !== undefined && { state }),
+                        ...(state === "closed" && stateReason ? { state_reason: stateReason } : {}),
+                        ...(milestone !== undefined && { milestone: milestone === 0 ? null : milestone }),
+                        ...(assignees !== undefined && {
+                            assignees: assignees.split(",").map((s) => s.trim()).filter(Boolean)
+                        }),
+                    });
+                    if (assignees !== undefined) updates.push("assignees");
+                }
+
+                // Step 2: Add labels
+                if (labels) {
+                    const labelList = labels.split(",").map((s) => s.trim()).filter(Boolean);
+                    await octokit.rest.issues.addLabels({ owner, repo: repoName, issue_number: issueNumber, labels: labelList });
+                }
+
+                // Step 3: Remove labels
+                if (removeLabels) {
+                    const toRemove = removeLabels.split(",").map((s) => s.trim()).filter(Boolean);
+                    for (const label of toRemove) {
+                        await octokit.rest.issues.removeLabel({ owner, repo: repoName, issue_number: issueNumber, name: label });
                     }
+                    updates.push("removeLabels");
+                }
 
+                // Step 4: Add comment
+                if (comment) {
+                    await octokit.rest.issues.createComment({ owner, repo: repoName, issue_number: issueNumber, body: comment });
                     updates.push("comment added");
                 }
 
                 if (updates.length === 0) {
-                    return createSuccessResult({
-                        message: "No updates provided",
-                        issueNumber: issueNumber
-                    });
+                    return createSuccessResult({ message: "No updates provided", issueNumber });
                 }
 
                 return createSuccessResult({
                     message: `Issue #${issueNumber} updated successfully`,
-                    updates: updates,
-                    repository: repo
+                    updates,
+                    repository: repo,
                 });
             } catch (error) {
                 const message = error instanceof Error ? error.message : String(error);
                 return createErrorResult(message);
-            } finally {
-                if (tempFile) {
-                    try { fs.unlinkSync(tempFile); } catch { /* ignore */ }
-                }
             }
         }
     );

--- a/src/tools/github-projects/create-issue-in-project.ts
+++ b/src/tools/github-projects/create-issue-in-project.ts
@@ -1,0 +1,117 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { CreateIssueInProjectInputSchema } from "./schemas.js";
+import { getProjectFields, getIssueNodeId, addIssueToProject, updateProjectFieldValue } from "./graphql.js";
+import { createOctokitClient } from "../github-issues/octokit.js";
+import { ensureLabelsExist } from "../github-issues/label-helper.js";
+import { createSuccessResult, createErrorResult } from "./results.js";
+
+const name = "create-issue-in-project";
+const toolConfig = {
+    title: "Create Issue in Project",
+    description:
+        "Atomically create a GitHub issue, add it to a Projects V2 board, and optionally set its Status column — all in one call. " +
+        "Use get-project-status-options first to discover valid status values if needed.",
+    inputSchema: CreateIssueInProjectInputSchema
+};
+
+/**
+ * Registers the create-issue-in-project tool with the MCP server.
+ */
+export function registerCreateIssueInProjectTool(server: McpServer): void {
+    (server as any).registerTool(
+        name,
+        toolConfig,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { owner, repo, projectNumber, title, body, labels, status } = args as {
+                    owner: string;
+                    repo: string;
+                    projectNumber: number;
+                    title: string;
+                    body?: string;
+                    labels?: string;
+                    status?: string;
+                };
+
+                const octokit = createOctokitClient();
+
+                // Step 1: Ensure labels exist, then create the issue via REST
+                const labelList = labels
+                    ? labels.split(",").map((s) => s.trim()).filter(Boolean)
+                    : undefined;
+
+                if (labelList && labelList.length > 0) {
+                    await ensureLabelsExist(octokit, owner, repo, labelList);
+                }
+
+                const issueResponse = await octokit.rest.issues.create({
+                    owner,
+                    repo,
+                    title,
+                    body,
+                    labels: labelList,
+                });
+
+                const issue = issueResponse.data;
+
+                // Step 2: Get project metadata (fields + projectId) and issue node ID in parallel
+                const [{ projectId, fields }, issueNodeId] = await Promise.all([
+                    getProjectFields(owner, projectNumber),
+                    getIssueNodeId(owner, repo, issue.number),
+                ]);
+
+                // Step 3: Add issue to project
+                const itemId = await addIssueToProject(projectId, issueNodeId);
+
+                // Step 4: Set Status field if requested
+                let statusSet: string | null = null;
+                if (status) {
+                    const statusField = fields.find(
+                        (f) => f.name === "Status" && f.dataType === "SINGLE_SELECT"
+                    );
+                    if (!statusField) {
+                        // Issue is already on the board — just warn, don't fail
+                        return createSuccessResult({
+                            message: `Issue #${issue.number} created and added to project #${projectNumber}, but no Status field was found.`,
+                            issueNumber: issue.number,
+                            issueUrl: issue.html_url,
+                            projectItemId: itemId,
+                            statusSet: null,
+                        });
+                    }
+
+                    const option = statusField.options?.find(
+                        (o) => o.name.toLowerCase() === status.toLowerCase()
+                    );
+                    if (!option) {
+                        const availableNames = (statusField.options ?? []).map((o) => o.name).join(", ");
+                        return createSuccessResult({
+                            message:
+                                `Issue #${issue.number} created and added to project #${projectNumber}, ` +
+                                `but status "${status}" was not found. Available options: ${availableNames}.`,
+                            issueNumber: issue.number,
+                            issueUrl: issue.html_url,
+                            projectItemId: itemId,
+                            statusSet: null,
+                        });
+                    }
+
+                    await updateProjectFieldValue(projectId, itemId, statusField.id, option.id, "SINGLE_SELECT");
+                    statusSet = option.name;
+                }
+
+                return createSuccessResult({
+                    message: `Issue #${issue.number} created and added to project #${projectNumber}${statusSet ? ` with status "${statusSet}"` : ""}.`,
+                    issueNumber: issue.number,
+                    issueUrl: issue.html_url,
+                    projectItemId: itemId,
+                    statusSet,
+                });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return createErrorResult(message);
+            }
+        }
+    );
+}

--- a/src/tools/github-projects/get-project-status-options.ts
+++ b/src/tools/github-projects/get-project-status-options.ts
@@ -1,0 +1,57 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { GetProjectStatusOptionsInputSchema } from "./schemas.js";
+import { getProjectFields } from "./graphql.js";
+import { createSuccessResult, createErrorResult } from "./results.js";
+
+const name = "get-project-status-options";
+const toolConfig = {
+    title: "Get Project Status Options",
+    description: "Return all available Status column option names for a GitHub Projects V2 board. Use this before setting a Status field value so you know the exact valid option names.",
+    inputSchema: GetProjectStatusOptionsInputSchema
+};
+
+/**
+ * Registers the get-project-status-options tool with the MCP server.
+ */
+export function registerGetProjectStatusOptionsTool(server: McpServer): void {
+    (server as any).registerTool(
+        name,
+        toolConfig,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { owner, projectNumber } = args as {
+                    owner: string;
+                    projectNumber: number;
+                };
+
+                const { fields } = await getProjectFields(owner, projectNumber);
+                const statusField = fields.find(
+                    (f) => f.name === "Status" && f.dataType === "SINGLE_SELECT"
+                );
+
+                if (!statusField) {
+                    return createSuccessResult({
+                        owner,
+                        projectNumber,
+                        statusOptions: [],
+                        message: "No Status field found on this project.",
+                    });
+                }
+
+                return createSuccessResult({
+                    owner,
+                    projectNumber,
+                    statusFieldId: statusField.id,
+                    statusOptions: (statusField.options ?? []).map((o) => ({
+                        id: o.id,
+                        name: o.name,
+                    })),
+                });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return createErrorResult(message);
+            }
+        }
+    );
+}

--- a/src/tools/github-projects/graphql.ts
+++ b/src/tools/github-projects/graphql.ts
@@ -528,3 +528,117 @@ export function clearProjectCache(owner?: string, projectNumber?: number): void 
         projectCache.clear();
     }
 }
+
+/**
+ * List all items on a project board with their current field values.
+ * Returns up to 100 items per query (Projects V2 limit per page).
+ */
+export async function listProjectItems(
+    owner: string,
+    projectNumber: number
+): Promise<Array<{
+    id: string;
+    issueNumber: number | null;
+    title: string;
+    url: string;
+    fieldValues: Record<string, string | number>;
+}>> {
+    const client = createGraphqlClient();
+
+    const userQuery = `
+        query($owner: String!, $projectNumber: Int!) {
+            user(login: $owner) {
+                projectV2(number: $projectNumber) {
+                    items(first: 100) {
+                        nodes {
+                            id
+                            content {
+                                __typename
+                                ... on Issue {
+                                    number
+                                    title
+                                    url
+                                }
+                                ... on PullRequest {
+                                    number
+                                    title
+                                    url
+                                }
+                            }
+                            fieldValues(first: 20) {
+                                nodes {
+                                    __typename
+                                    ... on ProjectV2ItemFieldTextValue {
+                                        text
+                                        field { ... on ProjectV2Field { name } }
+                                    }
+                                    ... on ProjectV2ItemFieldNumberValue {
+                                        number
+                                        field { ... on ProjectV2Field { name } }
+                                    }
+                                    ... on ProjectV2ItemFieldDateValue {
+                                        date
+                                        field { ... on ProjectV2Field { name } }
+                                    }
+                                    ... on ProjectV2ItemFieldSingleSelectValue {
+                                        name
+                                        field { ... on ProjectV2SingleSelectField { name } }
+                                    }
+                                    ... on ProjectV2ItemFieldIterationValue {
+                                        title
+                                        field { ... on ProjectV2IterationField { name } }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+    const orgQuery = userQuery.replace("user(login: $owner)", "organization(login: $owner)");
+
+    let response: any;
+    try {
+        response = await client<any>(userQuery, { owner, projectNumber });
+    } catch {
+        response = await client<any>(orgQuery, { owner, projectNumber });
+    }
+
+    const projectData = response.user?.projectV2 ?? response.organization?.projectV2;
+    if (!projectData) {
+        throw new Error(`Project #${projectNumber} not found for owner '${owner}'.`);
+    }
+
+    return (projectData.items.nodes as any[]).map((item: any) => {
+        const content = item.content ?? {};
+        const fieldValues: Record<string, string | number> = {};
+
+        for (const fv of (item.fieldValues?.nodes ?? []) as any[]) {
+            const fieldName: string | undefined =
+                fv.field?.name;
+            if (!fieldName) continue;
+
+            if (fv.__typename === "ProjectV2ItemFieldTextValue" && fv.text !== null && fv.text !== undefined) {
+                fieldValues[fieldName] = fv.text;
+            } else if (fv.__typename === "ProjectV2ItemFieldNumberValue" && fv.number !== null && fv.number !== undefined) {
+                fieldValues[fieldName] = fv.number;
+            } else if (fv.__typename === "ProjectV2ItemFieldDateValue" && fv.date) {
+                fieldValues[fieldName] = fv.date;
+            } else if (fv.__typename === "ProjectV2ItemFieldSingleSelectValue" && fv.name) {
+                fieldValues[fieldName] = fv.name;
+            } else if (fv.__typename === "ProjectV2ItemFieldIterationValue" && fv.title) {
+                fieldValues[fieldName] = fv.title;
+            }
+        }
+
+        return {
+            id: item.id,
+            issueNumber: content.number ?? null,
+            title: content.title ?? "(no title)",
+            url: content.url ?? "",
+            fieldValues,
+        };
+    });
+}

--- a/src/tools/github-projects/index.ts
+++ b/src/tools/github-projects/index.ts
@@ -5,6 +5,9 @@ import { registerUpdateProjectFieldTool } from "./update-project-field.js";
 import { registerDeleteProjectFieldTool } from "./delete-project-field.js";
 import { registerSetProjectFieldValueTool } from "./set-project-field-value.js";
 import { registerBulkSetProjectFieldValuesTool } from "./bulk-set-project-field-values.js";
+import { registerListProjectItemsTool } from "./list-project-items.js";
+import { registerGetProjectStatusOptionsTool } from "./get-project-status-options.js";
+import { registerCreateIssueInProjectTool } from "./create-issue-in-project.js";
 
 /**
  * Registers all GitHub Projects V2 tools with the MCP server.
@@ -19,4 +22,11 @@ export function registerGitHubProjectsTools(server: McpServer): void {
     // Value operations
     registerSetProjectFieldValueTool(server);
     registerBulkSetProjectFieldValuesTool(server);
+
+    // Board visibility
+    registerListProjectItemsTool(server);
+    registerGetProjectStatusOptionsTool(server);
+
+    // Atomic workflows
+    registerCreateIssueInProjectTool(server);
 }

--- a/src/tools/github-projects/list-project-items.ts
+++ b/src/tools/github-projects/list-project-items.ts
@@ -1,0 +1,51 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { ListProjectItemsInputSchema } from "./schemas.js";
+import { listProjectItems } from "./graphql.js";
+import { createSuccessResult, createErrorResult } from "./results.js";
+
+const name = "list-project-items";
+const toolConfig = {
+    title: "List Project Items",
+    description: "List all items on a GitHub Projects V2 board, grouped by Status column, with their current field values and issue numbers. Gives a full board snapshot.",
+    inputSchema: ListProjectItemsInputSchema
+};
+
+/**
+ * Registers the list-project-items tool with the MCP server.
+ */
+export function registerListProjectItemsTool(server: McpServer): void {
+    (server as any).registerTool(
+        name,
+        toolConfig,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { owner, projectNumber } = args as {
+                    owner: string;
+                    projectNumber: number;
+                };
+
+                const items = await listProjectItems(owner, projectNumber);
+
+                // Group items by Status for easy reading
+                const byStatus: Record<string, typeof items> = {};
+                for (const item of items) {
+                    const status = (item.fieldValues["Status"] as string) ?? "(no status)";
+                    if (!byStatus[status]) byStatus[status] = [];
+                    byStatus[status].push(item);
+                }
+
+                return createSuccessResult({
+                    owner,
+                    projectNumber,
+                    totalItems: items.length,
+                    byStatus,
+                    items,
+                });
+            } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                return createErrorResult(message);
+            }
+        }
+    );
+}

--- a/src/tools/github-projects/schemas.ts
+++ b/src/tools/github-projects/schemas.ts
@@ -104,3 +104,32 @@ export const BulkSetProjectFieldValuesInputSchema = {
         .min(1)
         .describe("Array of updates, each with issueNumber and fields")
 };
+
+/**
+ * Schema for list-project-items tool input
+ */
+export const ListProjectItemsInputSchema = {
+    owner: OwnerSchema,
+    projectNumber: ProjectNumberSchema
+};
+
+/**
+ * Schema for get-project-status-options tool input
+ */
+export const GetProjectStatusOptionsInputSchema = {
+    owner: OwnerSchema,
+    projectNumber: ProjectNumberSchema
+};
+
+/**
+ * Schema for create-issue-in-project tool input
+ */
+export const CreateIssueInProjectInputSchema = {
+    owner: OwnerSchema,
+    repo: z.string().min(1).describe("Repository name (just the repo name, not owner/repo)"),
+    projectNumber: ProjectNumberSchema,
+    title: z.string().min(1).describe("Issue title"),
+    body: z.string().optional().describe("Issue body (Markdown allowed)"),
+    labels: z.string().optional().describe("Comma-separated labels to add to the issue"),
+    status: z.string().optional().describe("Status column name to place the issue in (e.g. 'Todo', 'In Progress')")
+};

--- a/test/tools/github-issues/create-issue.test.ts
+++ b/test/tools/github-issues/create-issue.test.ts
@@ -1,65 +1,108 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-// Mock gh-cli before importing modules that use it
-vi.mock('../../../src/tools/github-issues/gh-cli.js', () => ({
-    runGhCommand: vi.fn()
+// Mock octokit module before importing the tool
+vi.mock('../../../src/tools/github-issues/octokit.js', () => ({
+    createOctokitClient: vi.fn(),
+    parseRepo: (repo: string) => {
+        const [owner, repoName] = repo.split('/')
+        return { owner, repo: repoName }
+    }
+}))
+vi.mock('../../../src/tools/github-issues/label-helper.js', () => ({
+    ensureLabelsExist: vi.fn().mockResolvedValue(undefined)
 }))
 
 import { registerCreateIssueTool } from '../../../src/tools/github-issues/create-issue.js'
-import * as ghCli from '../../../src/tools/github-issues/gh-cli.js'
+import * as octokitModule from '../../../src/tools/github-issues/octokit.js'
 
 describe('create-issue tool', () => {
+    let mockServer: any
+    let registeredHandler: any
+    let mockOctokit: any
+
     beforeEach(() => {
         vi.clearAllMocks()
+
+        mockOctokit = {
+            rest: {
+                issues: {
+                    create: vi.fn().mockResolvedValue({
+                        data: {
+                            number: 42,
+                            html_url: 'https://github.com/owner/repo/issues/42',
+                            title: 'Test Issue'
+                        }
+                    })
+                }
+            }
+        }
+        vi.mocked(octokitModule.createOctokitClient).mockReturnValue(mockOctokit as any)
+
+        mockServer = {
+            registerTool: vi.fn((_name: string, _cfg: any, handler: any) => {
+                registeredHandler = handler
+            })
+        }
+        registerCreateIssueTool(mockServer as McpServer)
     })
 
-    it('uses --body-file for multiline body', async () => {
-        const fake: any = {}
-        fake.registerTool = (_name: string, _cfg: any, handler: any) => { fake.handler = handler }
-
-        registerCreateIssueTool(fake)
-
-        const run = ghCli.runGhCommand as unknown as ReturnType<typeof vi.fn>
-        (run as any).mockImplementation((args: string[]) => {
-            const cmd = args.join(' ')
-            if (cmd.includes('issue create')) return Promise.resolve('https://github.com/bryan-debaun/mcp-server/issues/123')
-            return Promise.resolve('[]')
-        })
-
-        const longBody = 'line1\nline2\n'
-        const result = await fake.handler({ repo: 'bryan-debaun/mcp-server', title: 'T', body: longBody })
-
-        expect(run).toHaveBeenCalled()
-        const createCall = (run as any).mock.calls.find((c: any) => c[0][0] === 'issue' && c[0].includes('create'))
-        expect(createCall).toBeTruthy()
-        expect(createCall[0]).toContain('--body-file')
-
-        // parse returned message
-        const payload = JSON.parse(result.content[0].text)
-        expect(payload.message).toContain('Issue #')
+    it('registers the tool with correct name', () => {
+        expect(mockServer.registerTool).toHaveBeenCalledWith(
+            'create-issue',
+            expect.objectContaining({ title: 'Create Issue' }),
+            expect.any(Function)
+        )
     })
 
-    it('accepts bodyJson and writes markdown file', async () => {
-        const fake: any = {}
-        fake.registerTool = (_name: string, _cfg: any, handler: any) => { fake.handler = handler }
-
-        registerCreateIssueTool(fake)
-
-        const run = ghCli.runGhCommand as unknown as ReturnType<typeof vi.fn>
-        (run as any).mockImplementation((args: string[]) => {
-            const cmd = args.join(' ')
-            if (cmd.includes('issue create')) return Promise.resolve('https://github.com/bryan-debaun/mcp-server/issues/456')
-            return Promise.resolve('[]')
+    it('creates an issue and returns success', async () => {
+        const result = await registeredHandler({
+            repo: 'owner/repo',
+            title: 'Test Issue',
+            body: 'Some body'
         })
 
-        const jsonBody = { foo: 'bar', x: 1 }
-        const result = await fake.handler({ repo: 'bryan-debaun/mcp-server', title: 'JSON', bodyJson: jsonBody })
-
-        expect(run).toHaveBeenCalled()
-        const createCall = (run as any).mock.calls.find((c: any) => c[0][0] === 'issue' && c[0].includes('create'))
-        expect(createCall[0]).toContain('--body-file')
-
+        expect(mockOctokit.rest.issues.create).toHaveBeenCalledWith(
+            expect.objectContaining({ owner: 'owner', repo: 'repo', title: 'Test Issue', body: 'Some body' })
+        )
         const payload = JSON.parse(result.content[0].text)
-        expect(payload.url).toContain('/issues/456')
+        expect(payload.message).toContain('#42')
+        expect(payload.url).toContain('/issues/42')
+    })
+
+    it('creates issue with labels, assignees, and milestone', async () => {
+        await registeredHandler({
+            repo: 'owner/repo',
+            title: 'With meta',
+            labels: 'bug, enhancement',
+            assignees: 'alice, bob',
+            milestone: 3
+        })
+
+        expect(mockOctokit.rest.issues.create).toHaveBeenCalledWith(
+            expect.objectContaining({
+                labels: ['bug', 'enhancement'],
+                assignees: ['alice', 'bob'],
+                milestone: 3
+            })
+        )
+    })
+
+    it('reads body from bodyJson', async () => {
+        const result = await registeredHandler({
+            repo: 'owner/repo',
+            title: 'JSON body',
+            bodyJson: { key: 'value' }
+        })
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.number).toBe(42)
+    })
+
+    it('returns error result if Octokit throws', async () => {
+        mockOctokit.rest.issues.create.mockRejectedValue(new Error('API rate limit'))
+        const result = await registeredHandler({ repo: 'owner/repo', title: 'Fail' })
+        expect(result.isError).toBe(true)
+        expect(result.content[0].text).toContain('API rate limit')
     })
 })
+

--- a/test/tools/github-issues/gh-cli.test.ts
+++ b/test/tools/github-issues/gh-cli.test.ts
@@ -1,28 +1,19 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import * as ghCli from "../../../src/tools/github-issues/gh-cli.js";
+import { describe, it, expect } from "vitest";
+import { parseGhJson } from "../../../src/tools/github-issues/gh-cli.js";
 
-// Mock the gh CLI module
-vi.mock("child_process", () => ({
-    exec: vi.fn()
-}));
-
-describe("gh-cli", () => {
-    beforeEach(() => {
-        vi.clearAllMocks();
-    });
-
-    afterEach(() => {
-        vi.restoreAllMocks();
-    });
-
+/**
+ * gh-cli.ts is retained as a legacy module but no longer used by issue tools.
+ * Only parseGhJson is tested here since runGhCommand is not invoked at runtime.
+ */
+describe("gh-cli (legacy)", () => {
     describe("parseGhJson", () => {
         it("should parse valid JSON", () => {
-            const result = ghCli.parseGhJson<{ foo: string }>('{"foo": "bar"}');
+            const result = parseGhJson<{ foo: string }>('{"foo": "bar"}');
             expect(result).toEqual({ foo: "bar" });
         });
 
         it("should throw on invalid JSON", () => {
-            expect(() => ghCli.parseGhJson("not json")).toThrow("Failed to parse GitHub CLI response");
+            expect(() => parseGhJson("not json")).toThrow("Failed to parse GitHub CLI response");
         });
     });
 });

--- a/test/tools/github-issues/list-labels.test.ts
+++ b/test/tools/github-issues/list-labels.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+vi.mock('../../../src/tools/github-issues/octokit.js', () => ({
+    createOctokitClient: vi.fn(),
+    parseRepo: (repo: string) => {
+        const [owner, repoName] = repo.split('/')
+        return { owner, repo: repoName }
+    }
+}))
+
+import { registerListLabelsTool } from '../../../src/tools/github-issues/list-labels.js'
+import * as octokitModule from '../../../src/tools/github-issues/octokit.js'
+
+describe('list-labels tool', () => {
+    let mockServer: any
+    let registeredHandler: any
+    let mockOctokit: any
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+
+        mockOctokit = {
+            rest: {
+                issues: {
+                    listLabelsForRepo: vi.fn().mockResolvedValue({
+                        data: [
+                            { name: 'bug', color: 'ee0701', description: 'Something is broken' },
+                            { name: 'feature', color: '0075ca', description: '' },
+                        ]
+                    })
+                }
+            }
+        }
+        vi.mocked(octokitModule.createOctokitClient).mockReturnValue(mockOctokit as any)
+
+        mockServer = {
+            registerTool: vi.fn((_name: string, _cfg: any, handler: any) => {
+                registeredHandler = handler
+            })
+        }
+        registerListLabelsTool(mockServer as McpServer)
+    })
+
+    it('registers with correct name and description', () => {
+        expect(mockServer.registerTool).toHaveBeenCalledWith(
+            'list-labels',
+            expect.objectContaining({ title: 'List Labels' }),
+            expect.any(Function)
+        )
+    })
+
+    it('returns all labels with name, color, and description', async () => {
+        const result = await registeredHandler({ repo: 'owner/repo' })
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.count).toBe(2)
+        expect(payload.labels[0]).toMatchObject({ name: 'bug', color: 'ee0701' })
+        expect(payload.labels[1]).toMatchObject({ name: 'feature' })
+    })
+
+    it('returns error result if Octokit throws', async () => {
+        mockOctokit.rest.issues.listLabelsForRepo.mockRejectedValue(new Error('Not found'))
+        const result = await registeredHandler({ repo: 'owner/repo' })
+        expect(result.isError).toBe(true)
+        expect(result.content[0].text).toContain('Not found')
+    })
+})

--- a/test/tools/github-issues/update-issue.test.ts
+++ b/test/tools/github-issues/update-issue.test.ts
@@ -1,94 +1,126 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 
-vi.mock('../../../src/tools/github-issues/gh-cli.js', () => ({
-    runGhCommand: vi.fn(),
-    parseGhJson: (s: string) => JSON.parse(s)
+vi.mock('../../../src/tools/github-issues/octokit.js', () => ({
+    createOctokitClient: vi.fn(),
+    parseRepo: (repo: string) => {
+        const [owner, repoName] = repo.split('/')
+        return { owner, repo: repoName }
+    }
+}))
+vi.mock('../../../src/tools/github-issues/label-helper.js', () => ({
+    ensureLabelsExist: vi.fn().mockResolvedValue(undefined)
 }))
 
 import { registerUpdateIssueTool } from '../../../src/tools/github-issues/update-issue.js'
-import * as ghCli from '../../../src/tools/github-issues/gh-cli.js'
+import * as octokitModule from '../../../src/tools/github-issues/octokit.js'
 
 describe('update-issue tool', () => {
+    let mockServer: any
+    let registeredHandler: any
+    let mockOctokit: any
+
     beforeEach(() => {
         vi.clearAllMocks()
-    })
 
-    it('uses --body-file for multiline body when updating', async () => {
-        const fake: any = {}
-        fake.registerTool = (_name: string, _cfg: any, handler: any) => { fake.handler = handler }
-
-        registerUpdateIssueTool(fake)
-
-        const run = ghCli.runGhCommand as unknown as ReturnType<typeof vi.fn>
-        (run as any).mockImplementation((args: string[]) => {
-            const cmd = args.join(' ')
-            if (cmd.includes('issue edit')) return Promise.resolve('')
-            return Promise.resolve('[]')
-        })
-
-        const res = await fake.handler({ repo: 'bryan-debaun/mcp-server', issueNumber: 10, body: 'multi\nline' })
-        expect(run).toHaveBeenCalled()
-        const editCall = (run as any).mock.calls.find((c: any) => c[0][0] === 'issue' && c[0].includes('edit'))
-        expect(editCall).toBeTruthy()
-        expect(editCall[0]).toContain('--body-file')
-        const payload = JSON.parse(res.content[0].text)
-        expect(payload.message).toContain('updated successfully')
-    })
-
-    it('creates missing labels before assigning them', async () => {
-        const fake: any = {}
-        fake.registerTool = (_name: string, _cfg: any, handler: any) => { fake.handler = handler }
-
-        registerUpdateIssueTool(fake)
-
-        const run = ghCli.runGhCommand as unknown as ReturnType<typeof vi.fn>
-        (run as any).mockImplementation((args: string[]) => {
-            const cmd = args.join(' ')
-            if (cmd.includes('label list')) {
-                // repo has only `existing` label
-                return Promise.resolve(JSON.stringify([{ name: 'existing' }]))
+        mockOctokit = {
+            rest: {
+                issues: {
+                    update: vi.fn().mockResolvedValue({ data: {} }),
+                    addLabels: vi.fn().mockResolvedValue({ data: [] }),
+                    removeLabel: vi.fn().mockResolvedValue({ data: [] }),
+                    createComment: vi.fn().mockResolvedValue({ data: {} })
+                }
             }
-            if (cmd.includes('label create')) return Promise.resolve('')
-            if (cmd.includes('issue edit')) return Promise.resolve('')
-            return Promise.resolve('')
+        }
+        vi.mocked(octokitModule.createOctokitClient).mockReturnValue(mockOctokit as any)
+
+        mockServer = {
+            registerTool: vi.fn((_name: string, _cfg: any, handler: any) => {
+                registeredHandler = handler
+            })
+        }
+        registerUpdateIssueTool(mockServer as McpServer)
+    })
+
+    it('registers the tool with correct name', () => {
+        expect(mockServer.registerTool).toHaveBeenCalledWith(
+            'update-issue',
+            expect.objectContaining({ title: 'Update Issue' }),
+            expect.any(Function)
+        )
+    })
+
+    it('updates title via REST', async () => {
+        const result = await registeredHandler({
+            repo: 'owner/repo',
+            issueNumber: 10,
+            title: 'New title'
         })
+        expect(mockOctokit.rest.issues.update).toHaveBeenCalledWith(
+            expect.objectContaining({ owner: 'owner', repo: 'repo', issue_number: 10, title: 'New title' })
+        )
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.updates).toContain('title')
+    })
 
-        const res = await fake.handler({ repo: 'bryan-debaun/mcp-server', issueNumber: 11, labels: 'existing,new-label' })
-        expect(run).toHaveBeenCalled()
-
-        const created = (run as any).mock.calls.find((c: any) => c[0][0] === 'label' && c[0].includes('create'))
-        expect(created).toBeTruthy()
-
-        const editCall = (run as any).mock.calls.find((c: any) => c[0][0] === 'issue' && c[0].includes('edit'))
-        expect(editCall).toBeTruthy()
-        expect(editCall[0]).toContain('--add-label')
-
-        const payload = JSON.parse(res.content[0].text)
+    it('adds labels via REST', async () => {
+        const result = await registeredHandler({
+            repo: 'owner/repo',
+            issueNumber: 11,
+            labels: 'bug,feature'
+        })
+        expect(mockOctokit.rest.issues.addLabels).toHaveBeenCalledWith(
+            expect.objectContaining({ labels: ['bug', 'feature'] })
+        )
+        const payload = JSON.parse(result.content[0].text)
         expect(payload.updates).toContain('labels')
     })
 
-    it('uses --body-file for multiline comment when updating', async () => {
-        const fake: any = {}
-        fake.registerTool = (_name: string, _cfg: any, handler: any) => { fake.handler = handler }
-
-        registerUpdateIssueTool(fake)
-
-        const run = ghCli.runGhCommand as unknown as ReturnType<typeof vi.fn>
-        (run as any).mockImplementation((args: string[]) => {
-            const cmd = args.join(' ')
-            if (cmd.includes('issue comment')) return Promise.resolve('')
-            return Promise.resolve('[]')
+    it('removes labels one by one via REST', async () => {
+        const result = await registeredHandler({
+            repo: 'owner/repo',
+            issueNumber: 12,
+            removeLabels: 'old-label'
         })
+        expect(mockOctokit.rest.issues.removeLabel).toHaveBeenCalledWith(
+            expect.objectContaining({ name: 'old-label' })
+        )
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.updates).toContain('removeLabels')
+    })
 
-        const longComment = 'line1\nline2\n- list item\n\n**markdown**'
-        const res = await fake.handler({ repo: 'bryan-debaun/mcp-server', issueNumber: 12, comment: longComment })
-        expect(run).toHaveBeenCalled()
+    it('closes issue by setting state=closed', async () => {
+        const result = await registeredHandler({
+            repo: 'owner/repo',
+            issueNumber: 13,
+            state: 'closed',
+            stateReason: 'completed'
+        })
+        expect(mockOctokit.rest.issues.update).toHaveBeenCalledWith(
+            expect.objectContaining({ state: 'closed', state_reason: 'completed' })
+        )
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.updates).toContain('state')
+    })
 
-        const commentCall = (run as any).mock.calls.find((c: any) => c[0][0] === 'issue' && c[0].includes('comment'))
-        expect(commentCall).toBeTruthy()
-        expect(commentCall[0]).toContain('--body-file')
-
-        const payload = JSON.parse(res.content[0].text)
+    it('adds a comment via REST', async () => {
+        const result = await registeredHandler({
+            repo: 'owner/repo',
+            issueNumber: 14,
+            comment: 'Hello!'
+        })
+        expect(mockOctokit.rest.issues.createComment).toHaveBeenCalledWith(
+            expect.objectContaining({ body: 'Hello!' })
+        )
+        const payload = JSON.parse(result.content[0].text)
         expect(payload.updates).toContain('comment added')
     })
+
+    it('returns no-updates message when nothing provided', async () => {
+        const result = await registeredHandler({ repo: 'owner/repo', issueNumber: 15 })
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.message).toContain('No updates')
+    })
 })
+

--- a/test/tools/github-projects/create-issue-in-project.test.ts
+++ b/test/tools/github-projects/create-issue-in-project.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+vi.mock('../../../src/tools/github-projects/graphql.js')
+vi.mock('../../../src/tools/github-issues/octokit.js', () => ({
+    createOctokitClient: vi.fn()
+}))
+vi.mock('../../../src/tools/github-issues/label-helper.js', () => ({
+    ensureLabelsExist: vi.fn().mockResolvedValue(undefined)
+}))
+
+import { registerCreateIssueInProjectTool } from '../../../src/tools/github-projects/create-issue-in-project.js'
+import * as graphql from '../../../src/tools/github-projects/graphql.js'
+import * as octokitModule from '../../../src/tools/github-issues/octokit.js'
+
+const PROJECT_FIELDS = {
+    projectId: 'PVT_123',
+    fields: [
+        {
+            id: 'PVTSSF_1',
+            name: 'Status',
+            dataType: 'SINGLE_SELECT' as const,
+            options: [
+                { id: 'opt_todo', name: 'Todo' },
+                { id: 'opt_inprog', name: 'In Progress' },
+            ]
+        }
+    ]
+}
+
+describe('create-issue-in-project tool', () => {
+    let mockServer: any
+    let registeredHandler: any
+    let mockOctokit: any
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+
+        mockOctokit = {
+            rest: {
+                issues: {
+                    create: vi.fn().mockResolvedValue({
+                        data: { number: 99, html_url: 'https://github.com/owner/repo/issues/99', title: 'New issue' }
+                    })
+                }
+            }
+        }
+        vi.mocked(octokitModule.createOctokitClient).mockReturnValue(mockOctokit as any)
+        vi.mocked(graphql.getProjectFields).mockResolvedValue(PROJECT_FIELDS)
+        vi.mocked(graphql.getIssueNodeId).mockResolvedValue('I_node_99')
+        vi.mocked(graphql.addIssueToProject).mockResolvedValue('PVTI_item_1')
+        vi.mocked(graphql.updateProjectFieldValue).mockResolvedValue(undefined)
+
+        mockServer = {
+            registerTool: vi.fn((_name: string, _cfg: any, handler: any) => { registeredHandler = handler })
+        }
+        registerCreateIssueInProjectTool(mockServer as McpServer)
+    })
+
+    it('registers with correct name', () => {
+        expect(mockServer.registerTool).toHaveBeenCalledWith(
+            'create-issue-in-project',
+            expect.objectContaining({ title: 'Create Issue in Project' }),
+            expect.any(Function)
+        )
+    })
+
+    it('creates issue, adds to project, and sets status', async () => {
+        const result = await registeredHandler({
+            owner: 'bryan-debaun',
+            repo: 'mcp-server',
+            projectNumber: 5,
+            title: 'New issue',
+            body: 'Issue body',
+            status: 'Todo'
+        })
+
+        expect(mockOctokit.rest.issues.create).toHaveBeenCalledWith(
+            expect.objectContaining({ owner: 'bryan-debaun', repo: 'mcp-server', title: 'New issue' })
+        )
+        expect(graphql.getIssueNodeId).toHaveBeenCalledWith('bryan-debaun', 'mcp-server', 99)
+        expect(graphql.addIssueToProject).toHaveBeenCalledWith('PVT_123', 'I_node_99')
+        expect(graphql.updateProjectFieldValue).toHaveBeenCalledWith(
+            'PVT_123', 'PVTI_item_1', 'PVTSSF_1', 'opt_todo', 'SINGLE_SELECT'
+        )
+
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.issueNumber).toBe(99)
+        expect(payload.statusSet).toBe('Todo')
+    })
+
+    it('adds to project without setting status when status omitted', async () => {
+        await registeredHandler({
+            owner: 'owner',
+            repo: 'repo',
+            projectNumber: 1,
+            title: 'No status'
+        })
+
+        expect(graphql.updateProjectFieldValue).not.toHaveBeenCalled()
+    })
+
+    it('warns when status option name is not recognised', async () => {
+        const result = await registeredHandler({
+            owner: 'owner',
+            repo: 'repo',
+            projectNumber: 1,
+            title: 'Bad status',
+            status: 'Nonexistent'
+        })
+
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.statusSet).toBeNull()
+        expect(payload.message).toContain('Nonexistent')
+        expect(payload.message).toContain('Todo')
+    })
+
+    it('warns when project has no Status field', async () => {
+        vi.mocked(graphql.getProjectFields).mockResolvedValue({
+            projectId: 'PVT_123',
+            fields: [{ id: 'f1', name: 'Title', dataType: 'TEXT' }]
+        })
+
+        const result = await registeredHandler({
+            owner: 'owner',
+            repo: 'repo',
+            projectNumber: 1,
+            title: 'No status field',
+            status: 'Todo'
+        })
+
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.statusSet).toBeNull()
+        expect(payload.message).toContain('no Status field')
+    })
+
+    it('returns error result if issue creation fails', async () => {
+        mockOctokit.rest.issues.create.mockRejectedValue(new Error('Forbidden'))
+        const result = await registeredHandler({ owner: 'o', repo: 'r', projectNumber: 1, title: 'Fail' })
+        expect(result.isError).toBe(true)
+        expect(result.content[0].text).toContain('Forbidden')
+    })
+})

--- a/test/tools/github-projects/get-project-status-options.test.ts
+++ b/test/tools/github-projects/get-project-status-options.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+vi.mock('../../../src/tools/github-projects/graphql.js')
+
+import { registerGetProjectStatusOptionsTool } from '../../../src/tools/github-projects/get-project-status-options.js'
+import * as graphql from '../../../src/tools/github-projects/graphql.js'
+
+describe('get-project-status-options tool', () => {
+    let mockServer: any
+    let registeredHandler: any
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+        mockServer = {
+            registerTool: vi.fn((_name: string, _cfg: any, handler: any) => { registeredHandler = handler })
+        }
+        registerGetProjectStatusOptionsTool(mockServer as McpServer)
+    })
+
+    it('registers with correct name', () => {
+        expect(mockServer.registerTool).toHaveBeenCalledWith(
+            'get-project-status-options',
+            expect.objectContaining({ title: 'Get Project Status Options' }),
+            expect.any(Function)
+        )
+    })
+
+    it('returns status options when Status field exists', async () => {
+        vi.mocked(graphql.getProjectFields).mockResolvedValue({
+            projectId: 'PVT_123',
+            fields: [
+                {
+                    id: 'PVTSSF_1',
+                    name: 'Status',
+                    dataType: 'SINGLE_SELECT',
+                    options: [
+                        { id: 'opt1', name: 'Todo' },
+                        { id: 'opt2', name: 'In Progress' },
+                        { id: 'opt3', name: 'Done' },
+                    ]
+                }
+            ]
+        })
+
+        const result = await registeredHandler({ owner: 'bryan-debaun', projectNumber: 5 })
+        const payload = JSON.parse(result.content[0].text)
+
+        expect(payload.statusFieldId).toBe('PVTSSF_1')
+        expect(payload.statusOptions).toHaveLength(3)
+        expect(payload.statusOptions[0]).toMatchObject({ id: 'opt1', name: 'Todo' })
+    })
+
+    it('returns empty options when no Status field found', async () => {
+        vi.mocked(graphql.getProjectFields).mockResolvedValue({
+            projectId: 'PVT_123',
+            fields: [{ id: 'f1', name: 'Title', dataType: 'TEXT' }]
+        })
+
+        const result = await registeredHandler({ owner: 'owner', projectNumber: 1 })
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.statusOptions).toHaveLength(0)
+        expect(payload.message).toContain('No Status field')
+    })
+
+    it('returns error result if graphql throws', async () => {
+        vi.mocked(graphql.getProjectFields).mockRejectedValue(new Error('Not found'))
+        const result = await registeredHandler({ owner: 'x', projectNumber: 99 })
+        expect(result.isError).toBe(true)
+        expect(result.content[0].text).toContain('Not found')
+    })
+})

--- a/test/tools/github-projects/list-project-items.test.ts
+++ b/test/tools/github-projects/list-project-items.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+
+vi.mock('../../../src/tools/github-projects/graphql.js')
+
+import { registerListProjectItemsTool } from '../../../src/tools/github-projects/list-project-items.js'
+import * as graphql from '../../../src/tools/github-projects/graphql.js'
+
+describe('list-project-items tool', () => {
+    let mockServer: any
+    let registeredHandler: any
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+
+        mockServer = {
+            registerTool: vi.fn((_name: string, _cfg: any, handler: any) => {
+                registeredHandler = handler
+            })
+        }
+        registerListProjectItemsTool(mockServer as McpServer)
+    })
+
+    it('registers with correct name', () => {
+        expect(mockServer.registerTool).toHaveBeenCalledWith(
+            'list-project-items',
+            expect.objectContaining({ title: 'List Project Items' }),
+            expect.any(Function)
+        )
+    })
+
+    it('groups items by status and returns board snapshot', async () => {
+        vi.mocked(graphql.listProjectItems).mockResolvedValue([
+            { id: 'item1', issueNumber: 10, title: 'Fix bug', url: 'https://github.com/x/y/issues/10', fieldValues: { Status: 'In Progress' } },
+            { id: 'item2', issueNumber: 11, title: 'Add feature', url: 'https://github.com/x/y/issues/11', fieldValues: { Status: 'Todo' } },
+            { id: 'item3', issueNumber: 12, title: 'Review', url: 'https://github.com/x/y/issues/12', fieldValues: { Status: 'In Progress' } },
+        ])
+
+        const result = await registeredHandler({ owner: 'bryan-debaun', projectNumber: 5 })
+        const payload = JSON.parse(result.content[0].text)
+
+        expect(payload.totalItems).toBe(3)
+        expect(payload.byStatus['In Progress']).toHaveLength(2)
+        expect(payload.byStatus['Todo']).toHaveLength(1)
+    })
+
+    it('places items with no status under "(no status)"', async () => {
+        vi.mocked(graphql.listProjectItems).mockResolvedValue([
+            { id: 'item1', issueNumber: 1, title: 'Uncategorized', url: '', fieldValues: {} },
+        ])
+
+        const result = await registeredHandler({ owner: 'owner', projectNumber: 1 })
+        const payload = JSON.parse(result.content[0].text)
+        expect(payload.byStatus['(no status)']).toHaveLength(1)
+    })
+
+    it('returns error result if graphql throws', async () => {
+        vi.mocked(graphql.listProjectItems).mockRejectedValue(new Error('Project not found'))
+        const result = await registeredHandler({ owner: 'x', projectNumber: 99 })
+        expect(result.isError).toBe(true)
+        expect(result.content[0].text).toContain('Project not found')
+    })
+})


### PR DESCRIPTION
## Summary

Closes #83
Closes #13

Migrates all 5 GitHub issue tools from the \gh\ CLI to \@octokit/rest\ and adds 4 new tools for a more reliable, no-subprocess GitHub integration.

## Changes

### Dependency
- Added \@octokit/rest@22.0.1\

### New shared helper
- \src/tools/github-issues/octokit.ts\ — \createOctokitClient()\ factory + \parseRepo()\ helper

### Migrated issue tools (gh CLI → Octokit REST)
- \create-issue\ — added \ssignees\, \milestone\ fields; returns \
umber\
- \update-issue\ — added \emoveLabels\, \ssignees\, \milestone\, \state\, \stateReason\
- \get-open-issues\ — uses \issues.listForRepo()\
- \get-issue\ — returns \milestone\ in response
- \close-issue\ — uses \issues.update()" + optional comment