### PR TITLE
refactor: typed tool registration; remove 42 (server as any) casts (#92)

### DIFF
--- a/src/tools/db/authors/create-author.ts
+++ b/src/tools/db/authors/create-author.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateAuthorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerCreateAuthorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/authors/delete-author.ts
+++ b/src/tools/db/authors/delete-author.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DeleteAuthorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerDeleteAuthorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/authors/get-author.ts
+++ b/src/tools/db/authors/get-author.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetAuthorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerGetAuthorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/authors/list-authors.ts
+++ b/src/tools/db/authors/list-authors.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListAuthorsInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerListAuthorsTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/authors/update-author.ts
+++ b/src/tools/db/authors/update-author.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateAuthorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerUpdateAuthorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/books/create-book.ts
+++ b/src/tools/db/books/create-book.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateBookInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerCreateBookTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/books/delete-book.ts
+++ b/src/tools/db/books/delete-book.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DeleteBookInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerDeleteBookTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/books/get-book.ts
+++ b/src/tools/db/books/get-book.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetBookInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerGetBookTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/books/list-books.ts
+++ b/src/tools/db/books/list-books.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListBooksInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerListBooksTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/books/update-book.ts
+++ b/src/tools/db/books/update-book.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateBookInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerUpdateBookTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/content-creators/create-content-creator.ts
+++ b/src/tools/db/content-creators/create-content-creator.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateContentCreatorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerCreateContentCreatorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/content-creators/delete-content-creator.ts
+++ b/src/tools/db/content-creators/delete-content-creator.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DeleteContentCreatorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerDeleteContentCreatorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/content-creators/get-content-creator.ts
+++ b/src/tools/db/content-creators/get-content-creator.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetContentCreatorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerGetContentCreatorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/content-creators/list-content-creators.ts
+++ b/src/tools/db/content-creators/list-content-creators.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListContentCreatorsInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerListContentCreatorsTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/content-creators/update-content-creator.ts
+++ b/src/tools/db/content-creators/update-content-creator.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateContentCreatorInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerUpdateContentCreatorTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/get-user.ts
+++ b/src/tools/db/get-user.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetUserInputSchema } from "./schemas.js";
 import { prisma } from "../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerGetUserTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/list-users.ts
+++ b/src/tools/db/list-users.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListUsersInputSchema } from "./schemas.js";
 import { prisma } from "../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerListUsersTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (_args: any): Promise<CallToolResult> => {

--- a/src/tools/db/movies/create-movie.ts
+++ b/src/tools/db/movies/create-movie.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateMovieInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerCreateMovieTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/movies/delete-movie.ts
+++ b/src/tools/db/movies/delete-movie.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DeleteMovieInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerDeleteMovieTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/movies/get-movie.ts
+++ b/src/tools/db/movies/get-movie.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetMovieInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerGetMovieTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/movies/list-movies.ts
+++ b/src/tools/db/movies/list-movies.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListMoviesInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerListMoviesTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/movies/update-movie.ts
+++ b/src/tools/db/movies/update-movie.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateMovieInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerUpdateMovieTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/videogames/create-videogame.ts
+++ b/src/tools/db/videogames/create-videogame.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateVideoGameInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerCreateVideoGameTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/videogames/delete-videogame.ts
+++ b/src/tools/db/videogames/delete-videogame.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DeleteVideoGameInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerDeleteVideoGameTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/videogames/get-videogame.ts
+++ b/src/tools/db/videogames/get-videogame.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetVideoGameInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerGetVideoGameTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/videogames/list-videogames.ts
+++ b/src/tools/db/videogames/list-videogames.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListVideoGamesInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -12,7 +13,7 @@ const config = {
 };
 
 export function registerListVideoGamesTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/db/videogames/update-videogame.ts
+++ b/src/tools/db/videogames/update-videogame.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateVideoGameInputSchema } from "./schemas.js";
 import { prisma } from "../../../db/index.js";
@@ -13,7 +14,7 @@ const config = {
 };
 
 export function registerUpdateVideoGameTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-issues/close-issue.ts
+++ b/src/tools/github-issues/close-issue.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CloseIssueInputSchema } from "./schemas.js";
 import { createOctokitClient, parseRepo } from "./octokit.js";
@@ -15,7 +16,7 @@ const toolConfig = {
  * Registers the close-issue tool with the MCP server.
  */
 export function registerCloseIssueTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-issues/create-issue.ts
+++ b/src/tools/github-issues/create-issue.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateIssueInputSchema } from "./schemas.js";
 import { createOctokitClient, parseRepo } from "./octokit.js";
@@ -18,7 +19,7 @@ const toolConfig = {
  * Registers the create-issue tool with the MCP server.
  */
 export function registerCreateIssueTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-issues/get-issue.ts
+++ b/src/tools/github-issues/get-issue.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetIssueInputSchema } from "./schemas.js";
 import { createOctokitClient, parseRepo } from "./octokit.js";
@@ -15,7 +16,7 @@ const toolConfig = {
  * Registers the get-issue tool with the MCP server.
  */
 export function registerGetIssueTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-issues/get-open-issues.ts
+++ b/src/tools/github-issues/get-open-issues.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetOpenIssuesInputSchema } from "./schemas.js";
 import { createOctokitClient, parseRepo } from "./octokit.js";
@@ -15,7 +16,7 @@ const toolConfig = {
  * Registers the get-open-issues tool with the MCP server.
  */
 export function registerGetOpenIssuesTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-issues/list-labels.ts
+++ b/src/tools/github-issues/list-labels.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListLabelsInputSchema } from "./schemas.js";
 import { createOctokitClient, parseRepo } from "./octokit.js";
@@ -15,7 +16,7 @@ const toolConfig = {
  * Registers the list-labels tool with the MCP server.
  */
 export function registerListLabelsTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-issues/update-issue.ts
+++ b/src/tools/github-issues/update-issue.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateIssueInputSchema } from "./schemas.js";
 import { createOctokitClient, parseRepo } from "./octokit.js";
@@ -18,7 +19,7 @@ const toolConfig = {
  * Registers the update-issue tool with the MCP server.
  */
 export function registerUpdateIssueTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/bulk-set-project-field-values.ts
+++ b/src/tools/github-projects/bulk-set-project-field-values.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { BulkSetProjectFieldValuesInputSchema } from "./schemas.js";
 import {
@@ -31,7 +32,7 @@ interface UpdateResult {
  * Registers the bulk-set-project-field-values tool with the MCP server.
  */
 export function registerBulkSetProjectFieldValuesTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/create-issue-in-project.ts
+++ b/src/tools/github-projects/create-issue-in-project.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateIssueInProjectInputSchema } from "./schemas.js";
 import { getProjectFields, getIssueNodeId, addIssueToProject, updateProjectFieldValue } from "./graphql.js";
@@ -19,7 +20,7 @@ const toolConfig = {
  * Registers the create-issue-in-project tool with the MCP server.
  */
 export function registerCreateIssueInProjectTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/create-project-field.ts
+++ b/src/tools/github-projects/create-project-field.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { CreateProjectFieldInputSchema } from "./schemas.js";
 import { getProjectFields, createProjectField, clearProjectCache } from "./graphql.js";
@@ -15,7 +16,7 @@ const config = {
  * Registers the create-project-field tool with the MCP server.
  */
 export function registerCreateProjectFieldTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/delete-project-field.ts
+++ b/src/tools/github-projects/delete-project-field.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { DeleteProjectFieldInputSchema } from "./schemas.js";
 import { getProjectFields, deleteProjectField, clearProjectCache } from "./graphql.js";
@@ -20,7 +21,7 @@ const config = {
  * Registers the delete-project-field tool with the MCP server.
  */
 export function registerDeleteProjectFieldTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/get-project-fields.ts
+++ b/src/tools/github-projects/get-project-fields.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetProjectFieldsInputSchema } from "./schemas.js";
 import { getProjectFields } from "./graphql.js";
@@ -15,7 +16,7 @@ const config = {
  * Registers the get-project-fields tool with the MCP server.
  */
 export function registerGetProjectFieldsTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/get-project-status-options.ts
+++ b/src/tools/github-projects/get-project-status-options.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { GetProjectStatusOptionsInputSchema } from "./schemas.js";
 import { getProjectFields } from "./graphql.js";
@@ -15,7 +16,7 @@ const toolConfig = {
  * Registers the get-project-status-options tool with the MCP server.
  */
 export function registerGetProjectStatusOptionsTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/list-project-items.ts
+++ b/src/tools/github-projects/list-project-items.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { ListProjectItemsInputSchema } from "./schemas.js";
 import { listProjectItems } from "./graphql.js";
@@ -15,7 +16,7 @@ const toolConfig = {
  * Registers the list-project-items tool with the MCP server.
  */
 export function registerListProjectItemsTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         toolConfig,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/set-project-field-value.ts
+++ b/src/tools/github-projects/set-project-field-value.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { SetProjectFieldValueInputSchema } from "./schemas.js";
 import {
@@ -26,7 +27,7 @@ const config = {
  * Registers the set-project-field-value tool with the MCP server.
  */
 export function registerSetProjectFieldValueTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/github-projects/update-project-field.ts
+++ b/src/tools/github-projects/update-project-field.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { registerTool } from "../registration.js";
 import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { UpdateProjectFieldInputSchema } from "./schemas.js";
 import {
@@ -26,7 +27,7 @@ const config = {
  * Registers the update-project-field tool with the MCP server.
  */
 export function registerUpdateProjectFieldTool(server: McpServer): void {
-    (server as any).registerTool(
+    registerTool(server,
         name,
         config,
         async (args: any): Promise<CallToolResult> => {

--- a/src/tools/registration.ts
+++ b/src/tools/registration.ts
@@ -1,0 +1,34 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import type { ZodRawShape } from "zod";
+
+/**
+ * Configuration for an MCP tool — mirrors the shape the SDK's `registerTool`
+ * accepts. `inputSchema` is a Zod raw shape (a plain object of Zod types).
+ */
+export interface ToolDefinition {
+    title?: string;
+    description: string;
+    inputSchema?: ZodRawShape;
+}
+
+/** A tool handler: takes validated args, returns an MCP tool result. */
+export type ToolHandler = (args: any) => Promise<CallToolResult>;
+
+/**
+ * Typed wrapper over `McpServer.registerTool`.
+ *
+ * The SDK's `registerTool` is heavily overloaded and its generic inference
+ * fights a plain `ZodRawShape` config + loosely-typed handler, which is why
+ * every tool previously called `(server as any).registerTool(...)`. This helper
+ * centralizes that single cast so individual tools get full type-checking on
+ * their `name`, `config`, and `handler` instead of opting out with `as any`.
+ */
+export function registerTool(
+    server: McpServer,
+    name: string,
+    config: ToolDefinition,
+    handler: ToolHandler,
+): void {
+    (server as any).registerTool(name, config, handler);
+}


### PR DESCRIPTION
## Summary

Closes #92. Adds `src/tools/registration.ts` — a typed `registerTool(server, name, config, handler)` wrapper plus a `ToolDefinition` interface — and routes all 42 tools through it, replacing `(server as any).registerTool(...)`.

The SDK's `registerTool` is heavily overloaded; its generic inference fights a plain `ZodRawShape` config + loosely-typed handler, which is why every tool opted out with `as any`. The wrapper centralizes that single cast so each tool now gets **real type-checking** on its `name`, `config` (must have a `description`), and `handler` (must return `Promise<CallToolResult>`).

## Scope

- New: `src/tools/registration.ts` (the one remaining, justified cast lives here).
- Changed: 42 tool files across `github-issues/`, `github-projects/`, `db/**` — each is a 2-line change (add import, swap the call).
- No runtime behavior change.

## Verification

- `npm run typecheck` clean — the helper accepts every existing tool config/handler (proves the types line up, not just that casts were removed).
- `npm test` — **246 passing**, 6 skipped.
- `npm run lint` — at baseline (no new errors).
- `grep` confirms no `(server as any).registerTool` remains outside `registration.ts`.
