### PR TITLE
[render preview] fix: register MCP HTTP transport before DB init so /mcp is always reachable

### DIFF
--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -177,25 +177,6 @@ export async function registerDbDependentRoutes(app: any) {
         res.status(status).json({ error: message })
     })
 
-    // MCP HTTP transport (HTTP Stream + SSE fallback)
-    try {
-        const mod = await import('./mcp-http.js');
-        try {
-            mod.registerMcpHttp(app);
-            console.error('registered MCP HTTP transport (routes mounted at /mcp)');
-            try {
-                const routes = (app as any)._router?.stack?.filter((l: any) => l.route).map((l: any) => ({ path: l.route.path, methods: l.route.methods }));
-                console.error('registered routes:', JSON.stringify(routes));
-            } catch (e) {
-                console.error('failed to enumerate routes', e);
-            }
-        } catch (err) {
-            console.error('failed to register MCP HTTP transport', err)
-        }
-    } catch (err) {
-        console.error('failed to import MCP HTTP transport', err)
-    }
-
     // Basic 404 handler (must be registered after all other routes so it doesn't
     // intercept later-registered DB-dependent routes)
     app.use((_req: any, res: any) => res.status(404).json({ error: "not found" }));
@@ -241,6 +222,16 @@ export async function startHttpServer(port: number, host?: string, opts?: { earl
             }
 
             const early = opts?.earlyStart === true || config.server.earlyStart
+
+            // Register MCP HTTP transport immediately — no DB dependency at route-registration
+            // time. Tool handlers that need Prisma will lazily call initPrisma themselves.
+            try {
+                const mod = await import('./mcp-http.js');
+                mod.registerMcpHttp(app);
+                console.error('registered MCP HTTP transport (routes mounted at /mcp)');
+            } catch (err) {
+                console.error('failed to register MCP HTTP transport', err)
+            }
 
             // Initialize Prisma and register DB-dependent routes.
             // If `early` is true, do this in the background and resolve immediately.

--- a/test/http/spotify-adapter-autostart.test.ts
+++ b/test/http/spotify-adapter-autostart.test.ts
@@ -44,9 +44,15 @@ describe('Spotify adapter auto-start', () => {
         config.spotify.clientSecret = 'y'
         config.spotify.refreshToken = 'z'
 
+        // Re-apply mock implementation after vi.resetAllMocks() cleared it in beforeEach
+        mockStart.mockResolvedValue(undefined)
+
         const app = express()
         app.use(express.json())
         await registerDbDependentRoutes(app)
+
+        // The Spotify auto-start is a fire-and-forget IIFE; flush microtasks so it completes
+        await new Promise(resolve => setTimeout(resolve, 0))
 
         // IIFE in registerSpotifyRoute should import and call startSpotifyAdapter
         expect(mockStart).toHaveBeenCalled()


### PR DESCRIPTION
## Problem

When connecting a VS Code or other MCP client to the deployed server at \https://mcp-server.onrender.com/mcp\, the client gets a 404 HTML error:

\\\
Cannot GET /mcp
\\\

## Root Cause

\egisterMcpHttp(app)\ was called inside \egisterDbDependentRoutes()\, which only runs **after** \initPrisma()\ completes. On Render cold-starts (or any DB failure), Prisma init is slow/async — so the \/mcp\ routes were never mounted when the first HTTP request arrived.

## Fix

Move \egisterMcpHttp()\ to run immediately after the HTTP server begins listening, **before** Prisma init. MCP route registration has no database dependency; individual tool handlers that need Prisma call it lazily at invocation time.

## Test fix

The \spotify-adapter-autostart\ test was accidentally relying on the removed \wait import('./mcp-http.js')\ as a microtask yield. Fixed by explicitly flushing microtasks with \setTimeout(resolve, 0)\ and restoring \mockResolvedValue\ after \i.resetAllMocks()\.

## Checklist
- [x] 55 test files passing (247 tests, 0 failures)
- [x] TypeScript clean
- [x] Render preview will confirm \GET /mcp\ returns SSE headers rather than 404