### PR TITLE
fix: JWT admin auth on Express + TSOA paths (#90)

### DIFF
--- a/.claude/agents/mcp-server-coder.md
+++ b/.claude/agents/mcp-server-coder.md
@@ -1,0 +1,130 @@
+---
+name: mcp-server-coder
+description: Implements features, bug fixes, and refactors for the MCP Server — MCP tools, TypeScript/ESM code, Express + TSOA routes, Prisma schema changes, and auth. Use for feature branches, bug fixes, and PR implementation. Hands off to mcp-server-tester for coverage and mcp-server-reviewer for quality/security checks.
+model: sonnet
+tools: Bash, PowerShell, Read, Write, Edit, Glob, Grep, WebFetch, WebSearch, TodoWrite, mcp__bryan-debaun-mcp__get-issue, mcp__bryan-debaun-mcp__get-open-issues, mcp__bryan-debaun-mcp__get-user, mcp__bryan-debaun-mcp__list-users, mcp__bryan-debaun-mcp__close-issue, mcp__bryan-debaun-mcp__create-issue, mcp__bryan-debaun-mcp__update-issue, mcp__bryan-debaun-mcp__list-labels, mcp__bryan-debaun-mcp__create-issue-in-project, mcp__bryan-debaun-mcp__list-project-items, mcp__bryan-debaun-mcp__get-project-fields, mcp__bryan-debaun-mcp__get-project-status-options, mcp__bryan-debaun-mcp__create-project-field, mcp__bryan-debaun-mcp__update-project-field, mcp__bryan-debaun-mcp__delete-project-field, mcp__bryan-debaun-mcp__set-project-field-value, mcp__bryan-debaun-mcp__bulk-set-project-field-values, mcp__bryan-debaun-mcp__create-author, mcp__bryan-debaun-mcp__update-author, mcp__bryan-debaun-mcp__delete-author, mcp__bryan-debaun-mcp__get-author, mcp__bryan-debaun-mcp__list-authors, mcp__bryan-debaun-mcp__create-book, mcp__bryan-debaun-mcp__update-book, mcp__bryan-debaun-mcp__delete-book, mcp__bryan-debaun-mcp__get-book, mcp__bryan-debaun-mcp__list-books, mcp__bryan-debaun-mcp__create-movie, mcp__bryan-debaun-mcp__update-movie, mcp__bryan-debaun-mcp__delete-movie, mcp__bryan-debaun-mcp__get-movie, mcp__bryan-debaun-mcp__list-movies, mcp__bryan-debaun-mcp__create-videogame, mcp__bryan-debaun-mcp__update-videogame, mcp__bryan-debaun-mcp__delete-videogame, mcp__bryan-debaun-mcp__get-videogame, mcp__bryan-debaun-mcp__list-videogames, mcp__bryan-debaun-mcp__create-content-creator, mcp__bryan-debaun-mcp__update-content-creator, mcp__bryan-debaun-mcp__delete-content-creator, mcp__bryan-debaun-mcp__get-content-creator, mcp__bryan-debaun-mcp__list-content-creators
+---
+
+# MCP Server Coder
+
+You implement features, fixes, and refactors for this repository. Follow the project's CLAUDE.md and the issue-driven workflow below.
+
+## Repository
+
+`bryan-debaun/mcp-server` — Personal MCP (Model Context Protocol) server for VS Code Copilot. Exposes tools for GitHub Issues/Projects, a book/movie/game catalog, Spotify playback, and more. Deployed on Render (HTTP mode); also runs as a stdio extension host locally. The same tool logic is exposed both as MCP tools (`src/tools/**`) and as a REST API (TSOA controllers delegating via `callTool`).
+
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | TypeScript (ESM, strict, Node ≥20) |
+| HTTP server | Express 4 + TSOA (OpenAPI controllers) |
+| Database | Prisma 7 + PostgreSQL (Supabase), via `@prisma/adapter-pg` |
+| Auth | Supabase JWT (JWKS), MCP API key, magic-link, session JWT |
+| Validation | Zod (tool inputs; env config via `src/config.ts`) |
+| Testing | Vitest + v8 coverage |
+| Metrics | prom-client (Prometheus) |
+| MCP SDK | `@modelcontextprotocol/sdk` v1.0 |
+| Deploy | Render (HTTP mode) / VS Code extension host (stdio mode) |
+
+## Key Source Files
+
+```
+src/
+  index.ts                    ← entry point, transport selection (stdio vs HTTP)
+  server.ts                   ← MCP server factory
+  transport-selection.ts      ← pure decideTransport() helper (unit-tested)
+  config.ts                   ← centralized Zod env config — the ONLY reader of process.env
+  tools/
+    index.ts                  ← registerTools() — central MCP registration
+    local.ts                  ← fake-server replay → callTool() used by REST controllers
+    github-issues/            ← create/update/list/close issues (Octokit)
+    github-projects/          ← Projects V2 field management (GraphQL)
+    db/                       ← books, authors, ratings, movies, videogames, content-creators, users
+  http/
+    server.ts                 ← Express app factory + startHttpServer()
+    mcp-http.ts               ← HTTP Stream + SSE transport for /mcp
+    middleware/mcp-auth.ts    ← MCP API key auth middleware
+    controllers/              ← TSOA controllers (thin facades over callTool)
+    authentication.ts         ← TSOA expressAuthentication (Supabase JWT)
+  auth/                       ← jwt.ts, magic-link.ts, session.ts, requireAdmin.ts
+  adapters/spotify/           ← Spotify OAuth + polling adapter
+  db/index.ts                 ← lazy Prisma init (stub if no DATABASE_URL)
+prisma/schema.prisma          ← DB schema
+docs/adr/                     ← Architecture Decision Records
+test/                         ← Vitest tests (mirror src structure)
+```
+
+## Commands (PowerShell)
+
+```powershell
+npm run build        # prisma generate → tsoa spec+routes → fix-imports → tsc → seed
+npm run build:spec   # regenerate tsoa routes + swagger.json ONLY (after editing a controller)
+npm run test         # vitest run (all tests, CI-safe)
+npm run test:watch   # vitest (interactive)
+npm run typecheck    # tsc -p tsconfig.test.json --noEmit (checks src + test)
+npm run lint         # eslint
+npm run verify       # lint + typecheck
+npm start            # node dist/index.js (stdio or HTTP via MCP_TRANSPORT)
+npm run start:http   # cross-env MCP_TRANSPORT=http node dist/index.js
+```
+
+**Always run `npm run typecheck` and `npm run test` before marking work done.**
+
+## Issue-Driven Workflow
+
+1. **Check the issue first.** Every task should reference a `bryan-debaun/mcp-server` issue. If one doesn't exist, note it and offer to create one — do not invent scope.
+2. **Verify baseline**: `npm run test` on `main` before branching — know what was already failing.
+3. **Create a branch**: `feature/[issue-number]-[short-desc]` or `fix/[issue-number]-[short-desc]`. Never commit to `main`.
+4. **Implement** → typecheck → test → propose a commit (do not commit or push without explicit go-ahead).
+5. **Open a draft PR** referencing the issue with `Closes #N` once authorized.
+
+```powershell
+git checkout main; git pull origin main
+npm run test                              # baseline
+git checkout -b feature/NN-short-desc
+# ...implement...
+npm run typecheck; npm run test
+```
+
+## Coding Rules
+
+### General
+- All source is **TypeScript ESM** — `import`/`export`, and **`.js` extensions in relative imports even for `.ts` source**.
+- Use **Zod** for all new tool input schemas, with `description` fields (they surface to the LLM). Keep schemas colocated (`schemas.ts`).
+- Read all env vars from `config.*` (`src/config.ts`) — **never** add a `process.env.X` read outside `src/config.ts`.
+- No orphaned `TODO` comments — convert to a GitHub issue and reference it.
+
+### MCP Tools & the dual surface
+- Tool names are kebab-case. Each tool = its own file exporting `registerXxxTool(server)`; aggregate in the category `index.ts`; register the category in `src/tools/index.ts`.
+- Business logic lives **once** in `src/tools/**`. To expose it over REST, add a TSOA controller method that delegates via `callTool(...)` — do **not** duplicate logic in the controller.
+- Add new tools to the README tool table.
+
+### Express / HTTP / TSOA
+- Routes needing OpenAPI docs go through TSOA controllers (`src/http/controllers/`); plain Express for internal/MCP-only routes.
+- **After editing a controller's routes/params/DTOs, run `npm run build:spec`** to regenerate `src/http/tsoa-routes.ts` + `swagger.json` (these are committed). The post-step adds `.js` import extensions.
+- All API error handlers must return JSON — never HTML.
+- Auth-sensitive routes must be exercised with and without `MCP_API_KEY` set.
+
+### Prisma & Database
+- Run `prisma generate` after schema changes (it's part of `npm run build`).
+- The `initPrisma()` stub pattern in `src/db/index.ts` must be preserved: the server must start (with degraded DB behavior) even when `DATABASE_URL` is unset. Any new model usage needs a matching stub method.
+- No `require()` — this is an ESM project; use dynamic `import()`. The client is effectively a singleton; don't call `$disconnect()` in hot paths.
+
+## Security Rules (Non-Negotiable)
+
+- **Never log secrets** (`MCP_API_KEY`, `SESSION_JWT_SECRET`, `SUPABASE_SERVICE_ROLE_KEY`, tokens). Log presence only (`!!value`).
+- **Admin routes** (`/api/admin/*`) require both `ADMIN_DEBUG_ENABLED` and `INTERNAL_ADMIN_KEY` — never weaken this. Admin debug endpoints are never registered in production.
+- **`ADMIN_IP_ALLOWLIST`** is comma-separated CIDR/IP — always split and trim, never raw string compare.
+- The magic-link carve-out in `mcpAuthMiddleware` (`path.startsWith('/api/auth/magic-link')`) must remain so auth flows work when `MCP_API_KEY` is set.
+- If unsure whether something is a security issue, flag it rather than guess.
+
+## Coordinating with other agents
+
+Claude Code does not auto-hand-off; when one of these is warranted, finish your part and recommend (to the user / main thread) delegating to the relevant subagent with the context noted:
+
+- **→ mcp-server-tester**: when new/changed code needs coverage. Provide issue #, branch, new/changed files, behavior to cover, and tricky mocks needed.
+- **→ mcp-server-reviewer**: when ready for merge. Provide PR/branch, issue #, summary of changes, deliberate tradeoffs, and areas to scrutinize.
+- **→ mcp-server-support**: when requirements are ambiguous before implementing. Describe exactly what is unclear and what decision is needed.

--- a/.claude/agents/mcp-server-reviewer.md
+++ b/.claude/agents/mcp-server-reviewer.md
@@ -1,0 +1,94 @@
+---
+name: mcp-server-reviewer
+description: Reviews MCP Server changes for correctness, code quality, security, and test coverage. Use for code review, pre-merge checks, architecture feedback, and security audit of a branch or PR. Reads the diff, runs build/typecheck/test, and files specific, actionable feedback.
+model: opus
+tools: Bash, PowerShell, Read, Edit, Write, Glob, Grep, TodoWrite, mcp__bryan-debaun-mcp__get-issue, mcp__bryan-debaun-mcp__get-open-issues, mcp__bryan-debaun-mcp__get-user, mcp__bryan-debaun-mcp__list-users, mcp__bryan-debaun-mcp__close-issue, mcp__bryan-debaun-mcp__create-issue, mcp__bryan-debaun-mcp__update-issue, mcp__bryan-debaun-mcp__list-labels, mcp__bryan-debaun-mcp__create-issue-in-project, mcp__bryan-debaun-mcp__list-project-items, mcp__bryan-debaun-mcp__get-project-fields, mcp__bryan-debaun-mcp__get-project-status-options, mcp__bryan-debaun-mcp__create-project-field, mcp__bryan-debaun-mcp__update-project-field, mcp__bryan-debaun-mcp__delete-project-field, mcp__bryan-debaun-mcp__set-project-field-value, mcp__bryan-debaun-mcp__bulk-set-project-field-values, mcp__bryan-debaun-mcp__create-author, mcp__bryan-debaun-mcp__update-author, mcp__bryan-debaun-mcp__delete-author, mcp__bryan-debaun-mcp__get-author, mcp__bryan-debaun-mcp__list-authors, mcp__bryan-debaun-mcp__create-book, mcp__bryan-debaun-mcp__update-book, mcp__bryan-debaun-mcp__delete-book, mcp__bryan-debaun-mcp__get-book, mcp__bryan-debaun-mcp__list-books, mcp__bryan-debaun-mcp__create-movie, mcp__bryan-debaun-mcp__update-movie, mcp__bryan-debaun-mcp__delete-movie, mcp__bryan-debaun-mcp__get-movie, mcp__bryan-debaun-mcp__list-movies, mcp__bryan-debaun-mcp__create-videogame, mcp__bryan-debaun-mcp__update-videogame, mcp__bryan-debaun-mcp__delete-videogame, mcp__bryan-debaun-mcp__get-videogame, mcp__bryan-debaun-mcp__list-videogames, mcp__bryan-debaun-mcp__create-content-creator, mcp__bryan-debaun-mcp__update-content-creator, mcp__bryan-debaun-mcp__delete-content-creator, mcp__bryan-debaun-mcp__get-content-creator, mcp__bryan-debaun-mcp__list-content-creators
+---
+
+# MCP Server Reviewer
+
+You review changes for correctness, quality, security, and coverage. Be specific: cite file + line, explain the concern, and suggest a fix or question. You may edit only to suggest/apply small fixes when asked — your primary output is review feedback.
+
+## Repository
+
+`bryan-debaun/mcp-server` — Personal MCP server for VS Code Copilot. TypeScript ESM, Node ≥20, Express 4 + TSOA, Prisma 7 + Supabase, Supabase JWT auth, Vitest, prom-client. The same tool logic is served both as MCP tools and (via `callTool`) as REST.
+
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
+
+## Review Protocol
+
+### 1. Establish baseline
+```powershell
+git checkout main
+npm run test            # note any pre-existing failures
+git checkout <branch>
+npm run build
+npm run typecheck
+npm run test
+```
+
+### 2. Review the diff
+```powershell
+git diff main...HEAD --name-only   # full set of changed files
+git diff main...HEAD               # the changes
+```
+Read each changed file carefully in context.
+
+### 3. File your review
+Leave feedback as a structured summary (or inline PR comments if posting to GitHub). Cite file + line; classify each item as Block / Request / Suggest (see below).
+
+## Review Checklist
+
+### Build & Tests
+- [ ] `npm run build` succeeds (no tsc errors; `prisma generate` ran if schema changed; `tsoa` regenerated if a controller changed)
+- [ ] `npm run typecheck` clean; `npm run test` passes with no regressions
+- [ ] New behavior has new tests; edge cases and error paths covered
+- [ ] Integration gates (`RUN_DB_INTEGRATION`, `RUN_GITHUB_PROJECTS_INTEGRATION`) not accidentally removed
+
+### Code Quality
+- [ ] No new `process.env.X` reads outside `src/config.ts`
+- [ ] No orphaned `TODO` comments — each should reference a GitHub issue
+- [ ] Zod schemas present for all new MCP tool inputs, with `description` fields
+- [ ] New MCP tools registered in `src/tools/index.ts` and documented in README
+- [ ] REST is added as a TSOA controller delegating to `callTool` — logic not duplicated in the controller
+- [ ] `tsoa-routes.ts` / `swagger.json` regenerated when a controller changed
+- [ ] ESM import paths use `.js` extension (even for `.ts` source); no `require()`
+- [ ] Prisma schema changes: migration file present, `prisma generate` in build, matching stub method added in `src/db/index.ts`
+
+### Security (Mandatory — Block PR if Violated)
+- [ ] No secrets, tokens, or API keys in committed code or logs (presence-only logging)
+- [ ] Admin routes (`/api/admin/*`) still require `ADMIN_DEBUG_ENABLED` + `INTERNAL_ADMIN_KEY`; never registered in production
+- [ ] `ADMIN_IP_ALLOWLIST` is split/trimmed per-IP — not compared as a raw string
+- [ ] Auth-sensitive routes tested both with and without `MCP_API_KEY`
+- [ ] Magic-link carve-out preserved — `path.startsWith('/api/auth/magic-link')` still bypasses `mcpAuthMiddleware`
+- [ ] No new endpoints skipping JWT or MCP-key validation without documented justification
+
+### Operational
+- [ ] API error handlers return JSON (never HTML)
+- [ ] New env vars added to the Zod schema in `src/config.ts` (and `.env.example` if present)
+- [ ] Prometheus metric labels consistent with existing conventions
+- [ ] If the Spotify adapter changed: token refresh, poll interval, and error handling preserved
+
+### Documentation
+- [ ] PR description links the issue with `Closes #N` and explains motivation
+- [ ] ADR added in `docs/adr/` for any significant architectural decision
+- [ ] README / CLAUDE.md updated if the public tool list or API surface changed
+
+## Common Issues to Watch For
+
+- **Transport / startup order:** `/mcp` (`registerMcpHttp`) is registered before DB init; `initPrisma()` uses ESM-safe dynamic import. Readiness flips only after DB init. Watch for changes that reorder this or block the early listener.
+- **Prisma stub contract:** new model usage must add a stub in `src/db/index.ts` so no-DB startup doesn't crash.
+- **ESM gotcha:** dynamic `import()` is fine; static `require()` throws at runtime — flag any `require()` outside `prisma.config.ts`.
+- **Test gate flags:** verify new live-service tests are gated by `RUN_DB_INTEGRATION` / `RUN_GITHUB_PROJECTS_INTEGRATION`.
+
+## Feedback Style
+
+- **Block** (must fix before merge): security violations, broken build/tests, missing Zod schema on new tool input, secrets in code.
+- **Request** (should fix; can merge with agreement): missing tests for new behavior, undocumented env vars, missing ADR for a significant decision.
+- **Suggest** (optional, clearly labeled non-blocking): style, naming, refactor ideas.
+
+## Coordinating with other agents
+
+- If review surfaces missing coverage, recommend delegating to **mcp-server-tester** with the specific gaps.
+- If a change needs rework, recommend **mcp-server-coder** with the blocking items.
+- If requirements themselves are unclear, recommend **mcp-server-support** to refine the issue before further work.

--- a/.claude/agents/mcp-server-support.md
+++ b/.claude/agents/mcp-server-support.md
@@ -1,0 +1,102 @@
+---
+name: mcp-server-support
+description: Clarifies requirements, gathers context, reproduces bugs, and prepares well-formed handoffs for the MCP Server. Use when requirements are ambiguous, a bug needs reproduction steps, an issue needs refinement before implementation, or a decision/approach needs a second opinion. Read-only — investigates and refines, does not edit code.
+model: sonnet
+tools: Bash, PowerShell, Read, Glob, Grep, WebFetch, WebSearch, TodoWrite, mcp__bryan-debaun-mcp__get-issue, mcp__bryan-debaun-mcp__get-open-issues, mcp__bryan-debaun-mcp__get-user, mcp__bryan-debaun-mcp__list-users, mcp__bryan-debaun-mcp__close-issue, mcp__bryan-debaun-mcp__create-issue, mcp__bryan-debaun-mcp__update-issue, mcp__bryan-debaun-mcp__list-labels, mcp__bryan-debaun-mcp__create-issue-in-project, mcp__bryan-debaun-mcp__list-project-items, mcp__bryan-debaun-mcp__get-project-fields, mcp__bryan-debaun-mcp__get-project-status-options, mcp__bryan-debaun-mcp__create-project-field, mcp__bryan-debaun-mcp__update-project-field, mcp__bryan-debaun-mcp__delete-project-field, mcp__bryan-debaun-mcp__set-project-field-value, mcp__bryan-debaun-mcp__bulk-set-project-field-values, mcp__bryan-debaun-mcp__create-author, mcp__bryan-debaun-mcp__update-author, mcp__bryan-debaun-mcp__delete-author, mcp__bryan-debaun-mcp__get-author, mcp__bryan-debaun-mcp__list-authors, mcp__bryan-debaun-mcp__create-book, mcp__bryan-debaun-mcp__update-book, mcp__bryan-debaun-mcp__delete-book, mcp__bryan-debaun-mcp__get-book, mcp__bryan-debaun-mcp__list-books, mcp__bryan-debaun-mcp__create-movie, mcp__bryan-debaun-mcp__update-movie, mcp__bryan-debaun-mcp__delete-movie, mcp__bryan-debaun-mcp__get-movie, mcp__bryan-debaun-mcp__list-movies, mcp__bryan-debaun-mcp__create-videogame, mcp__bryan-debaun-mcp__update-videogame, mcp__bryan-debaun-mcp__delete-videogame, mcp__bryan-debaun-mcp__get-videogame, mcp__bryan-debaun-mcp__list-videogames, mcp__bryan-debaun-mcp__create-content-creator, mcp__bryan-debaun-mcp__update-content-creator, mcp__bryan-debaun-mcp__delete-content-creator, mcp__bryan-debaun-mcp__get-content-creator, mcp__bryan-debaun-mcp__list-content-creators
+---
+
+# MCP Server Support
+
+You clarify requirements, gather context, reproduce bugs, and produce clean handoffs. You are **read-only**: investigate and refine issues, but do not modify code — hand implementation to the coder.
+
+## Repository
+
+`bryan-debaun/mcp-server` — Personal MCP server for VS Code Copilot. TypeScript ESM, Express 4 + TSOA, Prisma 7 + Supabase, Vitest, deployed on Render.
+
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
+**Issues:** https://github.com/bryan-debaun/mcp-server/issues
+
+## When to Use This Agent
+
+- A GitHub issue exists but requirements are incomplete or contradictory
+- A bug is reported but reproduction steps are missing
+- You need to understand what a piece of code does before proposing a change
+- You need to research an upstream API (Spotify, Supabase, GitHub) before designing a solution
+- A decision needs to be made (e.g., a policy question) before coding starts
+
+## Initial Triage
+
+1. **Read the issue** — `mcp__bryan-debaun-mcp__get-issue` (or `gh issue view N --repo bryan-debaun/mcp-server`).
+2. **Check the project board** — Todo / In Progress / Done? (`mcp__bryan-debaun-mcp__list-project-items`).
+3. **Find related code** — search for the feature, route, or tool mentioned.
+4. **Identify what's missing** — reproduction steps? expected behavior? acceptance criteria?
+
+## Codebase Quick Reference
+
+```powershell
+gh issue list --repo bryan-debaun/mcp-server --state open
+gh pr list --repo bryan-debaun/mcp-server --state closed --limit 10
+```
+Use the Grep/Glob tools (not raw Select-String) to locate where an env var, route, or tool is used.
+
+**Key entry points:**
+- `src/index.ts` — startup + transport selection
+- `src/tools/index.ts` — all registered MCP tools; `src/tools/local.ts` — REST→tool bridge (`callTool`)
+- `src/http/server.ts` — HTTP app factory, route registration order, readiness timing
+- `src/auth/` — JWT, magic-link, session, admin guard
+- `src/config.ts` — every env var (the only `process.env` reader)
+- `docs/adr/` — past architectural decisions
+
+## Bug Reproduction Template
+
+```
+**Issue:** #N — [title]
+**Environment:** local stdio | local HTTP | Render preview | Render production
+**Steps to reproduce:**
+1. Set env vars: DATABASE_URL=... MCP_API_KEY=test
+2. Start: npm run start:http (or stdio)
+3. Call: curl -H "Authorization: Bearer test" http://localhost:<PORT>/[route]
+**Expected:** [status code + response shape]
+**Actual:** [what happened, including logs]
+**Relevant logs:** [key console.error lines]
+**Key files to inspect:** [src/...]
+```
+
+## Handoff Templates
+
+### → mcp-server-coder
+```
+**Issue:** #N — https://github.com/bryan-debaun/mcp-server/issues/N
+**Summary:** [1–2 sentence problem + proposed fix]
+**Acceptance criteria:** [clear pass/fail — add if the issue lacks them]
+**Files to change:** [specific .ts files]
+**Constraints:** [must not break existing tests; security/ESM/Prisma/config constraints]
+**Open questions resolved:** [decisions made during triage]
+**Suggested branch:** feature/N-[short-desc]
+```
+
+### → mcp-server-tester
+```
+**Issue:** #N
+**Branch / files changed:** [branch + modified .ts files]
+**New behavior to cover:** [what the code does]
+**Edge cases:** [missing auth, DB unavailable, invalid input, ...]
+**Mocks needed:** [fetch? prisma? config? gh CLI?]
+**Integration test needed?** [yes/no — which gate: RUN_DB_INTEGRATION?]
+```
+
+## Common Context to Gather
+
+| Scenario | What to check |
+|----------|---------------|
+| Auth issue | `src/auth/jwt.ts`, `src/http/middleware/mcp-auth.ts`, `SUPABASE_JWKS_URL` |
+| Magic-link broken | `src/auth/magic-link.ts`, `src/http/controllers/MagicLinkController.ts`, `MAGIC_LINK_JWT_SECRET` |
+| MCP tool not found | `src/tools/index.ts` (registration), `src/server.ts`, tool schema `description` field |
+| Route returns 404 | `src/http/server.ts` (registration order), `registerDbDependentRoutes()` timing |
+| DB error at startup | `src/db/index.ts` stub contract, `DATABASE_URL` set?, Prisma generated? |
+| Spotify not polling | `src/adapters/spotify/spotify-adapter.ts`, `SPOTIFY_CLIENT_ID/SECRET/REFRESH_TOKEN` set? |
+| Admin route 403 | `INTERNAL_ADMIN_KEY`, `ADMIN_IP_ALLOWLIST`, `ADMIN_DEBUG_ENABLED` all required |
+
+## Coordinating with other agents
+
+Per the user's issue-driven workflow, **ask before creating or closing issues**. Once context is complete, recommend delegating to **mcp-server-coder** (implementation) or **mcp-server-tester** (coverage) using the templates above.

--- a/.claude/agents/mcp-server-tester.md
+++ b/.claude/agents/mcp-server-tester.md
@@ -1,0 +1,112 @@
+---
+name: mcp-server-tester
+description: Writes and runs Vitest tests for the MCP Server — MCP tool handlers, Express/TSOA routes, auth, Prisma, and adapters. Use for adding unit/integration tests, diagnosing test failures, improving coverage, and setting up mocks.
+model: sonnet
+tools: Bash, PowerShell, Read, Write, Edit, Glob, Grep, TodoWrite, mcp__bryan-debaun-mcp__get-issue, mcp__bryan-debaun-mcp__get-open-issues, mcp__bryan-debaun-mcp__get-user, mcp__bryan-debaun-mcp__list-users, mcp__bryan-debaun-mcp__close-issue, mcp__bryan-debaun-mcp__create-issue, mcp__bryan-debaun-mcp__update-issue, mcp__bryan-debaun-mcp__list-labels, mcp__bryan-debaun-mcp__create-issue-in-project, mcp__bryan-debaun-mcp__list-project-items, mcp__bryan-debaun-mcp__get-project-fields, mcp__bryan-debaun-mcp__get-project-status-options, mcp__bryan-debaun-mcp__create-project-field, mcp__bryan-debaun-mcp__update-project-field, mcp__bryan-debaun-mcp__delete-project-field, mcp__bryan-debaun-mcp__set-project-field-value, mcp__bryan-debaun-mcp__bulk-set-project-field-values, mcp__bryan-debaun-mcp__create-author, mcp__bryan-debaun-mcp__update-author, mcp__bryan-debaun-mcp__delete-author, mcp__bryan-debaun-mcp__get-author, mcp__bryan-debaun-mcp__list-authors, mcp__bryan-debaun-mcp__create-book, mcp__bryan-debaun-mcp__update-book, mcp__bryan-debaun-mcp__delete-book, mcp__bryan-debaun-mcp__get-book, mcp__bryan-debaun-mcp__list-books, mcp__bryan-debaun-mcp__create-movie, mcp__bryan-debaun-mcp__update-movie, mcp__bryan-debaun-mcp__delete-movie, mcp__bryan-debaun-mcp__get-movie, mcp__bryan-debaun-mcp__list-movies, mcp__bryan-debaun-mcp__create-videogame, mcp__bryan-debaun-mcp__update-videogame, mcp__bryan-debaun-mcp__delete-videogame, mcp__bryan-debaun-mcp__get-videogame, mcp__bryan-debaun-mcp__list-videogames, mcp__bryan-debaun-mcp__create-content-creator, mcp__bryan-debaun-mcp__update-content-creator, mcp__bryan-debaun-mcp__delete-content-creator, mcp__bryan-debaun-mcp__get-content-creator, mcp__bryan-debaun-mcp__list-content-creators
+---
+
+# MCP Server Tester
+
+You write and run Vitest tests and diagnose failures for this repository.
+
+## Repository
+
+`bryan-debaun/mcp-server` — TypeScript ESM, Node ≥20, Express 4 + TSOA, Prisma 7, Vitest + v8 coverage, `@modelcontextprotocol/sdk` v1.0.
+
+**Project board:** BAD MCP — https://github.com/users/bryan-debaun/projects/5
+
+## Test Commands (PowerShell)
+
+```powershell
+npm run test                               # all tests (CI-safe)
+npm run test:watch                         # interactive watch
+npx vitest run test/tools/                 # single directory
+npx vitest run test/http/mcp-http.test.ts  # single file
+npx vitest run -t "test name substring"    # single test by name
+npx vitest run --coverage                  # with v8 coverage report
+
+# Integration tests (require live DB / GitHub token); DB integration runs serially
+$env:RUN_DB_INTEGRATION="true"; npm run test
+$env:RUN_GITHUB_PROJECTS_INTEGRATION="true"; npm run test
+```
+
+`vitest.config.ts` loads `.env.local` for tests. **Run `npm run test` on `main` first to establish a clean baseline before writing new tests.**
+
+## Test Structure
+
+```
+test/
+  auth/           ← JWT validation, magic-link token flow
+  db/             ← Prisma init, stub behavior when DATABASE_URL missing
+  http/           ← Express routes, mcp-http transport, middleware, TSOA controllers
+  tools/          ← MCP tool handlers (github-issues, github-projects, db/*)
+  integration/    ← RLS policies, GitHub Projects V2, SendGrid (gated by env flags)
+  rls/            ← DB migration + SQL-policy-lint + snapshot tests
+  build/          ← Production dependency smoke tests
+  config/         ← config.ts parsing
+```
+
+## Mocking Conventions
+
+### Prisma (note the `.js` specifier in the mock path)
+```ts
+vi.mock('../../src/db/index.js', () => ({
+  prisma: {
+    book: { findMany: vi.fn(), findUnique: vi.fn(), create: vi.fn(), update: vi.fn(), delete: vi.fn() },
+    // add model stubs as needed
+  },
+  initPrisma: vi.fn().mockResolvedValue(undefined),
+  prismaReady: vi.fn().mockResolvedValue(undefined),
+}));
+```
+
+### `fetch` (Spotify, SendGrid, GitHub API)
+```ts
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+fetchMock.mockResolvedValue({ ok: true, json: async () => ({}), text: async () => '' });
+```
+
+### GitHub CLI (`gh`)
+```ts
+vi.mock('child_process', () => ({ execSync: vi.fn().mockReturnValue(Buffer.from('[]')) }));
+```
+
+### Config (preferred over stubbing process.env)
+Mock the centralized config module rather than `process.env`:
+```ts
+vi.mock('../../src/config.js', () => ({ config: { security: { mcpApiKey: 'test-key' }, /* ... */ } }));
+```
+When you must set env directly, use `vi.stubEnv` + `vi.unstubAllEnvs()` in `afterEach`.
+
+## Test Writing Rules
+
+### Always
+- Reset mocks in `beforeEach`/`afterEach` (`vi.clearAllMocks()` or per-mock `.mockReset()`).
+- Test error paths: missing params, invalid Zod input, service unavailable, DB missing/stubbed.
+- Test auth both ways: valid bearer token, and missing/wrong token when `MCP_API_KEY` is set.
+- Name tests by observable behavior: `it('returns 401 when MCP_API_KEY is set and token is missing')`.
+
+### Never
+- No real network calls in unit tests — mock `fetch`, `gh`, and external SDKs.
+- Don't hardcode ports; use `0` + `server.address().port` for HTTP tests.
+- Don't `.skip()` without a comment + linked issue.
+- Don't assert on log output as the primary assertion — assert return values, status codes, DB calls.
+
+### Integration tests
+- Gate with env flags: `if (!process.env.RUN_DB_INTEGRATION) { it.skip(...) }`.
+- Reference `test/integration/github-projects.test.ts` for the pattern.
+- Clean up test data in `afterAll` — never leave orphaned records in shared DBs.
+
+## Coverage Priorities
+
+1. Security-sensitive paths: auth middleware, `requireAdmin`, JWT validation, admin guards
+2. MCP tool handlers: Zod input validation, happy path, downstream-service error
+3. HTTP routes: status codes, response shape, auth-required vs public
+4. Adapters: Spotify token refresh, error fallback, stub when credentials missing
+5. Config: valid parse, defaults, alias normalization, invalid-value rejection
+6. DB init: stub behavior when `DATABASE_URL` is unset, ESM-safe import path
+
+## Coordinating with other agents
+
+When done, run the full suite, confirm green, and report: branch/PR, new test files, what's covered vs still missing, any skipped/flaky/slow tests. Then recommend delegating to **mcp-server-reviewer** for pre-merge review, or back to **mcp-server-coder** if tests expose a defect that needs a code fix.

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ test/**/*.d.ts.map
 # Agent artifacts (working files for AI agents)
 agent-artifacts/
 
+# Claude Code local settings (machine-specific; agents/ and CLAUDE.md are tracked)
+.claude/settings.local.json
+
 # Logs
 *.log
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Controllers are decorated TSOA classes. `npm run build:spec` runs `tsoa spec-and
 [src/config.ts](src/config.ts) is the **only** place that reads `process.env`. It Zod-validates all env vars and `process.exit(1)`s on invalid config. Import it for its side effect (dotenv load + validation) before other modules — `src/index.ts` imports it first. Everywhere else, read from the exported `config` object, never `process.env`.
 
 ### 7. Security layers
-- `mcpAuthMiddleware` ([src/http/middleware/mcp-auth.ts](src/http/middleware/mcp-auth.ts)): when `MCP_API_KEY` is set, requires `Authorization: Bearer <MCP_API_KEY>` on DB-dependent `/api/*` routes and `/mcp`. Public magic-link auth routes are exempt. Legacy `x-mcp-api-key` header is a deprecated fallback.
+- `mcpAuthMiddleware` ([src/http/middleware/mcp-auth.ts](src/http/middleware/mcp-auth.ts)): when `MCP_API_KEY` is set, the gateway key is required on DB-dependent `/api/*` routes and `/mcp`, via either `Authorization: Bearer <MCP_API_KEY>` (pure MCP clients) or the `X-Mcp-Api-Key` header (first-class second factor for callers whose `Authorization` already carries a Supabase user JWT). Public magic-link auth routes are exempt.
 - TSOA `@Security('jwt', ['admin'])`: Supabase-issued JWT verification (`src/auth/jwt.ts`) for user/admin REST endpoints.
 
 ## Data model

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+An extensible **Model Context Protocol (MCP) server** that exposes the same tool logic two ways: as **MCP tools** (for VS Code Copilot / MCP clients) and as a **REST API** (with auto-generated OpenAPI/Swagger). Tool categories: GitHub Issues (Octokit REST), GitHub Projects V2 (GraphQL), and a database-backed catalog (books, authors, ratings, movies, videogames, content-creators, users) over Postgres/Prisma. Also includes a Spotify read-only adapter and Supabase-JWT auth.
+
+ESM project (`"type": "module"`), Node 20+, TypeScript strict mode.
+
+## Commands
+
+```powershell
+npm run build          # FULL build: prisma generate → tsoa spec+routes → fix imports → tsc → seed
+npm run build:spec     # Regenerate tsoa routes + swagger.json ONLY (run after editing controllers)
+npm run dev            # tsc --watch
+npm start              # node dist/index.js (transport auto-selected)
+npm run start:http     # force HTTP transport (MCP_TRANSPORT=http)
+
+npm test               # vitest run (all)
+npm run test:watch     # vitest watch
+npm run typecheck      # tsc -p tsconfig.test.json --noEmit  (type-checks src + test)
+npm run lint           # eslint src/**/*.ts test/**/*.ts
+npm run lint:fix
+npm run verify         # lint + typecheck (run before proposing a commit)
+```
+
+Run a single test file / single test by name (PowerShell):
+```powershell
+npx vitest run test/http/mcp-http.test.ts
+npx vitest run -t "decideTransport prefers stdio"
+```
+
+Most tests mock external services and run without a DB. Tests that hit a real Postgres are **opt-in and gated by env flags**, and DB integration runs serially (`fileParallelism` is disabled when the flag is set — see [vitest.config.ts](vitest.config.ts)):
+```powershell
+$env:RUN_DB_INTEGRATION='true'; npm test               # enables test/integration/db.test.ts, RLS tests, etc.
+$env:RUN_GITHUB_PROJECTS_INTEGRATION='true'; npm test   # hits real GitHub Projects (needs GITHUB_TEST_* vars)
+```
+`vitest.config.ts` loads `.env.local` for tests.
+
+Database / migrations / SQL tooling:
+```powershell
+npx prisma migrate deploy        # apply migrations
+npm run prisma:dev               # prisma db push + generate (local schema iteration)
+npm run prisma:seed:dev          # seed via tsx (dev); prisma:seed runs the compiled seed
+npm run sql:parse                # dry-run lint a migration SQL file (scripts/find-sql-error.ts)
+npm run sql:validate             # apply-validate a migration SQL file
+```
+
+## Architecture — the big picture
+
+### 1. One tool implementation, two surfaces (the central pattern)
+Business logic lives **once** in `src/tools/**`. Each tool is its own file exporting a `registerXxxTool(server)` that calls `server.registerTool(name, config, handler)`. The handler returns an MCP `CallToolResult` (`{ content: [{ type, text }], isError? }`). Inputs are validated with **Zod** schemas (`schemas.ts` per category).
+
+- **MCP surface:** `src/tools/index.ts` → `registerTools()` registers every category onto the real `McpServer`.
+- **REST surface:** `src/tools/local.ts` registers the *same* tools onto a **fake server** that captures handlers into a `Map`, and exposes `callTool(name, args)` (parses the JSON text result, throws on `isError`). TSOA controllers in `src/http/controllers/*Controller.ts` are thin facades that call `callTool(...)`.
+
+**Implication:** to add catalog functionality, write the tool under `src/tools/db/<category>/`, register it, then add a controller method that delegates via `callTool`. Don't duplicate logic in the controller.
+
+### 2. TSOA code generation (REST routes + OpenAPI)
+Controllers are decorated TSOA classes. `npm run build:spec` runs `tsoa spec-and-routes` to generate `src/http/tsoa-routes.ts` and `build/swagger.json`, then `scripts/fix-tsoa-imports.ts` rewrites the generated relative imports to add `.js` extensions (TSOA emits extensionless imports, which break ESM at runtime). **Generated files are committed — regenerate with `build:spec` whenever you change a controller's routes, params, or DTO interfaces.** Config: [tsoa.json](tsoa.json). Auth integrates via `src/http/authentication.ts` (`expressAuthentication`), invoked by `@Security('jwt', [scopes])`.
+
+### 3. Transport selection (stdio vs HTTP)
+`src/index.ts` picks a transport using the pure, unit-tested helper `decideTransport()` in [src/transport-selection.ts](src/transport-selection.ts):
+- `MCP_TRANSPORT=stdio|http` forces it; otherwise production+PORT → HTTP, stdin-attached+PORT → stdio (VS Code LocalProcess), PORT alone → HTTP, nothing → stdio.
+- stdio mode connects a `StdioServerTransport`. HTTP mode calls `startHttpServer()`.
+
+### 4. HTTP server lifecycle (hosted mode)
+[src/http/server.ts](src/http/server.ts) `startHttpServer()` is built for fast cold-starts on Render:
+- Binds the port early with only liveness/readiness/metrics routes.
+- Registers the **MCP HTTP transport at `/mcp` immediately** (no DB dependency) — and a WebSocket transport at `/mcp/ws` when `MCP_API_KEY` is set.
+- Then lazily `initPrisma()` and registers DB-dependent routes; flips the **readiness** flag (`src/http/readiness.ts`) only after DB init succeeds. `EARLY_START` runs this in the background so the listener resolves immediately.
+
+### 5. Prisma: lazy init with stub fallback
+[src/db/index.ts](src/db/index.ts) exports a shared mutable `prisma` object. `initPrisma()` either populates it with a real `PrismaClient` (via the `@prisma/adapter-pg` Postgres adapter) or, **when `DATABASE_URL` is unset / client unavailable, fills it with no-op stubs** (reads return empty, writes throw). This lets the server and the GitHub-only tooling run without a database. Tool code should assume `prisma` may be a stub in non-DB environments.
+
+### 6. Configuration is centralized
+[src/config.ts](src/config.ts) is the **only** place that reads `process.env`. It Zod-validates all env vars and `process.exit(1)`s on invalid config. Import it for its side effect (dotenv load + validation) before other modules — `src/index.ts` imports it first. Everywhere else, read from the exported `config` object, never `process.env`.
+
+### 7. Security layers
+- `mcpAuthMiddleware` ([src/http/middleware/mcp-auth.ts](src/http/middleware/mcp-auth.ts)): when `MCP_API_KEY` is set, requires `Authorization: Bearer <MCP_API_KEY>` on DB-dependent `/api/*` routes and `/mcp`. Public magic-link auth routes are exempt. Legacy `x-mcp-api-key` header is a deprecated fallback.
+- TSOA `@Security('jwt', ['admin'])`: Supabase-issued JWT verification (`src/auth/jwt.ts`) for user/admin REST endpoints.
+
+## Data model
+
+Postgres via Prisma ([prisma/schema.prisma](prisma/schema.prisma)). Catalog entities (`Book`, `Movie`, `VideoGame`) share an `ItemStatus` enum (`NOT_STARTED|IN_PROGRESS|COMPLETED`) and **embed rating fields directly** (`rating`, `review`, `ratedAt`) rather than a separate ratings table for the single-user case. `Profile` is keyed by the Supabase Auth UUID. Row-Level-Security policies are exercised by `test/rls/**` and `test/integration/rls*` (DB-integration-gated), and migration SQL is lint-checked via the `sql:parse`/`sql:validate` scripts.
+
+## Conventions specific to this repo
+
+- **ESM imports must include the `.js` extension** on relative paths (e.g. `import { x } from './foo.js'`), even though the source is `.ts`. This applies to hand-written code and is the reason `fix-tsoa-imports.ts` exists for generated code.
+- One tool = one file + a `registerXxxTool` function; aggregate registration in the category `index.ts`; Zod input schemas in `schemas.ts`; success/error result builders in `results.ts`.
+- `docs/adr/` holds architecture decision records (transport, HTTP facade, hosting); `docs/handoffs/` and `agent-artifacts/` hold working notes and agent-generated drafts.
+- The `README.md` is partly out of date (its "Project Structure" section predates the HTTP/REST/DB expansion) — trust the source and this file over it for architecture.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ GITHUB_TOKEN=ghp_your_personal_access_token
 # When `MCP_API_KEY` is set, MCP transport endpoints (eg. `/mcp`) and DB-dependent routes (`/api/*` for books/authors/ratings) require `Authorization: Bearer <MCP_API_KEY>`.
 MCP_API_KEY=your-secret-key
 
-> Note: A legacy header `x-mcp-api-key` is temporarily supported as a fallback but is deprecated and will be removed in a future release; the server emits a deprecation log when it is used.
+> Note: The gateway key may also be sent via the `X-Mcp-Api-Key` header. This is a first-class, supported second factor for callers whose `Authorization` header already carries a Supabase user JWT (e.g. the website's admin requests, which send `Authorization: Bearer <SUPABASE_JWT>` + `X-Mcp-Api-Key: <MCP_API_KEY>`). Pure MCP clients may instead send the key directly as `Authorization: Bearer <MCP_API_KEY>`.
 
 # Optional: For admin endpoints
 INTERNAL_ADMIN_KEY=your-admin-key

--- a/docs/adr/0009-mcp-api-key-auth.md
+++ b/docs/adr/0009-mcp-api-key-auth.md
@@ -4,7 +4,9 @@ Date: 2026-02-04
 
 ## Status
 
-Proposed/Accepted
+Accepted
+
+> **Update (2026-05, #90):** The `X-Mcp-Api-Key` header is **no longer deprecated**. It is now a first-class second factor, because the dual-credential pattern is legitimate: a caller's `Authorization` header carries a Supabase **user JWT** (for `jwtMiddleware`/TSOA admin auth) while the **gateway key** needs its own header. The deprecation warning and the "remove after a short period" intent below are superseded. Pure MCP clients may still send the key as `Authorization: Bearer <MCP_API_KEY>`; callers presenting a user JWT send it as `X-Mcp-Api-Key`. The middleware also no longer logs the presented credential value.
 
 ## Context
 

--- a/docs/mcp-http.md
+++ b/docs/mcp-http.md
@@ -56,4 +56,4 @@ The server exposes `GET /api/auth/session` which reads the `session` cookie and 
 
 Missing or invalid sessions return `401`. Rate-limiting protections apply and are configurable via `SESSION_RATE_LIMIT_PER_IP` and `SESSION_RATE_LIMIT_WINDOW_MS`.
 
-> **Note:** When `MCP_API_KEY` is set, DB-dependent routes under `/api/*` (books, authors, ratings) are also protected by the same API key. Requests must present `Authorization: Bearer <MCP_API_KEY>`. As a temporary fallback we accept `x-mcp-api-key` but this header is **deprecated** and will be removed in a future release (the server logs a deprecation warning when it is used).
+> **Note:** When `MCP_API_KEY` is set, DB-dependent routes under `/api/*` (books, authors, ratings) are also protected by the same API key. Present the key one of two supported ways: `Authorization: Bearer <MCP_API_KEY>` (pure MCP clients), or the **`X-Mcp-Api-Key: <MCP_API_KEY>`** header — a first-class second factor for callers whose `Authorization` header already carries a Supabase user JWT (e.g. the website's admin requests).

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -30,7 +30,17 @@ export async function runSeed(prismaClient?: any) {
 
     // Generate UUIDs for profiles (matching Supabase Auth format)
     const crypto = await import('crypto')
-    const bryanUuid = crypto.randomUUID()
+    // Bryan's Profile.id MUST equal his Supabase Auth user.id for JWT admin auth
+    // to resolve him as admin (see issue #90). Supply it via ADMIN_SUPABASE_UUID.
+    const adminSupabaseUuid = process.env.ADMIN_SUPABASE_UUID
+    if (!adminSupabaseUuid) {
+        console.warn(
+            'ADMIN_SUPABASE_UUID not set — using a random UUID for the admin Profile. ' +
+            'JWT admin auth will not match the Supabase user until this is set and any ' +
+            'existing prod row is reconciled (see issue #90).'
+        )
+    }
+    const bryanUuid = adminSupabaseUuid ?? crypto.randomUUID()
     const adminUuid = crypto.randomUUID()
 
     // Create Bryan's admin profile

--- a/src/adapters/spotify/spotify-adapter.ts
+++ b/src/adapters/spotify/spotify-adapter.ts
@@ -8,12 +8,39 @@ let cachedAccessToken: string | null = null;
 let tokenExpiresAt = 0; // epoch ms
 let pollHandle: NodeJS.Timeout | null = null;
 
+// Runtime override for the refresh token (e.g. seeded via the admin OAuth
+// callback after startup). When set it takes precedence over the startup
+// config value, so a freshly-seeded token is used without a restart.
+let refreshTokenOverride: string | null = null;
+
 function nowMs() { return Date.now(); }
+
+/** The active refresh token: a runtime override wins over the startup config. */
+function currentRefreshToken(): string | undefined {
+    return refreshTokenOverride ?? config.spotify.refreshToken;
+}
+
+/** Whether the adapter has all credentials it needs to run (override-aware). */
+export function isSpotifyConfigured(): boolean {
+    return Boolean(config.spotify.clientId && config.spotify.clientSecret && currentRefreshToken());
+}
+
+/**
+ * Seed/replace the refresh token at runtime and invalidate the cached access
+ * token so the next call re-authenticates with the new token. Used by the admin
+ * OAuth-callback endpoint instead of mutating process.env (which the adapter
+ * never reads).
+ */
+export function setSpotifyRefreshToken(token: string): void {
+    refreshTokenOverride = token;
+    cachedAccessToken = null;
+    tokenExpiresAt = 0;
+}
 
 async function refreshAccessToken(): Promise<string> {
     const clientId = config.spotify.clientId;
     const clientSecret = config.spotify.clientSecret;
-    const refreshToken = config.spotify.refreshToken;
+    const refreshToken = currentRefreshToken();
 
     if (!clientId || !clientSecret || !refreshToken) throw new Error('Spotify credentials not configured');
 
@@ -105,7 +132,7 @@ export async function getPlaylists(limit = 20, offset = 0): Promise<any> {
 }
 
 export async function startSpotifyAdapter() {
-    if (!config.spotify.enabled) return;
+    if (!isSpotifyConfigured()) return;
 
     // Prime a token so errors are visible on startup
     try {

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -51,20 +51,74 @@ export async function verifySupabaseJwt(token: string): Promise<JWTPayload> {
     return payload
 }
 
-async function findLocalProfileBySub(sub: string) {
-    if (!sub) return null
-    const s = String(sub)
-    if (/^[0-9a-fA-F-]{36}$/.test(s)) return prisma.profile.findUnique({ where: { external_id: s } as any, include: { role: true } })
-    if (s.includes('@')) return prisma.profile.findUnique({ where: { email: s } as any, include: { role: true } })
+/**
+ * Resolve an application role baked into the token, if present.
+ *
+ * NOTE: Supabase always sets a top-level `role` claim, but it is the Postgres
+ * role (`anon` | `authenticated` | `service_role`) — NOT an application role.
+ * We deliberately ignore that claim and look for an app-level role under
+ * `app_metadata.role` (admin-controlled, the standard Supabase RBAC location)
+ * or a custom top-level `user_role` claim emitted by a custom access-token hook.
+ */
+function roleFromToken(payload: any): string | undefined {
+    const appRole = payload?.app_metadata?.role ?? payload?.user_role
+    return typeof appRole === 'string' && appRole.length > 0 ? appRole : undefined
+}
+
+/**
+ * Look up the local Profile for a Supabase user. `Profile.id` IS the Supabase
+ * Auth `user.id` (UUID), so match on `id` first; fall back to `email` (from the
+ * JWT) so admin auth still works when a stored Profile.id has not yet been
+ * reconciled with the Supabase UUID. See issue #90.
+ */
+async function findLocalProfileBySub(sub: string, email?: string) {
+    const s = sub ? String(sub) : ''
+    if (s && /^[0-9a-fA-F-]{36}$/.test(s)) {
+        const byId = await prisma.profile.findUnique({ where: { id: s } })
+        if (byId) return byId
+    }
+    const emailToTry = s.includes('@') ? s : email
+    if (emailToTry) return prisma.profile.findUnique({ where: { email: emailToTry } })
     return null
 }
 
-function attachLocalProfileToReq(req: any, profile: any) {
-    if (!profile) return
-    req.user.role = profile.role?.name ?? (profile.isAdmin ? 'admin' : 'user')
-    req.user.isAdmin = Boolean(profile.isAdmin)
-    req.user.localUserId = profile.id
-    req.user.external_id = profile.external_id
+export interface ResolvedAuthz {
+    role: string
+    isAdmin: boolean
+    localUserId?: unknown
+}
+
+/**
+ * Hybrid authorization resolution: prefer an app role baked into the token
+ * (stateless, no DB hit — the standard/scalable path); otherwise fall back to
+ * the local Profile (by id, then email). Pure — returns the resolution so both
+ * the Express middleware and the TSOA authentication handler can share it.
+ */
+export async function resolveAppRole(payload: any): Promise<ResolvedAuthz> {
+    const tokenRole = roleFromToken(payload)
+    if (tokenRole) {
+        return { role: tokenRole, isAdmin: tokenRole === 'admin', localUserId: payload?.sub }
+    }
+
+    const profile = await findLocalProfileBySub(
+        payload?.sub ? String(payload.sub) : '',
+        typeof payload?.email === 'string' ? payload.email : undefined
+    )
+    if (profile) {
+        return { role: profile.isAdmin ? 'admin' : 'user', isAdmin: Boolean(profile.isAdmin), localUserId: profile.id }
+    }
+
+    // No app role and no local profile: preserve the token's (Postgres) role
+    // claim so non-admin authenticated users still pass non-admin guards.
+    return { role: typeof payload?.role === 'string' ? payload.role : 'user', isAdmin: false }
+}
+
+/** Resolve authz for a request and mutate `req.user` in place. */
+async function resolveUserAuthz(req: any, payload: any) {
+    const { role, isAdmin, localUserId } = await resolveAppRole(payload)
+    req.user.role = role
+    req.user.isAdmin = isAdmin
+    if (localUserId !== undefined) req.user.localUserId = localUserId
 }
 
 function parseCookies(header?: string) {
@@ -104,14 +158,11 @@ export async function jwtMiddleware(req: Request, res: Response, next: NextFunct
             // attach a minimal user object (from token)
             (<any>req).user = Object.assign({ sub: payload.sub }, payload);
 
-            // If the token represents a Supabase user (sub is UUID or email), attach local profile when present
+            // Resolve application role (token claim preferred, local Profile fallback)
             try {
-                if (payload.sub) {
-                    const localProfile = await findLocalProfileBySub(String(payload.sub))
-                    if (localProfile) attachLocalProfileToReq(req as any, localProfile)
-                }
+                await resolveUserAuthz(req as any, payload)
             } catch (err) {
-                console.debug('jwtMiddleware: failed to lookup local user for token sub', err)
+                console.debug('jwtMiddleware: failed to resolve authz for token sub', err)
             }
 
             return next()
@@ -125,12 +176,9 @@ export async function jwtMiddleware(req: Request, res: Response, next: NextFunct
                 ; (req as any).user = Object.assign({ sub: payload.sub ?? payload.userId }, payload)
 
             try {
-                if (payload.sub) {
-                    const localProfile = await findLocalProfileBySub(String(payload.sub))
-                    if (localProfile) attachLocalProfileToReq(req as any, localProfile)
-                }
+                await resolveUserAuthz(req as any, (req as any).user)
             } catch (err) {
-                console.debug('jwtMiddleware: failed to lookup local user for session payload', err)
+                console.debug('jwtMiddleware: failed to resolve authz for session payload', err)
             }
 
             return next()

--- a/src/http/authentication.ts
+++ b/src/http/authentication.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express';
-import { verifySupabaseJwt } from '../auth/jwt.js';
+import { verifySupabaseJwt, resolveAppRole } from '../auth/jwt.js';
 
 /**
  * Tsoa authentication handler for JWT bearer tokens
@@ -17,25 +17,25 @@ export async function expressAuthentication(
             throw new Error('No token provided');
         }
 
-        try {
-            // Use existing Supabase JWT verification
-            const decoded = await verifySupabaseJwt(token);
-            // If scopes are required (e.g., ['admin']), verify user has them
-            if (scopes && scopes.length > 0) {
-                const userRole = decoded.role || 'user';
-                const hasRequiredScope = scopes.some(scope =>
-                    scope === userRole || userRole === 'admin'
-                );
+        const decoded = await verifySupabaseJwt(token);
 
-                if (!hasRequiredScope) {
-                    throw new Error('Insufficient permissions');
-                }
+        // Resolve the application role the same way as the Express middleware:
+        // a token-baked app role (app_metadata.role) wins, otherwise the local
+        // Profile (by id, then email). The Supabase top-level `role` claim is
+        // the Postgres role ('authenticated') — NOT an app role — so checking it
+        // directly (the previous behavior) always failed admin scope checks.
+        const { role, isAdmin } = await resolveAppRole(decoded);
+
+        if (scopes && scopes.length > 0) {
+            const hasRequiredScope = isAdmin || scopes.some(scope => scope === role);
+            if (!hasRequiredScope) {
+                throw new Error('Insufficient permissions');
             }
-
-            return decoded;
-        } catch (err: any) {
-            throw new Error('Invalid token: ' + err.message);
         }
+
+        // Attach the resolved user to the request so controllers can read it.
+        (request as any).user = Object.assign({}, decoded, { role, isAdmin });
+        return (request as any).user;
     }
 
     throw new Error('Unknown security name: ' + securityName);

--- a/src/http/controllers/AuthorsController.ts
+++ b/src/http/controllers/AuthorsController.ts
@@ -1,5 +1,7 @@
 import { Controller, Get, Post, Put, Delete, Query, Route, Tags, Response, SuccessResponse, Path, Body, Security, Request } from 'tsoa';
 import type { Request as ExpressRequest } from 'express';
+import { callTool } from '../../tools/local.js';
+import { isNotFound, httpError } from './_http-errors.js';
 
 /**
  * Author representation
@@ -69,19 +71,8 @@ export class AuthorsController extends Controller {
         @Query() limit?: number,
         @Query() offset?: number
     ): Promise<ListAuthorsResponse> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('list-authors', {
-                search,
-                limit,
-                offset
-            });
-            return result as ListAuthorsResponse;
-        } catch (err: any) {
-            console.error('list-authors failed', err);
-            // Gracefully degrade: return empty list if database is unavailable
-            return { authors: [], total: 0 };
-        }
+        const result = await callTool('list-authors', { search, limit, offset });
+        return result as ListAuthorsResponse;
     }
 
     /**
@@ -94,14 +85,12 @@ export class AuthorsController extends Controller {
     @Response('404', 'Author not found')
     @Response('400', 'Invalid author ID')
     public async getAuthor(@Path() id: number): Promise<AuthorWithBooks> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             const result = await callTool('get-author', { id });
             return result as AuthorWithBooks;
         } catch (err: any) {
-            console.error('get-author failed', err);
-            this.setStatus(404);
-            throw new Error('Author not found');
+            if (isNotFound(err)) throw httpError(404, 'Author not found');
+            throw err;
         }
     }
 
@@ -121,25 +110,12 @@ export class AuthorsController extends Controller {
         @Request() request: ExpressRequest,
         @Body() body: CreateAuthorRequest
     ): Promise<Author> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            if (!body.name) {
-                this.setStatus(400);
-                throw new Error('name is required');
-            }
+        if (!body.name) throw httpError(400, 'name is required');
 
-            const createdBy = (request as any).user?.sub ? Number((request as any).user.sub) : undefined;
-            const result = await callTool('create-author', {
-                ...body,
-                createdBy
-            });
-            this.setStatus(201);
-            return result as Author;
-        } catch (err: any) {
-            console.error('create-author failed', err);
-            this.setStatus(500);
-            throw new Error('Failed to create author');
-        }
+        const createdBy = (request as any).user?.sub ? Number((request as any).user.sub) : undefined;
+        const result = await callTool('create-author', { ...body, createdBy });
+        this.setStatus(201);
+        return result as Author;
     }
 
     /**
@@ -159,21 +135,12 @@ export class AuthorsController extends Controller {
         @Path() id: number,
         @Body() body: UpdateAuthorRequest
     ): Promise<Author> {
-        const { callTool } = await import('../../tools/local.js');
         try {
-            const result = await callTool('update-author', {
-                id,
-                ...body
-            });
+            const result = await callTool('update-author', { id, ...body });
             return result as Author;
         } catch (err: any) {
-            console.error('update-author failed', err);
-            if (err.message?.includes('not found')) {
-                this.setStatus(404);
-                throw new Error('Author not found');
-            }
-            this.setStatus(500);
-            throw new Error('Failed to update author');
+            if (isNotFound(err)) throw httpError(404, 'Author not found');
+            throw err;
         }
     }
 
@@ -190,18 +157,12 @@ export class AuthorsController extends Controller {
     @Response('404', 'Author not found')
     @Response('500', 'Internal server error')
     public async deleteAuthor(@Path() id: number): Promise<{ success: boolean }> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             await callTool('delete-author', { id });
             return { success: true };
         } catch (err: any) {
-            console.error('delete-author failed', err);
-            if (err.message?.includes('not found')) {
-                this.setStatus(404);
-                throw new Error('Author not found');
-            }
-            this.setStatus(500);
-            throw new Error('Failed to delete author');
+            if (isNotFound(err)) throw httpError(404, 'Author not found');
+            throw err;
         }
     }
 }

--- a/src/http/controllers/BooksController.ts
+++ b/src/http/controllers/BooksController.ts
@@ -1,6 +1,8 @@
 import { Controller, Get, Post, Put, Delete, Query, Route, Tags, Response, SuccessResponse, Path, Body, Security, Request } from 'tsoa';
 import type { Request as ExpressRequest } from 'express';
 import type { ItemStatus } from '../../tools/db/books/status';
+import { callTool } from '../../tools/local.js';
+import { isNotFound, isUniqueViolation, httpError } from './_http-errors.js';
 
 /**
  * Book representation - force TSOA refresh
@@ -89,21 +91,10 @@ export class BooksController extends Controller {
         @Query() limit?: number,
         @Query() offset?: number
     ): Promise<ListBooksResponse> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('list-books', {
-                authorId,
-                minRating,
-                search,
-                limit,
-                offset
-            });
-            return result as ListBooksResponse;
-        } catch (err: any) {
-            console.error('list-books failed', err);
-            // Gracefully degrade: return empty list if database is unavailable
-            return { books: [], total: 0 };
-        }
+        // Let failures surface as 5xx via the global error handler — an empty
+        // result must mean "no books", never "the database is down".
+        const result = await callTool('list-books', { authorId, minRating, search, status, limit, offset });
+        return result as ListBooksResponse;
     }
 
     /**
@@ -116,14 +107,12 @@ export class BooksController extends Controller {
     @Response('404', 'Book not found')
     @Response('400', 'Invalid book ID')
     public async getBook(@Path() id: number): Promise<BookWithAuthors> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             const result = await callTool('get-book', { id });
             return result as BookWithAuthors;
         } catch (err: any) {
-            console.error('get-book failed', err);
-            this.setStatus(404);
-            throw new Error('Book not found');
+            if (isNotFound(err)) throw httpError(404, 'Book not found');
+            throw err;
         }
     }
 
@@ -143,28 +132,16 @@ export class BooksController extends Controller {
         @Request() request: ExpressRequest,
         @Body() body: CreateBookRequest
     ): Promise<Book> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            if (!body.title) {
-                this.setStatus(400);
-                throw new Error('title is required');
-            }
+        if (!body.title) throw httpError(400, 'title is required');
 
+        try {
             const createdBy = (request as any).user?.sub ? Number((request as any).user.sub) : undefined;
-            const result = await callTool('create-book', {
-                ...body,
-                createdBy
-            });
+            const result = await callTool('create-book', { ...body, createdBy });
             this.setStatus(201);
             return result as Book;
         } catch (err: any) {
-            console.error('create-book failed', err);
-            if (err.message?.includes('Unique constraint') || err.message?.includes('already exists')) {
-                this.setStatus(400);
-                throw new Error('ISBN already exists');
-            }
-            this.setStatus(500);
-            throw new Error('Failed to create book');
+            if (isUniqueViolation(err)) throw httpError(400, 'ISBN already exists');
+            throw err;
         }
     }
 
@@ -185,25 +162,13 @@ export class BooksController extends Controller {
         @Path() id: number,
         @Body() body: UpdateBookRequest
     ): Promise<Book> {
-        const { callTool } = await import('../../tools/local.js');
         try {
-            const result = await callTool('update-book', {
-                id,
-                ...body
-            });
+            const result = await callTool('update-book', { id, ...body });
             return result as Book;
         } catch (err: any) {
-            console.error('update-book failed', err);
-            if (err.message?.includes('not found')) {
-                this.setStatus(404);
-                throw new Error('Book not found');
-            }
-            if (err.message?.includes('Unique constraint') || err.message?.includes('already exists')) {
-                this.setStatus(400);
-                throw new Error('ISBN already exists');
-            }
-            this.setStatus(500);
-            throw new Error('Failed to update book');
+            if (isNotFound(err)) throw httpError(404, 'Book not found');
+            if (isUniqueViolation(err)) throw httpError(400, 'ISBN already exists');
+            throw err;
         }
     }
 
@@ -220,18 +185,12 @@ export class BooksController extends Controller {
     @Response('404', 'Book not found')
     @Response('500', 'Internal server error')
     public async deleteBook(@Path() id: number): Promise<{ success: boolean }> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             await callTool('delete-book', { id });
             return { success: true };
         } catch (err: any) {
-            console.error('delete-book failed', err);
-            if (err.message?.includes('not found')) {
-                this.setStatus(404);
-                throw new Error('Book not found');
-            }
-            this.setStatus(500);
-            throw new Error('Failed to delete book');
+            if (isNotFound(err)) throw httpError(404, 'Book not found');
+            throw err;
         }
     }
 }

--- a/src/http/controllers/ContentCreatorsController.ts
+++ b/src/http/controllers/ContentCreatorsController.ts
@@ -1,4 +1,6 @@
 import { Controller, Get, Post, Put, Delete, Path, Body, Route, Tags, Response, SuccessResponse, Security, Query } from 'tsoa';
+import { callTool } from '../../tools/local.js';
+import { isNotFound, httpError } from './_http-errors.js';
 
 export interface ContentCreator {
     id: number;
@@ -33,27 +35,22 @@ export class ContentCreatorsController extends Controller {
     @Get()
     @SuccessResponse('200', 'Content creators retrieved successfully')
     public async listContentCreators(@Query() search?: string, @Query() limit?: number, @Query() offset?: number): Promise<ListContentCreatorsResponse> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('list-content-creators', { search, limit, offset });
-            return result as ListContentCreatorsResponse;
-        } catch (err: any) {
-            console.error('list-content-creators failed', err);
-            return { creators: [], total: 0 };
-        }
+        const result = await callTool('list-content-creators', { search, limit, offset });
+        return result as ListContentCreatorsResponse;
     }
 
     @Get('{id}')
     @SuccessResponse('200', 'Content creator retrieved successfully')
     @Response('404', 'Content creator not found')
     public async getContentCreator(@Path() id: number): Promise<ContentCreator> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             const result = await callTool('get-content-creator', { id });
             return result as ContentCreator;
         } catch (err: any) {
-            console.error('get-content-creator failed', err);
-            throw new Error('Content creator not found');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Content creator not found');
+            }
+            throw err;
         }
     }
 
@@ -61,16 +58,9 @@ export class ContentCreatorsController extends Controller {
     @Security('jwt', ['admin'])
     @SuccessResponse('201', 'Content creator created successfully')
     public async createContentCreator(@Body() body: CreateContentCreatorRequest): Promise<ContentCreator> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('create-content-creator', body);
-            this.setStatus(201);
-            return result as ContentCreator;
-        } catch (err: any) {
-            console.error('create-content-creator failed', err);
-            this.setStatus(500);
-            throw new Error('Failed to create content creator');
-        }
+        const result = await callTool('create-content-creator', body);
+        this.setStatus(201);
+        return result as ContentCreator;
     }
 
     @Put('{id}')
@@ -78,29 +68,30 @@ export class ContentCreatorsController extends Controller {
     @SuccessResponse('200', 'Content creator updated successfully')
     @Response('404', 'Content creator not found')
     public async updateContentCreator(@Path() id: number, @Body() body: UpdateContentCreatorRequest): Promise<ContentCreator> {
-        const { callTool } = await import('../../tools/local.js');
         try {
-            const payload = { ...(body as any), id };
-            const result = await callTool('update-content-creator', payload);
+            const result = await callTool('update-content-creator', { ...(body as any), id });
             return result as ContentCreator;
         } catch (err: any) {
-            console.error('update-content-creator failed', err);
-            throw new Error('Content creator not found');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Content creator not found');
+            }
+            throw err;
         }
     }
 
     @Delete('{id}')
     @Security('jwt', ['admin'])
     @SuccessResponse('200', 'Content creator deleted successfully')
+    @Response('404', 'Content creator not found')
     public async deleteContentCreator(@Path() id: number): Promise<{ success: boolean }> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             await callTool('delete-content-creator', { id });
             return { success: true };
         } catch (err: any) {
-            console.error('delete-content-creator failed', err);
-            this.setStatus(500);
-            throw new Error('Failed to delete content creator');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Content creator not found');
+            }
+            throw err;
         }
     }
 }

--- a/src/http/controllers/MoviesController.ts
+++ b/src/http/controllers/MoviesController.ts
@@ -1,4 +1,6 @@
 import { Controller, Get, Post, Put, Delete, Path, Body, Route, Tags, Response, SuccessResponse, Security, Query } from 'tsoa';
+import { callTool } from '../../tools/local.js';
+import { isNotFound, httpError } from './_http-errors.js';
 
 export interface Movie {
     id: number;
@@ -47,29 +49,22 @@ export class MoviesController extends Controller {
     @Get()
     @SuccessResponse('200', 'Movies retrieved successfully')
     public async listMovies(@Query() status?: string, @Query() search?: string, @Query() limit?: number, @Query() offset?: number): Promise<ListMoviesResponse> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('list-movies', { status, search, limit, offset });
-            return result as ListMoviesResponse;
-        } catch (err: any) {
-            console.error('list-movies failed', err);
-            return { movies: [], total: 0 };
-        }
+        const result = await callTool('list-movies', { status, search, limit, offset });
+        return result as ListMoviesResponse;
     }
 
     @Get('{id}')
     @SuccessResponse('200', 'Movie retrieved successfully')
     @Response('404', 'Movie not found')
     public async getMovie(@Path() id: number): Promise<Movie> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             const result = await callTool('get-movie', { id });
             return result as Movie;
         } catch (err: any) {
-            console.error('get-movie failed', err);
-            const e: any = new Error('Movie not found');
-            e.status = 404;
-            throw e;
+            if (isNotFound(err)) {
+                throw httpError(404, 'Movie not found');
+            }
+            throw err;
         }
     }
 
@@ -77,16 +72,9 @@ export class MoviesController extends Controller {
     @Security('jwt', ['admin'])
     @SuccessResponse('201', 'Movie created successfully')
     public async createMovie(@Body() body: CreateMovieRequest): Promise<Movie> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('create-movie', body);
-            this.setStatus(201);
-            return result as Movie;
-        } catch (err: any) {
-            console.error('create-movie failed', err);
-            this.setStatus(500);
-            throw new Error('Failed to create movie');
-        }
+        const result = await callTool('create-movie', body);
+        this.setStatus(201);
+        return result as Movie;
     }
 
     @Put('{id}')
@@ -94,29 +82,30 @@ export class MoviesController extends Controller {
     @SuccessResponse('200', 'Movie updated successfully')
     @Response('404', 'Movie not found')
     public async updateMovie(@Path() id: number, @Body() body: UpdateMovieRequest): Promise<Movie> {
-        const { callTool } = await import('../../tools/local.js');
         try {
-            const payload = { ...(body as any), id };
-            const result = await callTool('update-movie', payload);
+            const result = await callTool('update-movie', { ...(body as any), id });
             return result as Movie;
         } catch (err: any) {
-            console.error('update-movie failed', err);
-            throw new Error('Movie not found');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Movie not found');
+            }
+            throw err;
         }
     }
 
     @Delete('{id}')
     @Security('jwt', ['admin'])
     @SuccessResponse('200', 'Movie deleted successfully')
+    @Response('404', 'Movie not found')
     public async deleteMovie(@Path() id: number): Promise<{ success: boolean }> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             await callTool('delete-movie', { id });
             return { success: true };
         } catch (err: any) {
-            console.error('delete-movie failed', err);
-            this.setStatus(500);
-            throw new Error('Failed to delete movie');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Movie not found');
+            }
+            throw err;
         }
     }
 }

--- a/src/http/controllers/SessionController.ts
+++ b/src/http/controllers/SessionController.ts
@@ -2,6 +2,7 @@ import { Controller, Route, Tags, Get, Request, Response } from 'tsoa'
 import type { Request as ExpressRequest } from 'express'
 import { verifySessionToken } from '../../auth/session.js'
 import { prisma } from '../../db/index.js'
+import { config } from '../../config.js'
 import { Counter } from 'prom-client'
 
 const sessionRequestsTotal = new Counter({ name: 'session_requests_total', help: 'Total session endpoint requests' })
@@ -10,9 +11,9 @@ const sessionRateLimitedTotal = new Counter({ name: 'session_rate_limited_total'
 // Simple per-IP rate limiting
 const ipRateMap: Map<string, { count: number; reset: number }> = new Map()
 function rateLimitIp(req: ExpressRequest): boolean {
-    // Read limits dynamically so tests can override env vars at runtime
-    const limit = Number(process.env.SESSION_RATE_LIMIT_PER_IP ?? 60)
-    const windowMs = Number(process.env.SESSION_RATE_LIMIT_WINDOW_MS ?? 60 * 1000)
+    // Centralized config (tests can override config.auth.* at runtime)
+    const limit = config.auth.sessionRateLimitPerIp
+    const windowMs = config.auth.sessionRateLimitWindowMs
 
     // Normalize IP so IPv4-mapped IPv6 addresses match the IPv4 representation
     const rawIp = req.ip || 'unknown'
@@ -81,8 +82,8 @@ export class SessionController extends Controller {
             }
 
             // Lazy-provision local profile if Supabase Auth is configured and we found a Supabase subject
-            const supabaseUrlEnv = process.env.PUBLIC_SUPABASE_URL ?? process.env.SUPABASE_ISS
-            const supabaseKeyEnv = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY
+            const supabaseUrlEnv = config.auth.supabaseIss
+            const supabaseKeyEnv = config.auth.supabaseServiceRoleKey
             if (!user && supabaseUrlEnv && supabaseKeyEnv && payload.sub) {
                 try {
                     const supabaseUrl = String(supabaseUrlEnv).replace(/\/$/, '')

--- a/src/http/controllers/SpotifyAdminController.ts
+++ b/src/http/controllers/SpotifyAdminController.ts
@@ -83,9 +83,10 @@ export class SpotifyAdminController extends Controller {
                 throw err
             }
 
-            // Set in-process so adapter picks it up immediately
-            // Runtime write: seeds the token in-process after OAuth callback; config.spotify.refreshToken reflects startup value only
-            process.env.SPOTIFY_REFRESH_TOKEN = refreshToken
+            // Seed the token into the adapter in-process so it's used immediately
+            // (the adapter reads its own override, not process.env).
+            const adapter = await import('../../adapters/spotify/spotify-adapter.js')
+            adapter.setSpotifyRefreshToken(refreshToken)
 
             // Persist to .env.local in development for convenience (do NOT persist in test/prod)
             let persisted = false
@@ -110,13 +111,10 @@ export class SpotifyAdminController extends Controller {
                 }
             }
 
-            // If adapter is running/available, attempt to start/restart it so the new token is used immediately
+            // Start/restart the adapter so the new token is used immediately
+            // (idempotent; no-ops if prerequisites are still missing).
             try {
-                const mod = await import('../../adapters/spotify/spotify-adapter.js')
-                if (mod && typeof mod.startSpotifyAdapter === 'function') {
-                    // startSpotifyAdapter is idempotent and will no-op if prerequisites missing
-                    await mod.startSpotifyAdapter()
-                }
+                await adapter.startSpotifyAdapter()
             } catch (err) {
                 console.error('spotify-admin: failed to start adapter after seeding token', err)
             }

--- a/src/http/controllers/VideoGamesController.ts
+++ b/src/http/controllers/VideoGamesController.ts
@@ -1,4 +1,6 @@
 import { Controller, Get, Post, Put, Delete, Path, Body, Route, Tags, Response, SuccessResponse, Security, Query } from 'tsoa';
+import { callTool } from '../../tools/local.js';
+import { isNotFound, httpError } from './_http-errors.js';
 
 export interface VideoGame {
     id: number;
@@ -47,27 +49,22 @@ export class VideoGamesController extends Controller {
     @Get()
     @SuccessResponse('200', 'Video games retrieved successfully')
     public async listVideoGames(@Query() platform?: string, @Query() search?: string, @Query() limit?: number, @Query() offset?: number): Promise<ListVideoGamesResponse> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('list-videogames', { platform, search, limit, offset });
-            return result as ListVideoGamesResponse;
-        } catch (err: any) {
-            console.error('list-videogames failed', err);
-            return { videoGames: [], total: 0 };
-        }
+        const result = await callTool('list-videogames', { platform, search, limit, offset });
+        return result as ListVideoGamesResponse;
     }
 
     @Get('{id}')
     @SuccessResponse('200', 'Video game retrieved successfully')
     @Response('404', 'Video game not found')
     public async getVideoGame(@Path() id: number): Promise<VideoGame> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             const result = await callTool('get-videogame', { id });
             return result as VideoGame;
         } catch (err: any) {
-            console.error('get-videogame failed', err);
-            throw new Error('Video game not found');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Video game not found');
+            }
+            throw err;
         }
     }
 
@@ -75,16 +72,9 @@ export class VideoGamesController extends Controller {
     @Security('jwt', ['admin'])
     @SuccessResponse('201', 'Video game created successfully')
     public async createVideoGame(@Body() body: CreateVideoGameRequest): Promise<VideoGame> {
-        const { callTool } = await import('../../tools/local.js');
-        try {
-            const result = await callTool('create-videogame', body);
-            this.setStatus(201);
-            return result as VideoGame;
-        } catch (err: any) {
-            console.error('create-videogame failed', err);
-            this.setStatus(500);
-            throw new Error('Failed to create video game');
-        }
+        const result = await callTool('create-videogame', body);
+        this.setStatus(201);
+        return result as VideoGame;
     }
 
     @Put('{id}')
@@ -92,29 +82,30 @@ export class VideoGamesController extends Controller {
     @SuccessResponse('200', 'Video game updated successfully')
     @Response('404', 'Video game not found')
     public async updateVideoGame(@Path() id: number, @Body() body: UpdateVideoGameRequest): Promise<VideoGame> {
-        const { callTool } = await import('../../tools/local.js');
         try {
-            const payload = { ...(body as any), id };
-            const result = await callTool('update-videogame', payload);
+            const result = await callTool('update-videogame', { ...(body as any), id });
             return result as VideoGame;
         } catch (err: any) {
-            console.error('update-videogame failed', err);
-            throw new Error('Video game not found');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Video game not found');
+            }
+            throw err;
         }
     }
 
     @Delete('{id}')
     @Security('jwt', ['admin'])
     @SuccessResponse('200', 'Video game deleted successfully')
+    @Response('404', 'Video game not found')
     public async deleteVideoGame(@Path() id: number): Promise<{ success: boolean }> {
-        const { callTool } = await import('../../tools/local.js');
         try {
             await callTool('delete-videogame', { id });
             return { success: true };
         } catch (err: any) {
-            console.error('delete-videogame failed', err);
-            this.setStatus(500);
-            throw new Error('Failed to delete video game');
+            if (isNotFound(err)) {
+                throw httpError(404, 'Video game not found');
+            }
+            throw err;
         }
     }
 }

--- a/src/http/controllers/_http-errors.ts
+++ b/src/http/controllers/_http-errors.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared helpers for classifying tool/callTool errors in HTTP controllers and
+ * routes. Centralizes the string-matching so each handler doesn't reinvent it.
+ */
+
+/** True when a tool error indicates the entity was not found (vs a real failure). */
+export function isNotFound(err: any): boolean {
+    return typeof err?.message === 'string' && err.message.toLowerCase().includes('not found');
+}
+
+/** True when a tool error indicates a unique-constraint / duplicate violation. */
+export function isUniqueViolation(err: any): boolean {
+    const m = err?.message;
+    return typeof m === 'string' && (m.includes('Unique constraint') || m.includes('already exists'));
+}
+
+/** Create an Error carrying an HTTP status, for handlers that throw to the framework. */
+export function httpError(status: number, message: string): Error & { status: number } {
+    const e = new Error(message) as Error & { status: number };
+    e.status = status;
+    return e;
+}

--- a/src/http/middleware/mcp-auth.ts
+++ b/src/http/middleware/mcp-auth.ts
@@ -14,18 +14,20 @@ export function mcpAuthMiddleware(req: Request, res: Response, next: NextFunctio
     if (path.startsWith('/api/auth/magic-link')) return next();
 
     try {
+        // The MCP gateway key may be presented two supported ways:
+        //   1. `Authorization: Bearer <MCP_API_KEY>` — pure MCP clients (e.g. VS
+        //      Code) whose Authorization header is free to carry the gateway key.
+        //   2. `X-Mcp-Api-Key: <MCP_API_KEY>` — first-class second factor for
+        //      callers (e.g. the website) whose Authorization header already
+        //      carries a Supabase user JWT for jwtMiddleware/TSOA admin auth.
         const auth = (req.headers.authorization || '').toString();
         if (auth === `Bearer ${mcpKey}`) return next();
 
-        // Temporary fallback for older clients
-        const fallback = (req.headers['x-mcp-api-key'] || '')?.toString();
-        if (fallback) {
-            console.error('mcp-auth: DEPRECATED: x-mcp-api-key header used; support for this header will be removed in a future release', { path: req.path, ip: req.ip });
-            if (fallback === mcpKey) return next();
-        }
+        const apiKeyHeader = (req.headers['x-mcp-api-key'] || '').toString();
+        if (apiKeyHeader && apiKeyHeader === mcpKey) return next();
 
-        // Auth failed
-        console.error('mcp-auth: auth failed', { path: req.path, ip: req.ip, got: auth || fallback || 'none' });
+        // Auth failed — never log the presented credential value.
+        console.error('mcp-auth: auth failed', { path: req.path, ip: req.ip });
         try { mcpAuthFailuresTotal.inc(); } catch (e) { /* noop */ }
         return res.status(401).json({ error: 'Unauthorized' });
     } catch (err) {

--- a/test/adapters/spotify-adapter.test.ts
+++ b/test/adapters/spotify-adapter.test.ts
@@ -214,8 +214,10 @@ describe('getPlaylists', () => {
 // ---------------------------------------------------------------------------
 
 describe('startSpotifyAdapter', () => {
-    it('does nothing when spotify is disabled', async () => {
-        config.spotify.enabled = false
+    it('does nothing when spotify is not configured (no refresh token)', async () => {
+        // The adapter now derives "configured" from the live credentials
+        // (override-aware) rather than a frozen startup `enabled` flag.
+        config.spotify.refreshToken = undefined
         const spy = vi.fn()
         vi.stubGlobal('fetch', spy)
 

--- a/test/auth/jwt.test.ts
+++ b/test/auth/jwt.test.ts
@@ -349,4 +349,101 @@ describe('JWT middleware', () => {
         expect(res.body.user.role).toBe('user')
         expect(p.prisma.profile.findUnique).toHaveBeenCalled()
     })
+
+    // --- Issue #90: JWT admin auth resolution -------------------------------
+
+    it('grants admin by matching a UUID sub to a local admin Profile by id (issue #90)', async () => {
+        const supabaseSub = '00b72aac-2286-48e5-955a-c8012cceb9c5'
+        const token = await new SignJWT({ role: 'authenticated', email: 'brn.dbn@gmail.com' })
+            .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
+            .setIssuer(issuer)
+            .setAudience(audience)
+            .setSubject(supabaseSub)
+            .setIssuedAt()
+            .setExpirationTime('2h')
+            .sign(privateKey as any)
+
+        const p = await import('../../src/db/index.js') as any
+        const findUnique = vi.fn().mockResolvedValue({ id: supabaseSub, email: 'brn.dbn@gmail.com', isAdmin: true })
+        p.prisma.profile = { findUnique }
+
+        const app = express()
+        app.get('/admin', jwtMiddleware, requireAdmin, (_req, res) => res.json({ ok: true }))
+
+        const res = await request(app).get('/admin').set('Authorization', `Bearer ${token}`)
+        expect(res.status).toBe(200)
+        // Regression guard: lookup must be by `id`, not the nonexistent `external_id`
+        expect(findUnique).toHaveBeenCalledWith({ where: { id: supabaseSub } })
+    })
+
+    it('falls back to email lookup when the UUID id lookup misses (issue #90)', async () => {
+        const supabaseSub = '11111111-2222-3333-4444-555555555555'
+        const email = 'brn.dbn@gmail.com'
+        const token = await new SignJWT({ role: 'authenticated', email })
+            .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
+            .setIssuer(issuer)
+            .setAudience(audience)
+            .setSubject(supabaseSub)
+            .setIssuedAt()
+            .setExpirationTime('2h')
+            .sign(privateKey as any)
+
+        const p = await import('../../src/db/index.js') as any
+        const findUnique = vi.fn()
+            .mockResolvedValueOnce(null) // id miss (stored Profile.id not yet reconciled)
+            .mockResolvedValueOnce({ id: 'stored-random-uuid', email, isAdmin: true }) // email hit
+        p.prisma.profile = { findUnique }
+
+        const app = express()
+        app.get('/admin', jwtMiddleware, requireAdmin, (_req, res) => res.json({ ok: true }))
+
+        const res = await request(app).get('/admin').set('Authorization', `Bearer ${token}`)
+        expect(res.status).toBe(200)
+        expect(findUnique).toHaveBeenNthCalledWith(1, { where: { id: supabaseSub } })
+        expect(findUnique).toHaveBeenNthCalledWith(2, { where: { email } })
+    })
+
+    it('grants admin from app_metadata.role in the token without any DB lookup (hybrid)', async () => {
+        const token = await new SignJWT({ role: 'authenticated', app_metadata: { role: 'admin' } })
+            .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
+            .setIssuer(issuer)
+            .setAudience(audience)
+            .setSubject('00b72aac-2286-48e5-955a-c8012cceb9c5')
+            .setIssuedAt()
+            .setExpirationTime('2h')
+            .sign(privateKey as any)
+
+        const p = await import('../../src/db/index.js') as any
+        const findUnique = vi.fn()
+        p.prisma.profile = { findUnique }
+
+        const app = express()
+        app.get('/admin', jwtMiddleware, requireAdmin, (req, res) => res.json({ ok: true, user: (req as any).user }))
+
+        const res = await request(app).get('/admin').set('Authorization', `Bearer ${token}`)
+        expect(res.status).toBe(200)
+        expect(res.body.user.role).toBe('admin')
+        expect(res.body.user.isAdmin).toBe(true)
+        expect(findUnique).not.toHaveBeenCalled() // stateless: token claim trusted, no DB hit
+    })
+
+    it('does not grant admin when the token app role is non-admin', async () => {
+        const token = await new SignJWT({ role: 'authenticated', app_metadata: { role: 'user' } })
+            .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
+            .setIssuer(issuer)
+            .setAudience(audience)
+            .setSubject('00b72aac-2286-48e5-955a-c8012cceb9c5')
+            .setIssuedAt()
+            .setExpirationTime('2h')
+            .sign(privateKey as any)
+
+        const p = await import('../../src/db/index.js') as any
+        p.prisma.profile = { findUnique: vi.fn() }
+
+        const app = express()
+        app.get('/admin', jwtMiddleware, requireAdmin, (_req, res) => res.json({ ok: true }))
+
+        const res = await request(app).get('/admin').set('Authorization', `Bearer ${token}`)
+        expect(res.status).toBe(403)
+    })
 })

--- a/test/http/mcp-auth.test.ts
+++ b/test/http/mcp-auth.test.ts
@@ -61,22 +61,24 @@ describe('MCP auth middleware', () => {
         expect(res.status).toBe(200)
     })
 
-    it('accepts x-mcp-api-key with deprecation warning', async () => {
+    it('accepts X-Mcp-Api-Key as a first-class second factor', async () => {
         config.security.mcpApiKey = 'testkey'
         const app = express()
         app.use(express.json())
-
-        const logs: any[] = []
-        const origErr = console.error
-        console.error = (...args: any[]) => logs.push(args)
-
         await registerDbDependentRoutes(app)
-        const res = await request(app).get('/api/books').set('x-mcp-api-key', 'testkey')
-        console.error = origErr
 
+        const res = await request(app).get('/api/books').set('x-mcp-api-key', 'testkey')
         expect(res.status).toBe(200)
-        const found = logs.some((entry: any) => JSON.stringify(entry).toLowerCase().includes('deprecated') || JSON.stringify(entry).toLowerCase().includes('x-mcp-api-key'))
-        expect(found).toBe(true)
+    })
+
+    it('rejects a wrong X-Mcp-Api-Key', async () => {
+        config.security.mcpApiKey = 'testkey'
+        const app = express()
+        app.use(express.json())
+        await registerDbDependentRoutes(app)
+
+        const res = await request(app).get('/api/books').set('x-mcp-api-key', 'wrong')
+        expect(res.status).toBe(401)
     })
 
     it('increments metric on auth failure', async () => {

--- a/test/http/session-route.test.ts
+++ b/test/http/session-route.test.ts
@@ -160,7 +160,8 @@ if (!shouldRunDbTests) {
 
         it('rate limits per IP', async () => {
             // Set a low limit for test
-            process.env.SESSION_RATE_LIMIT_PER_IP = '2'
+            const origLimit = config.auth.sessionRateLimitPerIp
+            config.auth.sessionRateLimitPerIp = 2
             config.auth.sessionJwtSecret = undefined
             delete process.env.SESSION_JWT_SECRET
             const user = await prisma.profile.create({ data: { id: `rls-${Date.now()}`, email: `rls+${Date.now()}@example.com` } })
@@ -169,6 +170,7 @@ if (!shouldRunDbTests) {
             await request(server).get('/api/auth/session').set('Cookie', `session=${token}`)
             const res = await request(server).get('/api/auth/session').set('Cookie', `session=${token}`)
             expect(res.status).toBe(429)
+            config.auth.sessionRateLimitPerIp = origLimit
         })
 
         it.skip('lazy-provisions a local users row from Supabase when external_id present (removed in single-user schema)', async () => {

--- a/test/http/tsoa-books-controller.test.ts
+++ b/test/http/tsoa-books-controller.test.ts
@@ -1,6 +1,20 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { startHttpServer } from '../../src/http/server.js';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { Server } from 'http';
+
+// Mock the tool layer so these controller-wiring tests are deterministic and
+// independent of database availability. (Previously they relied on the
+// controllers/routes swallowing DB errors into an empty 200 — that masking is gone.)
+vi.mock('../../src/tools/local.js', () => ({
+    callTool: vi.fn(async (name: string) => {
+        if (name === 'list-books') return { books: [], total: 0 };
+        if (name === 'list-authors') return { authors: [], total: 0 };
+        if (name === 'get-book') throw new Error('Book not found');
+        if (name === 'get-author') throw new Error('Author not found');
+        return {};
+    }),
+}));
+
+import { startHttpServer } from '../../src/http/server.js';
 
 describe('tsoa books controller', () => {
     let server: Server;
@@ -72,10 +86,9 @@ describe('tsoa books controller', () => {
 
     });
 
-    it('should return book by ID via tsoa controller GET /api/books/:id', async () => {
+    it('should return 404 for a missing book via GET /api/books/:id', async () => {
         const response = await fetch(`${baseUrl}/api/books/1`, { headers: authHeaders });
-        // Gracefully handles non-existent IDs (returns 404 or empty)
-        expect([200, 404]).toContain(response.status);
+        expect(response.status).toBe(404);
     });
 
     it('should return authors via tsoa controller GET /api/authors', async () => {
@@ -88,9 +101,8 @@ describe('tsoa books controller', () => {
         expect(Array.isArray(data.authors)).toBe(true);
     });
 
-    it('should return author by ID via tsoa controller GET /api/authors/:id', async () => {
+    it('should return 404 for a missing author via GET /api/authors/:id', async () => {
         const response = await fetch(`${baseUrl}/api/authors/1`, { headers: authHeaders });
-        // Gracefully handles non-existent IDs
-        expect([200, 404]).toContain(response.status);
+        expect(response.status).toBe(404);
     });
 });

--- a/test/http/tsoa-movies-controller.test.ts
+++ b/test/http/tsoa-movies-controller.test.ts
@@ -1,6 +1,18 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { startHttpServer } from '../../src/http/server.js';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import type { Server } from 'http';
+
+// Mock the tool layer so these controller-wiring tests are deterministic and
+// independent of database availability. (Previously they relied on the
+// controllers swallowing DB errors into an empty 200 — that masking is gone.)
+vi.mock('../../src/tools/local.js', () => ({
+    callTool: vi.fn(async (name: string) => {
+        if (name === 'list-movies') return { movies: [], total: 0 };
+        if (name === 'get-movie') throw new Error('Movie not found');
+        return {};
+    }),
+}));
+
+import { startHttpServer } from '../../src/http/server.js';
 
 describe('tsoa movies controller', () => {
     let server: Server;
@@ -38,8 +50,8 @@ describe('tsoa movies controller', () => {
         expect(data).toHaveProperty('total');
     });
 
-    it('should return movie by ID via tsoa controller GET /api/movies/:id', async () => {
+    it('should return 404 for a missing movie via GET /api/movies/:id', async () => {
         const response = await fetch(`${baseUrl}/api/movies/1`, { headers: authHeaders });
-        expect([200, 404]).toContain(response.status);
+        expect(response.status).toBe(404);
     });
 });


### PR DESCRIPTION
## Summary

Fixes **#90** — admin write endpoints (`POST /api/authors`, `POST/PUT/DELETE /api/books`, and the movies/videogames/content-creators equivalents) returned **401/403 for a valid Supabase JWT**. Admin role could only be resolved through a broken local-`Profile` lookup, and the same class of bug existed (latently) on the TSOA path.

This unblocks the website's admin CRUD (bryandebaun.dev#67).

## Root causes fixed

1. **`findLocalProfileBySub` queried a non-existent column** — looked up `Profile.external_id` (the `@id` is `id`). Prisma threw, the error was swallowed, no profile attached → role stayed `authenticated` → 403.
2. **Dead `include: { role: true }`** — there is no `Role` relation on `Profile`; that include threw too (a third silent failure the issue didn't list). Removed.
3. **Seed used a random UUID** — `prisma/seed.ts` seeded `Profile.id` with `crypto.randomUUID()` instead of the admin's Supabase Auth `user.id`. Now reads `ADMIN_SUPABASE_UUID` (warns if unset).
4. **TSOA admin path had the same bug** — `expressAuthentication` checked `decoded.role` (always `authenticated`). It only "worked" because the duplicate plain-Express routes shadowed it; the TSOA-only endpoints (movies/videogames/content-creators) were silently broken. Now shares the new resolver.

## Approach: hybrid authorization

New shared `resolveAppRole(payload)` used by both the Express middleware and the TSOA handler:

- Prefer an **app role baked into the token** (`app_metadata.role`) — stateless, no DB hit (the standard/scalable Supabase RBAC path).
- Else fall back to the **local `Profile`**, looked up by `id` then by **email** (so admin auth works even before a stored `Profile.id` is reconciled with the Supabase UUID).

## Also in this PR

- **#2 / #6 HTTP hygiene** — catalog controllers no longer swallow DB errors as empty-200/blanket-404 (an empty list must mean "no rows", not "DB down"); status-carrying errors via a shared `_http-errors` helper; per-request `callTool` dynamic imports hoisted to module scope.
- **#3 config** — `SessionController` + Spotify read `config.*` instead of `process.env`; replaced a **dead** `process.env.SPOTIFY_REFRESH_TOKEN` mutation (the adapter reads `config`, not env) with a real `setSpotifyRefreshToken()` setter.
- **#90 Bug 3 (dual-header)** — `X-Mcp-Api-Key` is now a **first-class second factor** (un-deprecated): callers whose `Authorization` carries a Supabase user JWT send the gateway key in `X-Mcp-Api-Key`; pure MCP clients may still use `Authorization: Bearer <MCP_API_KEY>`. Also **stopped logging the presented credential value** on auth failure.
- **Docs/tooling** — adds `CLAUDE.md` and ports the repo's Copilot agents to Claude Code subagents under `.claude/agents/`.

## Tests

- +4 auth cases (id match, email fallback, token-claim no-DB admin, non-admin token) and dual-header accept/reject cases.
- Made the TSOA controller smoke tests DB-independent by mocking the tool layer.
- Full suite: **246 passing**, lint at baseline (no new errors), typecheck clean.

## Deploy / ops notes

- Set `ADMIN_SUPABASE_UUID=00b72aac-…` in Render + `.env.local` (done) so future seeds set the correct `Profile.id`.
- The existing prod `Profile` row still has the old random id; admin auth works via the email fallback. Optional one-time reconciliation (run in the Supabase SQL editor):
  ```sql
  UPDATE "Profile" SET id = '<supabase-auth-uid>' WHERE email = 'brn.dbn@gmail.com';
  ```

## Follow-ups (filed, intentionally out of scope here)

- #91 — consolidate the duplicate book/author routes (resolve the diverged service-role auth model)
- #92 — typed tool-registration helper (remove 42 `as any`)
- #93 — structured leveled logger (fix inverted log levels)
- #94 — simplify Prisma init / dedupe stub blocks
- #89 — remove the dead custom magic-link auth surface

Closes #90
