### PR TITLE
docs: add remote HTTP access instructions and update tools table

### DIFF
--- a/.github/agents/mcp-server-coder.agent.md
+++ b/.github/agents/mcp-server-coder.agent.md
@@ -2,20 +2,7 @@
 description: "Coding agent for MCP Server - implement MCP tools, TypeScript features, Express routes, Prisma schema changes, and auth. Use for: feature branches, bug fixes, refactors, PR implementation. Hands off to Tester for coverage and Reviewer for quality checks."
 name: MCP Server Coder
 model: "claude-sonnet-4-5"
-tools:
-  - 'vscode/openSimpleBrowser'
-  - 'execute/runInTerminal'
-  - 'execute/runTests'
-  - 'read/problems'
-  - 'read/readFile'
-  - 'read/getChangedFiles'
-  - 'read/listCodeUsages'
-  - 'edit'
-  - 'search'
-  - 'web/fetch'
-  - 'web/search'
-  - 'agent'
-  - 'todo'
+tools: [execute/runInTerminal, read/problems, read/readFile, agent/runSubagent, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, edit/editNotebook, edit/rename, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, search/usages, web/fetch, bryan-debaun-mcp/get-issue, bryan-debaun-mcp/get-open-issues, bryan-debaun-mcp/get-user, bryan-debaun-mcp/list-users, bryan-debaun-mcp/close-issue, bryan-debaun-mcp/create-author, bryan-debaun-mcp/create-book, bryan-debaun-mcp/create-content-creator, bryan-debaun-mcp/create-issue, bryan-debaun-mcp/create-movie, bryan-debaun-mcp/create-videogame, bryan-debaun-mcp/delete-author, bryan-debaun-mcp/delete-book, bryan-debaun-mcp/delete-content-creator, bryan-debaun-mcp/delete-movie, bryan-debaun-mcp/delete-videogame, bryan-debaun-mcp/get-author, bryan-debaun-mcp/get-book, bryan-debaun-mcp/get-content-creator, bryan-debaun-mcp/get-movie, bryan-debaun-mcp/get-videogame, bryan-debaun-mcp/list-authors, bryan-debaun-mcp/list-books, bryan-debaun-mcp/list-content-creators, bryan-debaun-mcp/list-movies, bryan-debaun-mcp/list-videogames, bryan-debaun-mcp/update-author, bryan-debaun-mcp/update-book, bryan-debaun-mcp/update-content-creator, bryan-debaun-mcp/update-issue, bryan-debaun-mcp/update-movie, bryan-debaun-mcp/update-videogame, bryan-debaun-mcp/bulk-set-project-field-values, bryan-debaun-mcp/create-issue-in-project, bryan-debaun-mcp/create-project-field, bryan-debaun-mcp/delete-project-field, bryan-debaun-mcp/get-project-fields, bryan-debaun-mcp/get-project-status-options, bryan-debaun-mcp/list-labels, bryan-debaun-mcp/list-project-items, bryan-debaun-mcp/set-project-field-value, bryan-debaun-mcp/update-project-field, todo]
 
 handoffs:
   - label: "MCP Server Tester"

--- a/.github/agents/mcp-server-reviewer.agent.md
+++ b/.github/agents/mcp-server-reviewer.agent.md
@@ -2,16 +2,7 @@
 description: "Reviewer agent for MCP Server - review PRs, code quality, security, and test coverage. Use for: code review, pre-merge checks, architecture feedback, security audit of changes."
 name: MCP Server Reviewer
 model: "claude-sonnet-4-5"
-tools:
-  - 'execute/runInTerminal'
-  - 'execute/runTests'
-  - 'read/getChangedFiles'
-  - 'read/readFile'
-  - 'read/listCodeUsages'
-  - 'edit'
-  - 'search'
-  - 'agent'
-  - 'todo'
+tools: [execute/runInTerminal, read/readFile, agent/runSubagent, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, edit/editNotebook, edit/rename, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, search/usages, bryan-debaun-mcp/get-issue, bryan-debaun-mcp/get-open-issues, bryan-debaun-mcp/get-user, bryan-debaun-mcp/list-users, bryan-debaun-mcp/close-issue, bryan-debaun-mcp/create-author, bryan-debaun-mcp/create-book, bryan-debaun-mcp/create-content-creator, bryan-debaun-mcp/create-issue, bryan-debaun-mcp/create-movie, bryan-debaun-mcp/create-videogame, bryan-debaun-mcp/delete-author, bryan-debaun-mcp/delete-book, bryan-debaun-mcp/delete-content-creator, bryan-debaun-mcp/delete-movie, bryan-debaun-mcp/delete-videogame, bryan-debaun-mcp/get-author, bryan-debaun-mcp/get-book, bryan-debaun-mcp/get-content-creator, bryan-debaun-mcp/get-movie, bryan-debaun-mcp/get-videogame, bryan-debaun-mcp/list-authors, bryan-debaun-mcp/list-books, bryan-debaun-mcp/list-content-creators, bryan-debaun-mcp/list-movies, bryan-debaun-mcp/list-videogames, bryan-debaun-mcp/update-author, bryan-debaun-mcp/update-book, bryan-debaun-mcp/update-content-creator, bryan-debaun-mcp/update-issue, bryan-debaun-mcp/update-movie, bryan-debaun-mcp/update-videogame, bryan-debaun-mcp/bulk-set-project-field-values, bryan-debaun-mcp/create-issue-in-project, bryan-debaun-mcp/create-project-field, bryan-debaun-mcp/delete-project-field, bryan-debaun-mcp/get-project-fields, bryan-debaun-mcp/get-project-status-options, bryan-debaun-mcp/list-labels, bryan-debaun-mcp/list-project-items, bryan-debaun-mcp/set-project-field-value, bryan-debaun-mcp/update-project-field, todo]
 
 ---
 

--- a/.github/agents/mcp-server-support.agent.md
+++ b/.github/agents/mcp-server-support.agent.md
@@ -2,13 +2,7 @@
 description: "Support agent for MCP Server - clarify requirements, gather context, reproduce bugs, and prepare well-formed handoffs. Use when: requirements are ambiguous, a bug needs reproduction steps, an issue needs refinement before implementation, or you need a second opinion on approach."
 name: MCP Server Support
 model: "claude-sonnet-4-5"
-tools:
-  - 'execute/runInTerminal'
-  - 'read/readFile'
-  - 'search'
-  - 'web/fetch'
-  - 'agent'
-  - 'todo'
+tools: [execute/runInTerminal, read/readFile, agent/runSubagent, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, search/usages, web/fetch, bryan-debaun-mcp/get-issue, bryan-debaun-mcp/get-open-issues, bryan-debaun-mcp/get-user, bryan-debaun-mcp/list-users, bryan-debaun-mcp/close-issue, bryan-debaun-mcp/create-author, bryan-debaun-mcp/create-book, bryan-debaun-mcp/create-content-creator, bryan-debaun-mcp/create-issue, bryan-debaun-mcp/create-movie, bryan-debaun-mcp/create-videogame, bryan-debaun-mcp/delete-author, bryan-debaun-mcp/delete-book, bryan-debaun-mcp/delete-content-creator, bryan-debaun-mcp/delete-movie, bryan-debaun-mcp/delete-videogame, bryan-debaun-mcp/get-author, bryan-debaun-mcp/get-book, bryan-debaun-mcp/get-content-creator, bryan-debaun-mcp/get-movie, bryan-debaun-mcp/get-videogame, bryan-debaun-mcp/list-authors, bryan-debaun-mcp/list-books, bryan-debaun-mcp/list-content-creators, bryan-debaun-mcp/list-movies, bryan-debaun-mcp/list-videogames, bryan-debaun-mcp/update-author, bryan-debaun-mcp/update-book, bryan-debaun-mcp/update-content-creator, bryan-debaun-mcp/update-issue, bryan-debaun-mcp/update-movie, bryan-debaun-mcp/update-videogame, bryan-debaun-mcp/bulk-set-project-field-values, bryan-debaun-mcp/create-issue-in-project, bryan-debaun-mcp/create-project-field, bryan-debaun-mcp/delete-project-field, bryan-debaun-mcp/get-project-fields, bryan-debaun-mcp/get-project-status-options, bryan-debaun-mcp/list-labels, bryan-debaun-mcp/list-project-items, bryan-debaun-mcp/set-project-field-value, bryan-debaun-mcp/update-project-field, todo]
 
 ---
 

--- a/.github/agents/mcp-server-tester.agent.md
+++ b/.github/agents/mcp-server-tester.agent.md
@@ -2,16 +2,7 @@
 description: "Tester agent for MCP Server - write and run Vitest tests for MCP tools, Express routes, auth, Prisma, and adapters. Use for: adding unit/integration tests, diagnosing test failures, improving coverage, setting up mocks."
 name: MCP Server Tester
 model: "claude-sonnet-4-5"
-tools:
-  - 'execute/runTests'
-  - 'execute/runInTerminal'
-  - 'read/getChangedFiles'
-  - 'read/readFile'
-  - 'read/listCodeUsages'
-  - 'edit'
-  - 'search'
-  - 'agent'
-  - 'todo'
+tools: [execute/runInTerminal, read/readFile, agent/runSubagent, edit/createDirectory, edit/createFile, edit/createJupyterNotebook, edit/editFiles, edit/editNotebook, edit/rename, search/changes, search/codebase, search/fileSearch, search/listDirectory, search/textSearch, search/usages, bryan-debaun-mcp/get-issue, bryan-debaun-mcp/get-open-issues, bryan-debaun-mcp/get-user, bryan-debaun-mcp/list-users, bryan-debaun-mcp/close-issue, bryan-debaun-mcp/create-author, bryan-debaun-mcp/create-book, bryan-debaun-mcp/create-content-creator, bryan-debaun-mcp/create-issue, bryan-debaun-mcp/create-movie, bryan-debaun-mcp/create-videogame, bryan-debaun-mcp/delete-author, bryan-debaun-mcp/delete-book, bryan-debaun-mcp/delete-content-creator, bryan-debaun-mcp/delete-movie, bryan-debaun-mcp/delete-videogame, bryan-debaun-mcp/get-author, bryan-debaun-mcp/get-book, bryan-debaun-mcp/get-content-creator, bryan-debaun-mcp/get-movie, bryan-debaun-mcp/get-videogame, bryan-debaun-mcp/list-authors, bryan-debaun-mcp/list-books, bryan-debaun-mcp/list-content-creators, bryan-debaun-mcp/list-movies, bryan-debaun-mcp/list-videogames, bryan-debaun-mcp/update-author, bryan-debaun-mcp/update-book, bryan-debaun-mcp/update-content-creator, bryan-debaun-mcp/update-issue, bryan-debaun-mcp/update-movie, bryan-debaun-mcp/update-videogame, bryan-debaun-mcp/bulk-set-project-field-values, bryan-debaun-mcp/create-issue-in-project, bryan-debaun-mcp/create-project-field, bryan-debaun-mcp/delete-project-field, bryan-debaun-mcp/get-project-fields, bryan-debaun-mcp/get-project-status-options, bryan-debaun-mcp/list-labels, bryan-debaun-mcp/list-project-items, bryan-debaun-mcp/set-project-field-value, bryan-debaun-mcp/update-project-field, todo]
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,31 +21,38 @@ An extensible Model Context Protocol (MCP) server for VS Code Copilot with GitHu
 |------|-------------|------------|
 | `get-open-issues` | List open issues from a repository | `repo`, `labels?`, `limit?` |
 | `get-issue` | Get full details of a specific issue | `repo`, `issueNumber` |
-| `create-issue` | Create a new issue | `repo`, `title`, `body?`, `labels?` |
-| `update-issue` | Update an issue or add a comment | `repo`, `issueNumber`, `title?`, `body?`, `labels?`, `comment?` |
+| `create-issue` | Create a new issue | `repo`, `title`, `body?`, `labels?`, `assignees?`, `milestone?` |
+| `update-issue` | Update an issue or add a comment | `repo`, `issueNumber`, `title?`, `body?`, `labels?`, `removeLabels?`, `assignees?`, `milestone?`, `state?`, `stateReason?`, `comment?` |
 | `close-issue` | Close an issue with optional comment | `repo`, `issueNumber`, `comment?` |
+| `list-labels` | List all labels defined in a repository | `repo` |
 
 ### GitHub Projects V2
 
-Manage GitHub Projects V2 custom fields and values. Supports TEXT, NUMBER, DATE, SINGLE_SELECT, and ITERATION field types.
+Manage GitHub Projects V2 boards — list items, set field values, and atomically create issues straight onto the board. Requires a GitHub token with `project` scope.
 
-**Prerequisites**: GitHub token with `project` scope. Run `gh auth refresh -s project` to add the scope.
+#### Board & Items
+
+| Tool | Description | Parameters |
+|------|-------------|------------|
+| `list-project-items` | List all items on a board, grouped by Status | `owner`, `projectNumber` |
+| `get-project-status-options` | Get available options for the Status field | `owner`, `projectNumber` |
+| `create-issue-in-project` | Create an issue and add it to the board in one call | `owner`, `repo`, `projectNumber`, `title`, `body?`, `labels?`, `status?` |
 
 #### Field Management
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
-| `get-project-fields` | List all custom fields in a project with types and options | `owner`, `projectNumber` |
+| `get-project-fields` | List all custom fields with types and options | `owner`, `projectNumber` |
 | `create-project-field` | Create a new custom field | `owner`, `projectNumber`, `name`, `dataType`, `options?` |
 | `update-project-field` | Update field name or SINGLE_SELECT options | `owner`, `projectNumber`, `fieldName`, `newName?`, `addOptions?`, `removeOptions?` |
-| `delete-project-field` | Delete a custom field from the project | `owner`, `projectNumber`, `fieldName` |
+| `delete-project-field` | Delete a custom field | `owner`, `projectNumber`, `fieldName` |
 
 #### Value Operations
 
 | Tool | Description | Parameters |
 |------|-------------|------------|
 | `set-project-field-value` | Set a single field value on an issue | `owner`, `repo`, `projectNumber`, `issueNumber`, `fieldName`, `value` |
-| `bulk-set-project-field-values` | Set multiple fields on multiple issues (bulk operation) | `owner`, `repo`, `projectNumber`, `updates[]` |
+| `bulk-set-project-field-values` | Set multiple fields on multiple issues | `owner`, `repo`, `projectNumber`, `updates[]` |
 
 **Supported Field Types**:
 
@@ -144,19 +151,8 @@ Use this spec to generate client SDKs for any language using tools like [OpenAPI
 ## Prerequisites
 
 - **Node.js 20+**: Required runtime
-- **GitHub CLI (`gh`)**: Must be installed and authenticated
-- **PostgreSQL Database**: Required for book catalog features (optional for GitHub tools only)
-
-  ```bash
-  # Install gh CLI (if not already installed)
-  winget install --id GitHub.cli
-  
-  # Authenticate with GitHub
-  gh auth login
-  
-  # For GitHub Projects V2 tools, add project scope
-  gh auth refresh -s project
-  ```
+- **PostgreSQL Database**: Required for book/movie/game catalog features (optional for GitHub tools only)
+- **`GITHUB_TOKEN`**: A GitHub personal access token (PAT) or fine-grained token with `repo` and `project` scopes. Set via the `GITHUB_TOKEN` environment variable.
 
 ## Environment Variables
 
@@ -165,6 +161,9 @@ Create a `.env` file in the project root:
 ```env
 # Required for database features
 DATABASE_URL=postgresql://user:password@localhost:5432/dbname
+
+# Required for GitHub Issues and Projects tools
+GITHUB_TOKEN=ghp_your_personal_access_token
 
 # Optional: For HTTP MCP transport authentication
 # When `MCP_API_KEY` is set, MCP transport endpoints (eg. `/mcp`) and DB-dependent routes (`/api/*` for books/authors/ratings) require `Authorization: Bearer <MCP_API_KEY>`.
@@ -233,23 +232,60 @@ ADMIN_DEBUG_ENABLED=true
 
 ## VS Code Configuration
 
-### Option 1: Workspace Configuration (Recommended)
+### Option 1: Remote (Deployed Server — Recommended)
 
-Create or update `.vscode/mcp.json` in your workspace:
+Connect any VS Code installation to the deployed Render instance over HTTP Stream. Open your user MCP config (Command Palette → **MCP: Open User Configuration**) and add:
 
 ```json
 {
   "servers": {
     "bryan-debaun-mcp": {
+      "type": "http",
+      "url": "https://mcp-server.onrender.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:mcpApiKey}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "id": "mcpApiKey",
+      "type": "promptString",
+      "description": "MCP API Key",
+      "password": true
+    }
+  ]
+}
+```
+
+VS Code will prompt once for the `MCP_API_KEY` the first time the server connects. The key is stored securely in VS Code's secret storage and reused for subsequent sessions.
+
+> **Note for other apps**: Any MCP client that supports HTTP Stream transport can connect the same way. Point it at `https://mcp-server.onrender.com/mcp` with `Authorization: Bearer <MCP_API_KEY>`.
+
+---
+
+### Option 2: Local (stdio — for development)
+
+Run the server from a local build. Useful when iterating on the server itself.
+
+Create or update `.vscode/mcp.json` in your workspace, or add to your VS Code user MCP config:
+
+```json
+{
+  "servers": {
+    "bryan-debaun-mcp-local": {
       "type": "stdio",
       "command": "node",
-      "args": ["C:/Users/brndb/mcp-server/dist/index.js"]
+      "args": ["C:/path/to/mcp-server/dist/index.js"],
+      "env": {
+        "MCP_TRANSPORT": "stdio"
+      }
     }
   }
 }
 ```
 
-### Option 2: User Configuration
+### Option 3: Legacy User Configuration
 
 Add to your VS Code user settings (use Command Palette → "MCP: Open User Configuration"):
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,15 +36,15 @@
                 "@types/supertest": "^2.0.12",
                 "@types/swagger-ui-express": "^4.1.8",
                 "@types/ws": "^8.18.1",
-                "@typescript-eslint/eslint-plugin": "^6.12.0",
-                "@typescript-eslint/parser": "^6.12.0",
-                "eslint": "^8.48.0",
+                "@typescript-eslint/eslint-plugin": "^8.58.1",
+                "@typescript-eslint/parser": "^8.58.1",
+                "eslint": "^8.57.1",
                 "prisma": "^7.3.0",
                 "supertest": "^6.3.3",
                 "ts-node": "^10.9.1",
                 "tsx": "^4.21.0",
                 "typescript": "^5.4.0",
-                "vitest": "^2.0.0"
+                "vitest": "^3.2.4"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -75,43 +75,6 @@
                 "node": ">=6.9.0"
             }
         },
-        "node_modules/@chevrotain/cst-dts-gen": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-10.5.0.tgz",
-            "integrity": "sha512-lhmC/FyqQ2o7pGK4Om+hzuDrm9rhFYIJ/AXoQBeongmn870Xeb0L6oGEiuR8nohFNL5sMaQEJWCxr1oIVIVXrw==",
-            "devOptional": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/gast": "10.5.0",
-                "@chevrotain/types": "10.5.0",
-                "lodash": "4.17.21"
-            }
-        },
-        "node_modules/@chevrotain/gast": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-10.5.0.tgz",
-            "integrity": "sha512-pXdMJ9XeDAbgOWKuD1Fldz4ieCs6+nLNmyVhe2gZVqoO7v8HXuHYs5OV2EzUtbuai37TlOAQHrTDvxMnvMJz3A==",
-            "devOptional": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/types": "10.5.0",
-                "lodash": "4.17.21"
-            }
-        },
-        "node_modules/@chevrotain/types": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-10.5.0.tgz",
-            "integrity": "sha512-f1MAia0x/pAVPWH/T73BJVyO2XU5tI4/iE7cnxb7tqdNTNhQI3Uq3XkqcoteTmD4t1aM0LbHCJOhgIDn07kl2A==",
-            "devOptional": true,
-            "license": "Apache-2.0"
-        },
-        "node_modules/@chevrotain/utils": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-10.5.0.tgz",
-            "integrity": "sha512-hBzuU5+JjB2cqNZyszkDHZgOSrUUT8V3dhgRl8Q9Gp6dAj/H5+KILGjbhDpc3Iy9qmqlm/akuOI2ut9VUtzJxQ==",
-            "devOptional": true,
-            "license": "Apache-2.0"
-        },
         "node_modules/@cspotcode/source-map-support": {
             "version": "0.8.1",
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -126,40 +89,40 @@
             }
         },
         "node_modules/@electric-sql/pglite": {
-            "version": "0.3.15",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.3.15.tgz",
-            "integrity": "sha512-Cj++n1Mekf9ETfdc16TlDi+cDDQF0W7EcbyRHYOAeZdsAe8M/FJg18itDTSwyHfar2WIezawM9o0EKaRGVKygQ==",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.4.1.tgz",
+            "integrity": "sha512-mZ9NzzUSYPOCnxHH1oAHPRzoMFJHY472raDKwXl/+6oPbpdJ7g8LsCN4FSaIIfkiCKHhb3iF/Zqo3NYxaIhU7Q==",
             "devOptional": true,
             "license": "Apache-2.0",
             "peer": true
         },
         "node_modules/@electric-sql/pglite-socket": {
-            "version": "0.0.20",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.0.20.tgz",
-            "integrity": "sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-socket/-/pglite-socket-0.1.1.tgz",
+            "integrity": "sha512-p2hoXw3Z3LQHwTeikdZNsFBOvXGqKY2hk51BBw+8NKND8eoH+8LFOtW9Z8CQKmTJ2qqGYu82ipqiyFZOTTXNfw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "bin": {
                 "pglite-server": "dist/scripts/server.js"
             },
             "peerDependencies": {
-                "@electric-sql/pglite": "0.3.15"
+                "@electric-sql/pglite": "0.4.1"
             }
         },
         "node_modules/@electric-sql/pglite-tools": {
-            "version": "0.2.20",
-            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.2.20.tgz",
-            "integrity": "sha512-BK50ZnYa3IG7ztXhtgYf0Q7zijV32Iw1cYS8C+ThdQlwx12V5VZ9KRJ42y82Hyb4PkTxZQklVQA9JHyUlex33A==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@electric-sql/pglite-tools/-/pglite-tools-0.3.1.tgz",
+            "integrity": "sha512-C+T3oivmy9bpQvSxVqXA1UDY8cB9Eb9vZHL9zxWwEUfDixbXv4G3r2LjoTdR33LD8aomR3O9ZXEO3XEwr/cUCA==",
             "devOptional": true,
             "license": "Apache-2.0",
             "peerDependencies": {
-                "@electric-sql/pglite": "0.3.15"
+                "@electric-sql/pglite": "0.4.1"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
             "cpu": [
                 "ppc64"
             ],
@@ -170,13 +133,13 @@
                 "aix"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
-            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
             "cpu": [
                 "arm"
             ],
@@ -187,13 +150,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
-            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
             "cpu": [
                 "arm64"
             ],
@@ -204,13 +167,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
-            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
             "cpu": [
                 "x64"
             ],
@@ -221,13 +184,13 @@
                 "android"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
-            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
             "cpu": [
                 "arm64"
             ],
@@ -238,13 +201,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
-            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
             "cpu": [
                 "x64"
             ],
@@ -255,13 +218,13 @@
                 "darwin"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
-            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
             "cpu": [
                 "arm64"
             ],
@@ -272,13 +235,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
-            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
             "cpu": [
                 "x64"
             ],
@@ -289,13 +252,13 @@
                 "freebsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
-            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
             "cpu": [
                 "arm"
             ],
@@ -306,13 +269,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
-            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
             "cpu": [
                 "arm64"
             ],
@@ -323,13 +286,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
-            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
             "cpu": [
                 "ia32"
             ],
@@ -340,13 +303,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
-            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
             "cpu": [
                 "loong64"
             ],
@@ -357,13 +320,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
-            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
             "cpu": [
                 "mips64el"
             ],
@@ -374,13 +337,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
-            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -391,13 +354,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
-            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
             "cpu": [
                 "riscv64"
             ],
@@ -408,13 +371,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
-            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
             "cpu": [
                 "s390x"
             ],
@@ -425,13 +388,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
-            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
             "cpu": [
                 "x64"
             ],
@@ -442,13 +405,13 @@
                 "linux"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/netbsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
             "cpu": [
                 "arm64"
             ],
@@ -463,9 +426,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
             "cpu": [
                 "x64"
             ],
@@ -476,13 +439,13 @@
                 "netbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/openbsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
             "cpu": [
                 "arm64"
             ],
@@ -497,9 +460,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
-            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
             "cpu": [
                 "x64"
             ],
@@ -510,13 +473,13 @@
                 "openbsd"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/openharmony-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.2.tgz",
-            "integrity": "sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
             "cpu": [
                 "arm64"
             ],
@@ -531,9 +494,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
-            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
             "cpu": [
                 "x64"
             ],
@@ -544,13 +507,13 @@
                 "sunos"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
-            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
             "cpu": [
                 "arm64"
             ],
@@ -561,13 +524,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
-            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
             "cpu": [
                 "ia32"
             ],
@@ -578,13 +541,13 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
-            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
             "cpu": [
                 "x64"
             ],
@@ -595,7 +558,7 @@
                 "win32"
             ],
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -652,9 +615,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -669,9 +632,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -687,9 +650,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint/eslintrc/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -795,9 +758,9 @@
             }
         },
         "node_modules/@hapi/content": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.0.tgz",
-            "integrity": "sha512-CEhs7j+H0iQffKfe5Htdak5LBOz/Qc8TRh51cF+BFv0qnuph3Em4pjGVzJMkI2gfTDdlJKWJISGWS1rK34POGA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@hapi/content/-/content-6.0.1.tgz",
+            "integrity": "sha512-lQ2vOoFMNYxwKVnKf+3Pi3PfoviM4EJYlT9JbrBPfEc0xKMiVDqqXF8UTE1S1oKhHQliWSP5t6zTKNlmaXBGcQ==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@hapi/boom": "^10.0.0"
@@ -1026,9 +989,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.9",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-            "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+            "version": "1.19.13",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+            "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.14.1"
@@ -1054,9 +1017,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1065,9 +1028,9 @@
             }
         },
         "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1302,10 +1265,17 @@
                 "@jridgewell/sourcemap-codec": "^1.4.10"
             }
         },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "devOptional": true,
+            "license": "MIT"
+        },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.25.3",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.3.tgz",
-            "integrity": "sha512-vsAMBMERybvYgKbg/l4L1rhS7VXV1c0CtyJg72vwxONVX0l4ZfKVAnZEWTQixJGTzKnELjQ59e4NbdFDALRiAQ==",
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
             "license": "MIT",
             "dependencies": {
                 "@hono/node-server": "^1.19.9",
@@ -1316,14 +1286,15 @@
                 "cross-spawn": "^7.0.5",
                 "eventsource": "^3.0.2",
                 "eventsource-parser": "^3.0.0",
-                "express": "^5.0.1",
-                "express-rate-limit": "^7.5.0",
-                "jose": "^6.1.1",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
                 "json-schema-typed": "^8.0.2",
                 "pkce-challenge": "^5.0.0",
                 "raw-body": "^3.0.0",
                 "zod": "^3.25 || ^4.0",
-                "zod-to-json-schema": "^3.25.0"
+                "zod-to-json-schema": "^3.25.1"
             },
             "engines": {
                 "node": ">=18"
@@ -1585,20 +1556,6 @@
             },
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/@mrleebo/prisma-ast": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@mrleebo/prisma-ast/-/prisma-ast-0.13.1.tgz",
-            "integrity": "sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==",
-            "devOptional": true,
-            "license": "MIT",
-            "dependencies": {
-                "chevrotain": "^10.5.0",
-                "lilconfig": "^2.1.0"
-            },
-            "engines": {
-                "node": ">=16"
             }
         },
         "node_modules/@noble/hashes": {
@@ -1869,15 +1826,15 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/config": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.3.0.tgz",
-            "integrity": "sha512-QyMV67+eXF7uMtKxTEeQqNu/Be7iH+3iDZOQZW5ttfbSwBamCSdwPszA0dum+Wx27I7anYTPLmRmMORKViSW1A==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.7.0.tgz",
+            "integrity": "sha512-hmPI3tKLO2aP0Y5vugbjcnA9qqlfJndiT6ds4tw28U5hNHLWg+mHJEWAhjsSPgxjtmxhJ/EDIeIlyh+3Us0OPg==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "c12": "3.1.0",
                 "deepmerge-ts": "7.1.5",
-                "effect": "3.18.4",
+                "effect": "3.20.0",
                 "empathic": "2.0.0"
             }
         },
@@ -1888,22 +1845,22 @@
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/dev": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.20.0.tgz",
-            "integrity": "sha512-ovlBYwWor0OzG+yH4J3Ot+AneD818BttLA+Ii7wjbcLHUrnC4tbUPVGyNd3c/+71KETPKZfjhkTSpdS15dmXNQ==",
+            "version": "0.24.3",
+            "resolved": "https://registry.npmjs.org/@prisma/dev/-/dev-0.24.3.tgz",
+            "integrity": "sha512-ffHlQuKXZiaDt9Go0OnCTdJZrHxK0k7omJKNV86/VjpsXu5EIHZLK0T7JSWgvNlJwh56kW9JFu9v0qJciFzepg==",
             "devOptional": true,
             "license": "ISC",
             "dependencies": {
-                "@electric-sql/pglite": "0.3.15",
-                "@electric-sql/pglite-socket": "0.0.20",
-                "@electric-sql/pglite-tools": "0.2.20",
-                "@hono/node-server": "1.19.9",
-                "@mrleebo/prisma-ast": "0.13.1",
+                "@electric-sql/pglite": "0.4.1",
+                "@electric-sql/pglite-socket": "0.1.1",
+                "@electric-sql/pglite-tools": "0.3.1",
+                "@hono/node-server": "1.19.11",
                 "@prisma/get-platform": "7.2.0",
                 "@prisma/query-plan-executor": "7.2.0",
+                "@prisma/streams-local": "0.1.2",
                 "foreground-child": "3.3.1",
                 "get-port-please": "3.2.0",
-                "hono": "4.11.4",
+                "hono": "^4.12.8",
                 "http-status-codes": "2.3.0",
                 "pathe": "2.0.3",
                 "proper-lockfile": "4.1.2",
@@ -1913,22 +1870,18 @@
                 "zeptomatch": "2.1.0"
             }
         },
-        "node_modules/@prisma/dev/node_modules/hono": {
-            "version": "4.11.4",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.4.tgz",
-            "integrity": "sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==",
+        "node_modules/@prisma/dev/node_modules/@hono/node-server": {
+            "version": "1.19.11",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+            "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
-                "node": ">=16.9.0"
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
             }
-        },
-        "node_modules/@prisma/dev/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "devOptional": true,
-            "license": "MIT"
         },
         "node_modules/@prisma/driver-adapter-utils": {
             "version": "7.3.0",
@@ -1940,56 +1893,70 @@
             }
         },
         "node_modules/@prisma/engines": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.3.0.tgz",
-            "integrity": "sha512-cWRQoPDXPtR6stOWuWFZf9pHdQ/o8/QNWn0m0zByxf5Kd946Q875XdEJ52pEsX88vOiXUmjuPG3euw82mwQNMg==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.7.0.tgz",
+            "integrity": "sha512-7fmcbT7HHXBq/b+3h/dO1JI3fd8l8q7erf7xP7pRprh58hmSSnG8mg9K3yjW3h9WaHWUwngVFpSxxxivaitQ2w==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.3.0",
-                "@prisma/engines-version": "7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735",
-                "@prisma/fetch-engine": "7.3.0",
-                "@prisma/get-platform": "7.3.0"
+                "@prisma/debug": "7.7.0",
+                "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+                "@prisma/fetch-engine": "7.7.0",
+                "@prisma/get-platform": "7.7.0"
             }
         },
         "node_modules/@prisma/engines-version": {
-            "version": "7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735",
-            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735.tgz",
-            "integrity": "sha512-IH2va2ouUHihyiTTRW889LjKAl1CusZOvFfZxCDNpjSENt7g2ndFsK0vdIw/72v7+jCN6YgkHmdAP/BI7SDgyg==",
+            "version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+            "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711.tgz",
+            "integrity": "sha512-r51DLcJ8bDRSrBEJF3J4cinoWyGA7rfP2mG6lD90VqIbGNOkbfcLcXalSVjq5Y6brQS3vcjrq4GbyUb1Cb7vkw==",
+            "devOptional": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@prisma/engines/node_modules/@prisma/debug": {
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
+            "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
             "devOptional": true,
             "license": "Apache-2.0"
         },
         "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.3.0.tgz",
-            "integrity": "sha512-N7c6m4/I0Q6JYmWKP2RCD/sM9eWiyCPY98g5c0uEktObNSZnugW2U/PO+pwL0UaqzxqTXt7gTsYsb0FnMnJNbg==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
+            "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.3.0"
+                "@prisma/debug": "7.7.0"
             }
         },
         "node_modules/@prisma/fetch-engine": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.3.0.tgz",
-            "integrity": "sha512-Mm0F84JMqM9Vxk70pzfNpGJ1lE4hYjOeLMu7nOOD1i83nvp8MSAcFYBnHqLvEZiA6onUR+m8iYogtOY4oPO5lQ==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.7.0.tgz",
+            "integrity": "sha512-TfyzveBQoK4xALzsTpVhB/0KG1N8zOK0ap+RnBMkzGUu3f98fnQ4QtXa2wlKPhsO2X8a3N5ugFQgcKNoHGmDfw==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.3.0",
-                "@prisma/engines-version": "7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735",
-                "@prisma/get-platform": "7.3.0"
+                "@prisma/debug": "7.7.0",
+                "@prisma/engines-version": "7.6.0-1.75cbdc1eb7150937890ad5465d861175c6624711",
+                "@prisma/get-platform": "7.7.0"
             }
         },
+        "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.7.0.tgz",
+            "integrity": "sha512-12J62XdqCmpiwJHhHdQxZeY3ckVCWIFmcJP8hg5dPTceeiQ0wiojXGFYTluKqFQfu46fRLgb/rLALZMAx3+dTA==",
+            "devOptional": true,
+            "license": "Apache-2.0"
+        },
         "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.3.0.tgz",
-            "integrity": "sha512-N7c6m4/I0Q6JYmWKP2RCD/sM9eWiyCPY98g5c0uEktObNSZnugW2U/PO+pwL0UaqzxqTXt7gTsYsb0FnMnJNbg==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.7.0.tgz",
+            "integrity": "sha512-MEUNzvKxvYnJ7kgvd6oNRnMmmiGNS9TYLB2weMeIXplnHdL/UWEGnvavYGnN7KLJ2n0iI4dDAyzSkHI3c7AscQ==",
             "devOptional": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@prisma/debug": "7.3.0"
+                "@prisma/debug": "7.7.0"
             }
         },
         "node_modules/@prisma/get-platform": {
@@ -2016,22 +1983,194 @@
             "devOptional": true,
             "license": "Apache-2.0"
         },
-        "node_modules/@prisma/studio-core": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.13.1.tgz",
-            "integrity": "sha512-agdqaPEePRHcQ7CexEfkX1RvSH9uWDb6pXrZnhCRykhDFAV0/0P3d07WtfiY8hZWb7oRU4v+NkT4cGFHkQJIPg==",
+        "node_modules/@prisma/streams-local": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@prisma/streams-local/-/streams-local-0.1.2.tgz",
+            "integrity": "sha512-l49yTxKKF2odFxaAXTmwmkBKL3+bVQ1tFOooGifu4xkdb9NMNLxHj27XAhTylWZod8I+ISGM5erU1xcl/oBCtg==",
             "devOptional": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "ajv": "^8.12.0",
+                "better-result": "^2.7.0",
+                "env-paths": "^3.0.0",
+                "proper-lockfile": "^4.1.2"
+            },
+            "engines": {
+                "bun": ">=1.3.6",
+                "node": ">=22.0.0"
+            }
+        },
+        "node_modules/@prisma/studio-core": {
+            "version": "0.27.3",
+            "resolved": "https://registry.npmjs.org/@prisma/studio-core/-/studio-core-0.27.3.tgz",
+            "integrity": "sha512-AADjNFPdsrglxHQVTmHFqv6DuKQZ5WY4p5/gVFY017twvNrSwpLJ9lqUbYYxEu2W7nbvVxTZA8deJ8LseNALsw==",
+            "devOptional": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@radix-ui/react-toggle": "1.1.10",
+                "chart.js": "4.5.1"
+            },
+            "engines": {
+                "node": "^20.19 || ^22.12 || >=24.0",
+                "pnpm": "8"
+            },
             "peerDependencies": {
                 "@types/react": "^18.0.0 || ^19.0.0",
                 "react": "^18.0.0 || ^19.0.0",
                 "react-dom": "^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/@radix-ui/primitive": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+            "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+            "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/@radix-ui/react-compose-refs": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+            "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+            "devOptional": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-primitive": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+            "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-slot": "1.2.3"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-slot": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+            "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-compose-refs": "1.1.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-toggle": {
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-toggle/-/react-toggle-1.1.10.tgz",
+            "integrity": "sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/primitive": "1.1.3",
+                "@radix-ui/react-primitive": "2.1.3",
+                "@radix-ui/react-use-controllable-state": "1.2.2"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "@types/react-dom": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+                "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-controllable-state": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+            "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-effect-event": "0.0.2",
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-effect-event": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+            "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@radix-ui/react-use-layout-effect": "1.1.1"
+            },
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@radix-ui/react-use-layout-effect": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+            "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+            "devOptional": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "@types/react": "*",
+                "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.56.0.tgz",
-            "integrity": "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+            "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
             "cpu": [
                 "arm"
             ],
@@ -2043,9 +2182,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.56.0.tgz",
-            "integrity": "sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+            "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
             "cpu": [
                 "arm64"
             ],
@@ -2057,9 +2196,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.56.0.tgz",
-            "integrity": "sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+            "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
             "cpu": [
                 "arm64"
             ],
@@ -2071,9 +2210,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.56.0.tgz",
-            "integrity": "sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+            "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
             "cpu": [
                 "x64"
             ],
@@ -2085,9 +2224,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.56.0.tgz",
-            "integrity": "sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+            "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
             "cpu": [
                 "arm64"
             ],
@@ -2099,9 +2238,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.56.0.tgz",
-            "integrity": "sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+            "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
             "cpu": [
                 "x64"
             ],
@@ -2113,9 +2252,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.56.0.tgz",
-            "integrity": "sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+            "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
             "cpu": [
                 "arm"
             ],
@@ -2127,9 +2266,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.56.0.tgz",
-            "integrity": "sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+            "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
             "cpu": [
                 "arm"
             ],
@@ -2141,9 +2280,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.56.0.tgz",
-            "integrity": "sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+            "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2155,9 +2294,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.56.0.tgz",
-            "integrity": "sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+            "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
             "cpu": [
                 "arm64"
             ],
@@ -2169,9 +2308,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-gnu": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.56.0.tgz",
-            "integrity": "sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+            "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
             "cpu": [
                 "loong64"
             ],
@@ -2183,9 +2322,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-loong64-musl": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.56.0.tgz",
-            "integrity": "sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+            "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
             "cpu": [
                 "loong64"
             ],
@@ -2197,9 +2336,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.56.0.tgz",
-            "integrity": "sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+            "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
             "cpu": [
                 "ppc64"
             ],
@@ -2211,9 +2350,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-ppc64-musl": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.56.0.tgz",
-            "integrity": "sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+            "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
             "cpu": [
                 "ppc64"
             ],
@@ -2225,9 +2364,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.56.0.tgz",
-            "integrity": "sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+            "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
             "cpu": [
                 "riscv64"
             ],
@@ -2239,9 +2378,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.56.0.tgz",
-            "integrity": "sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+            "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
             "cpu": [
                 "riscv64"
             ],
@@ -2253,9 +2392,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.56.0.tgz",
-            "integrity": "sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+            "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
             "cpu": [
                 "s390x"
             ],
@@ -2267,9 +2406,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz",
-            "integrity": "sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+            "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
             "cpu": [
                 "x64"
             ],
@@ -2281,9 +2420,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.56.0.tgz",
-            "integrity": "sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+            "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
             "cpu": [
                 "x64"
             ],
@@ -2295,9 +2434,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openbsd-x64": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.56.0.tgz",
-            "integrity": "sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+            "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
             "cpu": [
                 "x64"
             ],
@@ -2309,9 +2448,9 @@
             ]
         },
         "node_modules/@rollup/rollup-openharmony-arm64": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.56.0.tgz",
-            "integrity": "sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+            "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
             "cpu": [
                 "arm64"
             ],
@@ -2323,9 +2462,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.56.0.tgz",
-            "integrity": "sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+            "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
             "cpu": [
                 "arm64"
             ],
@@ -2337,9 +2476,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.56.0.tgz",
-            "integrity": "sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+            "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
             "cpu": [
                 "ia32"
             ],
@@ -2351,9 +2490,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-gnu": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.56.0.tgz",
-            "integrity": "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+            "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
             "cpu": [
                 "x64"
             ],
@@ -2365,9 +2504,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.56.0.tgz",
-            "integrity": "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+            "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
             "cpu": [
                 "x64"
             ],
@@ -2475,12 +2614,12 @@
             }
         },
         "node_modules/@tsoa/cli/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
             "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^2.0.2"
             },
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2527,6 +2666,17 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
         "node_modules/@types/connect": {
             "version": "3.4.38",
             "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -2570,6 +2720,13 @@
             "dependencies": {
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
@@ -2651,13 +2808,6 @@
                 "expect": "^30.0.0",
                 "pretty-format": "^30.0.0"
             }
-        },
-        "node_modules/@types/json-schema": {
-            "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/keygrip": {
             "version": "1.0.6",
@@ -2754,22 +2904,15 @@
             "license": "MIT"
         },
         "node_modules/@types/react": {
-            "version": "19.2.10",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
-            "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
+            "version": "19.2.14",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+            "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "devOptional": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
-        },
-        "node_modules/@types/semver": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
-            "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@types/send": {
             "version": "1.2.1",
@@ -2870,125 +3013,160 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
-            "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+            "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/type-utils": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
-                "debug": "^4.3.4",
-                "graphemer": "^1.4.0",
-                "ignore": "^5.2.4",
+                "@eslint-community/regexpp": "^4.12.2",
+                "@typescript-eslint/scope-manager": "8.58.1",
+                "@typescript-eslint/type-utils": "8.58.1",
+                "@typescript-eslint/utils": "8.58.1",
+                "@typescript-eslint/visitor-keys": "8.58.1",
+                "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "@typescript-eslint/parser": "^8.58.1",
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-            "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+            "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
             "dev": true,
-            "license": "BSD-2-Clause",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
-                "debug": "^4.3.4"
+                "@typescript-eslint/scope-manager": "8.58.1",
+                "@typescript-eslint/types": "8.58.1",
+                "@typescript-eslint/typescript-estree": "8.58.1",
+                "@typescript-eslint/visitor-keys": "8.58.1",
+                "debug": "^4.4.3"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+            "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.58.1",
+                "@typescript-eslint/types": "^8.58.1",
+                "debug": "^4.4.3"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-            "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+            "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0"
+                "@typescript-eslint/types": "8.58.1",
+                "@typescript-eslint/visitor-keys": "8.58.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
-            "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+            "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
             "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "@typescript-eslint/utils": "6.21.0",
-                "debug": "^4.3.4",
-                "ts-api-utils": "^1.0.1"
-            },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/type-utils": {
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+            "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.58.1",
+                "@typescript-eslint/typescript-estree": "8.58.1",
+                "@typescript-eslint/utils": "8.58.1",
+                "debug": "^4.4.3",
+                "ts-api-utils": "^2.5.0"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-            "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+            "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -2996,76 +3174,86 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-            "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-            "dev": true,
-            "license": "BSD-2-Clause",
-            "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/visitor-keys": "6.21.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "minimatch": "9.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
-            "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+            "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@types/json-schema": "^7.0.12",
-                "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.21.0",
-                "@typescript-eslint/types": "6.21.0",
-                "@typescript-eslint/typescript-estree": "6.21.0",
-                "semver": "^7.5.4"
+                "@typescript-eslint/project-service": "8.58.1",
+                "@typescript-eslint/tsconfig-utils": "8.58.1",
+                "@typescript-eslint/types": "8.58.1",
+                "@typescript-eslint/visitor-keys": "8.58.1",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "typescript": ">=4.8.4 <6.1.0"
             }
         },
-        "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.21.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-            "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+            "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.21.0",
-                "eslint-visitor-keys": "^3.4.1"
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.58.1",
+                "@typescript-eslint/types": "8.58.1",
+                "@typescript-eslint/typescript-estree": "8.58.1"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.58.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+            "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.58.1",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -3076,38 +3264,39 @@
             "license": "ISC"
         },
         "node_modules/@vitest/expect": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
-            "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+            "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "2.1.9",
-                "@vitest/utils": "2.1.9",
-                "chai": "^5.1.2",
-                "tinyrainbow": "^1.2.0"
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/mocker": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
-            "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/spy": "2.1.9",
+                "@vitest/spy": "3.2.4",
                 "estree-walker": "^3.0.3",
-                "magic-string": "^0.30.12"
+                "magic-string": "^0.30.17"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "msw": "^2.4.9",
-                "vite": "^5.0.0"
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "peerDependenciesMeta": {
                 "msw": {
@@ -3119,70 +3308,71 @@
             }
         },
         "node_modules/@vitest/pretty-format": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
-            "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+            "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tinyrainbow": "^1.2.0"
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
-            "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/utils": "2.1.9",
-                "pathe": "^1.1.2"
+                "@vitest/utils": "3.2.4",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
-            "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "2.1.9",
-                "magic-string": "^0.30.12",
-                "pathe": "^1.1.2"
+                "@vitest/pretty-format": "3.2.4",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/spy": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
-            "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+            "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "tinyspy": "^3.0.2"
+                "tinyspy": "^4.0.3"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
-            "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+            "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/pretty-format": "2.1.9",
-                "loupe": "^3.1.2",
-                "tinyrainbow": "^1.2.0"
+                "@vitest/pretty-format": "3.2.4",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
@@ -3239,9 +3429,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-            "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+            "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -3315,16 +3505,6 @@
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "license": "MIT"
         },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/asap": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
@@ -3370,6 +3550,13 @@
             "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
             "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
             "license": "Apache-2.0"
+        },
+        "node_modules/better-result": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/better-result/-/better-result-2.8.2.tgz",
+            "integrity": "sha512-YOf0VSj5nUPI27doTtXF+BBnsiRq3qY7avHqfIWnppxTLGyvkLq1QV2RTxkwoZwJ60ywLfZ0raFF4J/G886i7A==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/bintrees": {
             "version": "1.0.2",
@@ -3444,9 +3631,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+            "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0"
@@ -3515,13 +3702,6 @@
             "funding": {
                 "url": "https://dotenvx.com"
             }
-        },
-        "node_modules/c12/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "devOptional": true,
-            "license": "MIT"
         },
         "node_modules/cac": {
             "version": "6.7.14",
@@ -3606,6 +3786,19 @@
                 "url": "https://github.com/chalk/chalk?sponsor=1"
             }
         },
+        "node_modules/chart.js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+            "devOptional": true,
+            "license": "MIT",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
+            }
+        },
         "node_modules/check-error": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
@@ -3614,21 +3807,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 16"
-            }
-        },
-        "node_modules/chevrotain": {
-            "version": "10.5.0",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-10.5.0.tgz",
-            "integrity": "sha512-Pkv5rBY3+CsHOYfV5g/Vs5JY9WTHHDEKOlohI2XeygaZhUeqhAlldZ8Hz9cRmxu709bvS08YzxHdTPHhffc13A==",
-            "devOptional": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@chevrotain/cst-dts-gen": "10.5.0",
-                "@chevrotain/gast": "10.5.0",
-                "@chevrotain/types": "10.5.0",
-                "@chevrotain/utils": "10.5.0",
-                "lodash": "4.17.21",
-                "regexp-to-ast": "0.5.0"
             }
         },
         "node_modules/chokidar": {
@@ -3736,9 +3914,9 @@
             "license": "MIT"
         },
         "node_modules/confbox": {
-            "version": "0.2.2",
-            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-            "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+            "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -3885,9 +4063,9 @@
             }
         },
         "node_modules/defu": {
-            "version": "6.1.4",
-            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-            "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+            "version": "6.1.7",
+            "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+            "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
             "devOptional": true,
             "license": "MIT"
         },
@@ -3958,19 +4136,6 @@
                 "node": ">=0.3.1"
             }
         },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/doctrine": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -4023,9 +4188,9 @@
             "license": "MIT"
         },
         "node_modules/effect": {
-            "version": "3.18.4",
-            "resolved": "https://registry.npmjs.org/effect/-/effect-3.18.4.tgz",
-            "integrity": "sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==",
+            "version": "3.20.0",
+            "resolved": "https://registry.npmjs.org/effect/-/effect-3.20.0.tgz",
+            "integrity": "sha512-qMLfDJscrNG8p/aw+IkT9W7fgj50Z4wG5bLBy0Txsxz8iUHjDIkOgO3SV0WZfnQbNG2VJYb0b+rDLMrhM4+Krw==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -4056,6 +4221,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
+            }
+        },
+        "node_modules/env-paths": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+            "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+            "devOptional": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/es-define-property": {
@@ -4112,9 +4290,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.21.5",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
-            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
@@ -4122,32 +4300,35 @@
                 "esbuild": "bin/esbuild"
             },
             "engines": {
-                "node": ">=12"
+                "node": ">=18"
             },
             "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.21.5",
-                "@esbuild/android-arm": "0.21.5",
-                "@esbuild/android-arm64": "0.21.5",
-                "@esbuild/android-x64": "0.21.5",
-                "@esbuild/darwin-arm64": "0.21.5",
-                "@esbuild/darwin-x64": "0.21.5",
-                "@esbuild/freebsd-arm64": "0.21.5",
-                "@esbuild/freebsd-x64": "0.21.5",
-                "@esbuild/linux-arm": "0.21.5",
-                "@esbuild/linux-arm64": "0.21.5",
-                "@esbuild/linux-ia32": "0.21.5",
-                "@esbuild/linux-loong64": "0.21.5",
-                "@esbuild/linux-mips64el": "0.21.5",
-                "@esbuild/linux-ppc64": "0.21.5",
-                "@esbuild/linux-riscv64": "0.21.5",
-                "@esbuild/linux-s390x": "0.21.5",
-                "@esbuild/linux-x64": "0.21.5",
-                "@esbuild/netbsd-x64": "0.21.5",
-                "@esbuild/openbsd-x64": "0.21.5",
-                "@esbuild/sunos-x64": "0.21.5",
-                "@esbuild/win32-arm64": "0.21.5",
-                "@esbuild/win32-ia32": "0.21.5",
-                "@esbuild/win32-x64": "0.21.5"
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
             }
         },
         "node_modules/escalade": {
@@ -4264,9 +4445,9 @@
             }
         },
         "node_modules/eslint/node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "6.14.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4281,9 +4462,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4312,9 +4493,9 @@
             "license": "MIT"
         },
         "node_modules/eslint/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -4504,10 +4685,13 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
-            "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+            "version": "8.3.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+            "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
             "license": "MIT",
+            "dependencies": {
+                "ip-address": "10.1.0"
+            },
             "engines": {
                 "node": ">= 16"
             },
@@ -4585,36 +4769,6 @@
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "license": "MIT"
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-glob/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -4660,6 +4814,24 @@
             "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
+            }
+        },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
             }
         },
         "node_modules/file-entry-cache": {
@@ -4754,9 +4926,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
             "dev": true,
             "license": "ISC"
         },
@@ -4966,13 +5138,6 @@
                 "giget": "dist/cli.mjs"
             }
         },
-        "node_modules/giget/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "devOptional": true,
-            "license": "MIT"
-        },
         "node_modules/glob": {
             "version": "7.2.3",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5009,9 +5174,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "1.1.12",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+            "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5020,9 +5185,9 @@
             }
         },
         "node_modules/glob/node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -5043,27 +5208,6 @@
             },
             "engines": {
                 "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -5102,15 +5246,16 @@
             "license": "MIT"
         },
         "node_modules/graphmatch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.0.tgz",
-            "integrity": "sha512-0E62MaTW5rPZVRLyIJZG/YejmdA/Xr1QydHEw3Vt+qOKkMIOE8WDLc9ZX2bmAjtJFZcId4lEdrdmASsEy7D1QA==",
-            "devOptional": true
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/graphmatch/-/graphmatch-1.1.1.tgz",
+            "integrity": "sha512-5ykVn/EXM1hF0XCaWh05VbYvEiOL2lY1kBxZtaYsyvjp7cmWOU1XsAdfQBwClraEofXDT197lFbXOEVMHpvQOg==",
+            "devOptional": true,
+            "license": "MIT"
         },
         "node_modules/handlebars": {
-            "version": "4.7.8",
-            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-            "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+            "version": "4.7.9",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+            "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
             "license": "MIT",
             "dependencies": {
                 "minimist": "^1.2.5",
@@ -5179,9 +5324,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.11.5",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
-            "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
+            "version": "4.12.12",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+            "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -5285,6 +5430,15 @@
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "license": "ISC"
+        },
+        "node_modules/ip-address": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
         },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
@@ -5590,16 +5744,6 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/lilconfig": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-            "devOptional": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5615,13 +5759,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
-        },
-        "node_modules/lodash": {
-            "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-            "devOptional": true,
-            "license": "MIT"
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
@@ -5725,16 +5862,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/methods": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -5759,9 +5886,9 @@
             }
         },
         "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+            "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -5805,19 +5932,42 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "9.0.3",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-            "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^2.0.1"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
-                "node": ">=16 || 14 >=14.17"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minimatch/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/minimatch/node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
             }
         },
         "node_modules/minimist": {
@@ -5927,9 +6077,9 @@
             "license": "MIT"
         },
         "node_modules/nypm": {
-            "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.4.tgz",
-            "integrity": "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+            "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -5945,23 +6095,16 @@
             }
         },
         "node_modules/nypm/node_modules/citty": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
-            "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
-            "devOptional": true,
-            "license": "MIT"
-        },
-        "node_modules/nypm/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+            "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/nypm/node_modules/tinyexec": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-            "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
             "devOptional": true,
             "license": "MIT",
             "engines": {
@@ -6141,26 +6284,16 @@
             }
         },
         "node_modules/path-to-regexp": {
-            "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-            "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+            "version": "0.1.13",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+            "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
             "license": "MIT"
         },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/pathe": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
-            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
-            "dev": true,
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "devOptional": true,
             "license": "MIT"
         },
         "node_modules/pathval": {
@@ -6287,9 +6420,9 @@
             "license": "ISC"
         },
         "node_modules/picomatch": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6320,17 +6453,10 @@
                 "pathe": "^2.0.3"
             }
         },
-        "node_modules/pkg-types/node_modules/pathe": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
-            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-            "devOptional": true,
-            "license": "MIT"
-        },
         "node_modules/postcss": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-            "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+            "version": "8.5.9",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+            "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
             "dev": true,
             "funding": [
                 {
@@ -6448,18 +6574,18 @@
             }
         },
         "node_modules/prisma": {
-            "version": "7.3.0",
-            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.3.0.tgz",
-            "integrity": "sha512-ApYSOLHfMN8WftJA+vL6XwAPOh/aZ0BgUyyKPwUFgjARmG6EBI9LzDPf6SWULQMSAxydV9qn5gLj037nPNlg2w==",
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.7.0.tgz",
+            "integrity": "sha512-HlgwRBt1uEFB9LStHL4HLYDvoi4BNu1rYA0hPG0zCAEyK9SaZBqp7E5Rjpc3Qh8Lex/ye/svoHZ0OWoFNhWxuQ==",
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
-                "@prisma/config": "7.3.0",
-                "@prisma/dev": "0.20.0",
-                "@prisma/engines": "7.3.0",
-                "@prisma/studio-core": "0.13.1",
+                "@prisma/config": "7.7.0",
+                "@prisma/dev": "0.24.3",
+                "@prisma/engines": "7.7.0",
+                "@prisma/studio-core": "0.27.3",
                 "mysql2": "3.15.3",
                 "postgres": "3.4.7"
             },
@@ -6554,9 +6680,9 @@
             "license": "MIT"
         },
         "node_modules/qs": {
-            "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-            "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+            "version": "6.14.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+            "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "side-channel": "^1.1.0"
@@ -6625,9 +6751,9 @@
             }
         },
         "node_modules/react": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-            "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+            "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
             "devOptional": true,
             "license": "MIT",
             "peer": true,
@@ -6636,9 +6762,9 @@
             }
         },
         "node_modules/react-dom": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+            "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
             "devOptional": true,
             "license": "MIT",
             "peer": true,
@@ -6646,7 +6772,7 @@
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.4"
+                "react": "^19.2.5"
             }
         },
         "node_modules/react-is": {
@@ -6675,13 +6801,6 @@
             "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
             "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
             "license": "Apache-2.0"
-        },
-        "node_modules/regexp-to-ast": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.5.0.tgz",
-            "integrity": "sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==",
-            "devOptional": true,
-            "license": "MIT"
         },
         "node_modules/remeda": {
             "version": "2.33.4",
@@ -6770,9 +6889,9 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.56.0",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
-            "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
+            "version": "4.60.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+            "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -6786,31 +6905,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.56.0",
-                "@rollup/rollup-android-arm64": "4.56.0",
-                "@rollup/rollup-darwin-arm64": "4.56.0",
-                "@rollup/rollup-darwin-x64": "4.56.0",
-                "@rollup/rollup-freebsd-arm64": "4.56.0",
-                "@rollup/rollup-freebsd-x64": "4.56.0",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.56.0",
-                "@rollup/rollup-linux-arm-musleabihf": "4.56.0",
-                "@rollup/rollup-linux-arm64-gnu": "4.56.0",
-                "@rollup/rollup-linux-arm64-musl": "4.56.0",
-                "@rollup/rollup-linux-loong64-gnu": "4.56.0",
-                "@rollup/rollup-linux-loong64-musl": "4.56.0",
-                "@rollup/rollup-linux-ppc64-gnu": "4.56.0",
-                "@rollup/rollup-linux-ppc64-musl": "4.56.0",
-                "@rollup/rollup-linux-riscv64-gnu": "4.56.0",
-                "@rollup/rollup-linux-riscv64-musl": "4.56.0",
-                "@rollup/rollup-linux-s390x-gnu": "4.56.0",
-                "@rollup/rollup-linux-x64-gnu": "4.56.0",
-                "@rollup/rollup-linux-x64-musl": "4.56.0",
-                "@rollup/rollup-openbsd-x64": "4.56.0",
-                "@rollup/rollup-openharmony-arm64": "4.56.0",
-                "@rollup/rollup-win32-arm64-msvc": "4.56.0",
-                "@rollup/rollup-win32-ia32-msvc": "4.56.0",
-                "@rollup/rollup-win32-x64-gnu": "4.56.0",
-                "@rollup/rollup-win32-x64-msvc": "4.56.0",
+                "@rollup/rollup-android-arm-eabi": "4.60.1",
+                "@rollup/rollup-android-arm64": "4.60.1",
+                "@rollup/rollup-darwin-arm64": "4.60.1",
+                "@rollup/rollup-darwin-x64": "4.60.1",
+                "@rollup/rollup-freebsd-arm64": "4.60.1",
+                "@rollup/rollup-freebsd-x64": "4.60.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+                "@rollup/rollup-linux-arm64-musl": "4.60.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+                "@rollup/rollup-linux-loong64-musl": "4.60.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+                "@rollup/rollup-linux-x64-gnu": "4.60.1",
+                "@rollup/rollup-linux-x64-musl": "4.60.1",
+                "@rollup/rollup-openbsd-x64": "4.60.1",
+                "@rollup/rollup-openharmony-arm64": "4.60.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+                "@rollup/rollup-win32-x64-gnu": "4.60.1",
+                "@rollup/rollup-win32-x64-msvc": "4.60.1",
                 "fsevents": "~2.3.2"
             }
         },
@@ -6831,9 +6950,9 @@
             }
         },
         "node_modules/router/node_modules/path-to-regexp": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-            "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+            "version": "8.4.2",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+            "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
             "license": "MIT",
             "funding": {
                 "type": "opencollective",
@@ -7239,6 +7358,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-literal": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/superagent": {
             "version": "8.1.2",
             "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
@@ -7357,6 +7496,23 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
         "node_modules/tinypool": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
@@ -7368,9 +7524,9 @@
             }
         },
         "node_modules/tinyrainbow": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
-            "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7378,9 +7534,9 @@
             }
         },
         "node_modules/tinyspy": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
-            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7410,16 +7566,16 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+            "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18.12"
             },
             "peerDependencies": {
-                "typescript": ">=4.2.0"
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/ts-deepmerge": {
@@ -7498,6 +7654,7 @@
             "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "~0.27.0",
                 "get-tsconfig": "^4.7.5"
@@ -7510,439 +7667,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.3"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.2.tgz",
-            "integrity": "sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "aix"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/android-arm": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.2.tgz",
-            "integrity": "sha512-DVNI8jlPa7Ujbr1yjU2PfUSRtAUZPG9I1RwW4F4xFB1Imiu2on0ADiI/c3td+KmDtVKNbi+nffGDQMfcIMkwIA==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.2.tgz",
-            "integrity": "sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/android-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.2.tgz",
-            "integrity": "sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "android"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.2.tgz",
-            "integrity": "sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.2.tgz",
-            "integrity": "sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.2.tgz",
-            "integrity": "sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.2.tgz",
-            "integrity": "sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "freebsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.2.tgz",
-            "integrity": "sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==",
-            "cpu": [
-                "arm"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.2.tgz",
-            "integrity": "sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.2.tgz",
-            "integrity": "sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.2.tgz",
-            "integrity": "sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==",
-            "cpu": [
-                "loong64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.2.tgz",
-            "integrity": "sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==",
-            "cpu": [
-                "mips64el"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.2.tgz",
-            "integrity": "sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==",
-            "cpu": [
-                "ppc64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.2.tgz",
-            "integrity": "sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==",
-            "cpu": [
-                "riscv64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.2.tgz",
-            "integrity": "sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==",
-            "cpu": [
-                "s390x"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.2.tgz",
-            "integrity": "sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "linux"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.2.tgz",
-            "integrity": "sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "netbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.2.tgz",
-            "integrity": "sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "openbsd"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.2.tgz",
-            "integrity": "sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "sunos"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.2.tgz",
-            "integrity": "sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==",
-            "cpu": [
-                "arm64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.2.tgz",
-            "integrity": "sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==",
-            "cpu": [
-                "ia32"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.2.tgz",
-            "integrity": "sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==",
-            "cpu": [
-                "x64"
-            ],
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "os": [
-                "win32"
-            ],
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/tsx/node_modules/esbuild": {
-            "version": "0.27.2",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.2.tgz",
-            "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "bin": {
-                "esbuild": "bin/esbuild"
-            },
-            "engines": {
-                "node": ">=18"
-            },
-            "optionalDependencies": {
-                "@esbuild/aix-ppc64": "0.27.2",
-                "@esbuild/android-arm": "0.27.2",
-                "@esbuild/android-arm64": "0.27.2",
-                "@esbuild/android-x64": "0.27.2",
-                "@esbuild/darwin-arm64": "0.27.2",
-                "@esbuild/darwin-x64": "0.27.2",
-                "@esbuild/freebsd-arm64": "0.27.2",
-                "@esbuild/freebsd-x64": "0.27.2",
-                "@esbuild/linux-arm": "0.27.2",
-                "@esbuild/linux-arm64": "0.27.2",
-                "@esbuild/linux-ia32": "0.27.2",
-                "@esbuild/linux-loong64": "0.27.2",
-                "@esbuild/linux-mips64el": "0.27.2",
-                "@esbuild/linux-ppc64": "0.27.2",
-                "@esbuild/linux-riscv64": "0.27.2",
-                "@esbuild/linux-s390x": "0.27.2",
-                "@esbuild/linux-x64": "0.27.2",
-                "@esbuild/netbsd-arm64": "0.27.2",
-                "@esbuild/netbsd-x64": "0.27.2",
-                "@esbuild/openbsd-arm64": "0.27.2",
-                "@esbuild/openbsd-x64": "0.27.2",
-                "@esbuild/openharmony-arm64": "0.27.2",
-                "@esbuild/sunos-x64": "0.27.2",
-                "@esbuild/win32-arm64": "0.27.2",
-                "@esbuild/win32-ia32": "0.27.2",
-                "@esbuild/win32-x64": "0.27.2"
             }
         },
         "node_modules/type-check": {
@@ -8101,22 +7825,25 @@
             }
         },
         "node_modules/vite": {
-            "version": "5.4.21",
-            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
-            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+            "version": "7.3.2",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+            "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "esbuild": "^0.21.3",
-                "postcss": "^8.4.43",
-                "rollup": "^4.20.0"
+                "esbuild": "^0.27.0",
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3",
+                "postcss": "^8.5.6",
+                "rollup": "^4.43.0",
+                "tinyglobby": "^0.2.15"
             },
             "bin": {
                 "vite": "bin/vite.js"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^20.19.0 || >=22.12.0"
             },
             "funding": {
                 "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -8125,17 +7852,23 @@
                 "fsevents": "~2.3.3"
             },
             "peerDependencies": {
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "less": "*",
+                "@types/node": "^20.19.0 || >=22.12.0",
+                "jiti": ">=1.21.0",
+                "less": "^4.0.0",
                 "lightningcss": "^1.21.0",
-                "sass": "*",
-                "sass-embedded": "*",
-                "stylus": "*",
-                "sugarss": "*",
-                "terser": "^5.4.0"
+                "sass": "^1.70.0",
+                "sass-embedded": "^1.70.0",
+                "stylus": ">=0.54.8",
+                "sugarss": "^5.0.0",
+                "terser": "^5.16.0",
+                "tsx": "^4.8.1",
+                "yaml": "^2.4.2"
             },
             "peerDependenciesMeta": {
                 "@types/node": {
+                    "optional": true
+                },
+                "jiti": {
                     "optional": true
                 },
                 "less": {
@@ -8158,79 +7891,92 @@
                 },
                 "terser": {
                     "optional": true
+                },
+                "tsx": {
+                    "optional": true
+                },
+                "yaml": {
+                    "optional": true
                 }
             }
         },
         "node_modules/vite-node": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
-            "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cac": "^6.7.14",
-                "debug": "^4.3.7",
-                "es-module-lexer": "^1.5.4",
-                "pathe": "^1.1.2",
-                "vite": "^5.0.0"
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
             },
             "bin": {
                 "vite-node": "vite-node.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/vitest": {
-            "version": "2.1.9",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
-            "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@vitest/expect": "2.1.9",
-                "@vitest/mocker": "2.1.9",
-                "@vitest/pretty-format": "^2.1.9",
-                "@vitest/runner": "2.1.9",
-                "@vitest/snapshot": "2.1.9",
-                "@vitest/spy": "2.1.9",
-                "@vitest/utils": "2.1.9",
-                "chai": "^5.1.2",
-                "debug": "^4.3.7",
-                "expect-type": "^1.1.0",
-                "magic-string": "^0.30.12",
-                "pathe": "^1.1.2",
-                "std-env": "^3.8.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/pretty-format": "^3.2.4",
+                "@vitest/runner": "3.2.4",
+                "@vitest/snapshot": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
                 "tinybench": "^2.9.0",
-                "tinyexec": "^0.3.1",
-                "tinypool": "^1.0.1",
-                "tinyrainbow": "^1.2.0",
-                "vite": "^5.0.0",
-                "vite-node": "2.1.9",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
                 "why-is-node-running": "^2.3.0"
             },
             "bin": {
                 "vitest": "vitest.mjs"
             },
             "engines": {
-                "node": "^18.0.0 || >=20.0.0"
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
                 "@edge-runtime/vm": "*",
-                "@types/node": "^18.0.0 || >=20.0.0",
-                "@vitest/browser": "2.1.9",
-                "@vitest/ui": "2.1.9",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.4",
+                "@vitest/ui": "3.2.4",
                 "happy-dom": "*",
                 "jsdom": "*"
             },
             "peerDependenciesMeta": {
                 "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
                     "optional": true
                 },
                 "@types/node": {
@@ -8379,9 +8125,9 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.8.2",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-            "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -67,15 +67,15 @@
         "@types/supertest": "^2.0.12",
         "@types/swagger-ui-express": "^4.1.8",
         "@types/ws": "^8.18.1",
-        "@typescript-eslint/eslint-plugin": "^6.12.0",
-        "@typescript-eslint/parser": "^6.12.0",
-        "eslint": "^8.48.0",
+        "@typescript-eslint/eslint-plugin": "^8.58.1",
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.1",
         "prisma": "^7.3.0",
         "supertest": "^6.3.3",
         "ts-node": "^10.9.1",
         "tsx": "^4.21.0",
         "typescript": "^5.4.0",
-        "vitest": "^2.0.0"
+        "vitest": "^3.2.4"
     },
     "prisma": {
         "schema": "prisma/schema.prisma"

--- a/src/tools/db/authors/schemas.ts
+++ b/src/tools/db/authors/schemas.ts
@@ -1,48 +1,29 @@
 // Input schemas for author-related MCP tools
+import { z } from "zod";
 
 export const CreateAuthorInputSchema = {
-    type: "object",
-    properties: {
-        name: { type: "string", description: "Author name" },
-        bio: { type: "string", description: "Author biography" },
-        website: { type: "string", description: "Author website URL" },
-    },
-    required: ["name"],
-} as const;
+    name: z.string().describe("Author name"),
+    bio: z.string().optional().describe("Author biography"),
+    website: z.string().optional().describe("Author website URL"),
+};
 
 export const UpdateAuthorInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Author ID" },
-        name: { type: "string", description: "Author name" },
-        bio: { type: "string", description: "Author biography" },
-        website: { type: "string", description: "Author website URL" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Author ID"),
+    name: z.string().optional().describe("Author name"),
+    bio: z.string().optional().describe("Author biography"),
+    website: z.string().optional().describe("Author website URL"),
+};
 
 export const DeleteAuthorInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Author ID to delete" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Author ID to delete"),
+};
 
 export const GetAuthorInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Author ID to retrieve" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Author ID to retrieve"),
+};
 
 export const ListAuthorsInputSchema = {
-    type: "object",
-    properties: {
-        search: { type: "string", description: "Search in author name and bio" },
-        limit: { type: "number", description: "Maximum number of results (default 50)" },
-        offset: { type: "number", description: "Number of results to skip (default 0)" },
-    },
-    required: [],
-} as const;
+    search: z.string().optional().describe("Search in author name and bio"),
+    limit: z.number().optional().describe("Maximum number of results (default 50)"),
+    offset: z.number().optional().describe("Number of results to skip (default 0)"),
+};

--- a/src/tools/db/books/schemas.ts
+++ b/src/tools/db/books/schemas.ts
@@ -1,69 +1,44 @@
 // Input schemas for book-related MCP tools
+import { z } from "zod";
+
+const StatusEnum = z.enum(['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED']);
 
 export const CreateBookInputSchema = {
-    type: "object",
-    properties: {
-        title: { type: "string", description: "Book title" },
-        status: { type: "string", description: "Book status (e.g., Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        description: { type: "string", description: "Book description" },
-        isbn: { type: "string", description: "ISBN (optional, must be unique)" },
-        publishedAt: { type: "string", description: "Publication date (ISO 8601 format)" },
-        rating: { type: "number", description: "Your rating (1-10 scale, optional)" },
-        review: { type: "string", description: "Your review text (optional)" },
-        authorIds: {
-            type: "array",
-            items: { type: "number" },
-            description: "Array of author IDs to associate with this book"
-        },
-    },
-    required: ["title"],
-} as const;
+    title: z.string().describe("Book title"),
+    status: StatusEnum.optional().describe("Book status (e.g., Not started, In progress, Completed)"),
+    description: z.string().optional().describe("Book description"),
+    isbn: z.string().optional().describe("ISBN (optional, must be unique)"),
+    publishedAt: z.string().optional().describe("Publication date (ISO 8601 format)"),
+    rating: z.number().optional().describe("Your rating (1-10 scale, optional)"),
+    review: z.string().optional().describe("Your review text (optional)"),
+    authorIds: z.array(z.number()).optional().describe("Array of author IDs to associate with this book"),
+};
 
 export const UpdateBookInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Book ID" },
-        title: { type: "string", description: "Book title" },
-        status: { type: "string", description: "Book status (e.g., Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        description: { type: "string", description: "Book description" },
-        rating: { type: "number", description: "Your rating (1-10 scale, optional)" },
-        review: { type: "string", description: "Your review text (optional)" },
-        isbn: { type: "string", description: "ISBN (must be unique)" },
-        publishedAt: { type: "string", description: "Publication date (ISO 8601 format)" },
-        authorIds: {
-            type: "array",
-            items: { type: "number" },
-            description: "Array of author IDs to associate with this book"
-        },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Book ID"),
+    title: z.string().optional().describe("Book title"),
+    status: StatusEnum.optional().describe("Book status (e.g., Not started, In progress, Completed)"),
+    description: z.string().optional().describe("Book description"),
+    rating: z.number().optional().describe("Your rating (1-10 scale, optional)"),
+    review: z.string().optional().describe("Your review text (optional)"),
+    isbn: z.string().optional().describe("ISBN (must be unique)"),
+    publishedAt: z.string().optional().describe("Publication date (ISO 8601 format)"),
+    authorIds: z.array(z.number()).optional().describe("Array of author IDs to associate with this book"),
+};
 
 export const DeleteBookInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Book ID to delete" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Book ID to delete"),
+};
 
 export const GetBookInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Book ID to retrieve" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Book ID to retrieve"),
+};
 
 export const ListBooksInputSchema = {
-    type: "object",
-    properties: {
-        authorId: { type: "number", description: "Filter by author ID" },
-        minRating: { type: "number", description: "Minimum average rating (1-10)" },
-        search: { type: "string", description: "Search in title and description" },
-        status: { type: "string", description: "Filter by status (Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        limit: { type: "number", description: "Maximum number of results (default 50)" },
-        offset: { type: "number", description: "Number of results to skip (default 0)" },
-    },
-    required: [],
-} as const;
+    authorId: z.number().optional().describe("Filter by author ID"),
+    minRating: z.number().optional().describe("Minimum average rating (1-10)"),
+    search: z.string().optional().describe("Search in title and description"),
+    status: StatusEnum.optional().describe("Filter by status (Not started, In progress, Completed)"),
+    limit: z.number().optional().describe("Maximum number of results (default 50)"),
+    offset: z.number().optional().describe("Number of results to skip (default 0)"),
+};

--- a/src/tools/db/content-creators/schemas.ts
+++ b/src/tools/db/content-creators/schemas.ts
@@ -1,48 +1,29 @@
 // Input schemas for content creator-related MCP tools
+import { z } from "zod";
 
 export const CreateContentCreatorInputSchema = {
-    type: "object",
-    properties: {
-        name: { type: "string", description: "Content creator name" },
-        description: { type: "string", description: "Description of content creator" },
-        website: { type: "string", description: "Website URL" },
-    },
-    required: ["name"],
-} as const;
+    name: z.string().describe("Content creator name"),
+    description: z.string().optional().describe("Description of content creator"),
+    website: z.string().optional().describe("Website URL"),
+};
 
 export const UpdateContentCreatorInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Content creator ID" },
-        name: { type: "string", description: "Content creator name" },
-        description: { type: "string", description: "Description of content creator" },
-        website: { type: "string", description: "Website URL" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Content creator ID"),
+    name: z.string().optional().describe("Content creator name"),
+    description: z.string().optional().describe("Description of content creator"),
+    website: z.string().optional().describe("Website URL"),
+};
 
 export const DeleteContentCreatorInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "ContentCreator ID to delete" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("ContentCreator ID to delete"),
+};
 
 export const GetContentCreatorInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "ContentCreator ID to retrieve" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("ContentCreator ID to retrieve"),
+};
 
 export const ListContentCreatorsInputSchema = {
-    type: "object",
-    properties: {
-        search: { type: "string", description: "Search in name and description" },
-        limit: { type: "number", description: "Maximum number of results (default 50)" },
-        offset: { type: "number", description: "Number of results to skip (default 0)" },
-    },
-    required: [],
-} as const;
+    search: z.string().optional().describe("Search in name and description"),
+    limit: z.number().optional().describe("Maximum number of results (default 50)"),
+    offset: z.number().optional().describe("Number of results to skip (default 0)"),
+};

--- a/src/tools/db/movies/schemas.ts
+++ b/src/tools/db/movies/schemas.ts
@@ -1,56 +1,39 @@
 // Input schemas for movie-related MCP tools
+import { z } from "zod";
+
+const StatusEnum = z.enum(['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED']);
 
 export const CreateMovieInputSchema = {
-    type: "object",
-    properties: {
-        title: { type: "string", description: "Movie title" },
-        status: { type: "string", description: "Movie status (e.g., Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        description: { type: "string", description: "Movie description" },
-        iasn: { type: "string", description: "IASN (optional, must be unique)" },
-        imdbId: { type: "string", description: "IMDB ID (optional, must be unique)" },
-        releasedAt: { type: "string", description: "Release date (ISO 8601 format)" },
-    },
-    required: ["title"],
-} as const;
+    title: z.string().describe("Movie title"),
+    status: StatusEnum.optional().describe("Movie status (e.g., Not started, In progress, Completed)"),
+    description: z.string().optional().describe("Movie description"),
+    iasn: z.string().optional().describe("IASN (optional, must be unique)"),
+    imdbId: z.string().optional().describe("IMDB ID (optional, must be unique)"),
+    releasedAt: z.string().optional().describe("Release date (ISO 8601 format)"),
+};
 
 export const UpdateMovieInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Movie ID" },
-        title: { type: "string", description: "Movie title" },
-        status: { type: "string", description: "Movie status (e.g., Not started, In progress, Completed)", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        description: { type: "string", description: "Movie description" },
-        iasn: { type: "string", description: "IASN (must be unique)" },
-        imdbId: { type: "string", description: "IMDB ID (must be unique)" },
-        releasedAt: { type: "string", description: "Release date (ISO 8601 format)" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Movie ID"),
+    title: z.string().optional().describe("Movie title"),
+    status: StatusEnum.optional().describe("Movie status (e.g., Not started, In progress, Completed)"),
+    description: z.string().optional().describe("Movie description"),
+    iasn: z.string().optional().describe("IASN (must be unique)"),
+    imdbId: z.string().optional().describe("IMDB ID (must be unique)"),
+    releasedAt: z.string().optional().describe("Release date (ISO 8601 format)"),
+};
 
 export const DeleteMovieInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Movie ID to delete" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Movie ID to delete"),
+};
 
 export const GetMovieInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Movie ID to retrieve" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Movie ID to retrieve"),
+};
 
 export const ListMoviesInputSchema = {
-    type: "object",
-    properties: {
-        minRating: { type: "number", description: "Minimum average rating (1-10)" },
-        search: { type: "string", description: "Search in title and description" },
-        status: { type: "string", description: "Filter by status", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        limit: { type: "number", description: "Maximum number of results (default 50)" },
-        offset: { type: "number", description: "Number of results to skip (default 0)" },
-    },
-    required: [],
-} as const;
+    minRating: z.number().optional().describe("Minimum average rating (1-10)"),
+    search: z.string().optional().describe("Search in title and description"),
+    status: StatusEnum.optional().describe("Filter by status"),
+    limit: z.number().optional().describe("Maximum number of results (default 50)"),
+    offset: z.number().optional().describe("Number of results to skip (default 0)"),
+};

--- a/src/tools/db/videogames/schemas.ts
+++ b/src/tools/db/videogames/schemas.ts
@@ -1,56 +1,40 @@
 // Input schemas for video game-related MCP tools
+import { z } from "zod";
+
+const StatusEnum = z.enum(['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED']);
+const PlatformEnum = z.enum(['PlayStation', 'Xbox', 'PC']);
 
 export const CreateVideoGameInputSchema = {
-    type: "object",
-    properties: {
-        title: { type: "string", description: "Video game title" },
-        status: { type: "string", description: "Status", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        description: { type: "string", description: "Game description" },
-        platform: { type: "string", description: "Platform (PlayStation, Xbox, PC)", enum: ['PlayStation', 'Xbox', 'PC'] },
-        igdbId: { type: "string", description: "IGDB ID (optional, unique)" },
-        releasedAt: { type: "string", description: "Release date (ISO 8601)" },
-    },
-    required: ["title", "platform"],
-} as const;
+    title: z.string().describe("Video game title"),
+    platform: PlatformEnum.describe("Platform (PlayStation, Xbox, PC)"),
+    status: StatusEnum.optional().describe("Status"),
+    description: z.string().optional().describe("Game description"),
+    igdbId: z.string().optional().describe("IGDB ID (optional, unique)"),
+    releasedAt: z.string().optional().describe("Release date (ISO 8601)"),
+};
 
 export const UpdateVideoGameInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Video game ID" },
-        title: { type: "string", description: "Video game title" },
-        status: { type: "string", description: "Status", enum: ['NOT_STARTED', 'IN_PROGRESS', 'COMPLETED'] },
-        description: { type: "string", description: "Game description" },
-        platform: { type: "string", description: "Platform (PlayStation, Xbox, PC)", enum: ['PlayStation', 'Xbox', 'PC'] },
-        igdbId: { type: "string", description: "IGDB ID (optional, unique)" },
-        releasedAt: { type: "string", description: "Release date (ISO 8601)" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Video game ID"),
+    title: z.string().optional().describe("Video game title"),
+    status: StatusEnum.optional().describe("Status"),
+    description: z.string().optional().describe("Game description"),
+    platform: PlatformEnum.optional().describe("Platform (PlayStation, Xbox, PC)"),
+    igdbId: z.string().optional().describe("IGDB ID (optional, unique)"),
+    releasedAt: z.string().optional().describe("Release date (ISO 8601)"),
+};
 
 export const DeleteVideoGameInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Video game ID to delete" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Video game ID to delete"),
+};
 
 export const GetVideoGameInputSchema = {
-    type: "object",
-    properties: {
-        id: { type: "number", description: "Video game ID to retrieve" },
-    },
-    required: ["id"],
-} as const;
+    id: z.number().describe("Video game ID to retrieve"),
+};
 
 export const ListVideoGamesInputSchema = {
-    type: "object",
-    properties: {
-        platform: { type: "string", description: "Filter by platform", enum: ['PlayStation', 'Xbox', 'PC'] },
-        minRating: { type: "number", description: "Minimum average rating (1-10)" },
-        search: { type: "string", description: "Search in title and description" },
-        limit: { type: "number", description: "Maximum number of results (default 50)" },
-        offset: { type: "number", description: "Number of results to skip (default 0)" },
-    },
-    required: [],
-} as const;
+    platform: PlatformEnum.optional().describe("Filter by platform"),
+    minRating: z.number().optional().describe("Minimum average rating (1-10)"),
+    search: z.string().optional().describe("Search in title and description"),
+    limit: z.number().optional().describe("Maximum number of results (default 50)"),
+    offset: z.number().optional().describe("Number of results to skip (default 0)"),
+};


### PR DESCRIPTION
## Summary

Updates the README for consumers connecting to the deployed server remotely.

### Changes

- **New VS Code config section (Option 1 — Remote)**: HTTP Stream config pointing at \https://mcp-server.onrender.com/mcp\ with \Authorization: Bearer\ header and VS Code secret input prompt for the API key. Replaces the stale workspace stdio example as the primary recommendation.
- **Local stdio kept as Option 2**: Reworded to be clearly dev-only, with a generic path placeholder instead of a hardcoded user path.
- **Tools table updated**: Adds \list-labels\, \list-project-items\, \get-project-status-options\, \create-issue-in-project\ from #83; expands parameter columns for \create-issue\ and \update-issue\ with new fields.
- **Prerequisites**: Removed stale \gh\ CLI requirement (migrated to Octokit in #83); added \GITHUB_TOKEN\ env var note.
- **Env vars**: Added \GITHUB_TOKEN\ to the example \.env\ block.