### PR TITLE
feat: Sentry error alerting bridged from the logger (#99)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,11 @@ Controllers are decorated TSOA classes. `npm run build:spec` runs `tsoa spec-and
 - `mcpAuthMiddleware` ([src/http/middleware/mcp-auth.ts](src/http/middleware/mcp-auth.ts)): when `MCP_API_KEY` is set, the gateway key is required on DB-dependent `/api/*` routes and `/mcp`, via either `Authorization: Bearer <MCP_API_KEY>` (pure MCP clients) or the `X-Mcp-Api-Key` header (first-class second factor for callers whose `Authorization` already carries a Supabase user JWT).
 - TSOA `@Security('jwt', ['admin'])`: Supabase-issued JWT verification (`src/auth/jwt.ts`) for user/admin REST endpoints.
 
+### 8. Observability
+- **Logging:** [src/logger.ts](src/logger.ts) is a pino-backed structured logger (pretty in dev, JSON in prod, silent in tests). Use `logger.{debug,info,warn,error}` — never `console.*` (enforced by eslint `no-console`, except `config.ts`/`logger.ts`). It exposes a single error choke point via `setErrorReporter`.
+- **Error alerting:** [src/sentry.ts](src/sentry.ts) `initSentry()` (called first in `index.ts`) is a no-op unless `SENTRY_DSN` is set. When enabled it bridges every `logger.error` to Sentry and captures process-level uncaught errors. Secrets are scrubbed in `beforeSend`.
+- **Metrics:** prom-client at `/metrics`.
+
 ## Data model
 
 Postgres via Prisma ([prisma/schema.prisma](prisma/schema.prisma)). Catalog entities (`Book`, `Movie`, `VideoGame`) share an `ItemStatus` enum (`NOT_STARTED|IN_PROGRESS|COMPLETED`) and **embed rating fields directly** (`rating`, `review`, `ratedAt`) rather than a separate ratings table for the single-user case. `Profile` is keyed by the Supabase Auth UUID. Row-Level-Security policies are exercised by `test/rls/**` and `test/integration/rls*` (DB-integration-gated), and migration SQL is lint-checked via the `sql:parse`/`sql:validate` scripts.

--- a/README.md
+++ b/README.md
@@ -174,6 +174,13 @@ MCP_API_KEY=your-secret-key
 # Optional: For admin endpoints
 INTERNAL_ADMIN_KEY=your-admin-key
 ADMIN_DEBUG_ENABLED=true
+
+# Optional: Sentry error alerting. When SENTRY_DSN is set, unhandled errors and
+# every logger.error are reported to Sentry. Unset = disabled (dev/test default).
+SENTRY_DSN=https://<key>@o<org>.ingest.sentry.io/<project>
+# SENTRY_ENVIRONMENT=production        # defaults to NODE_ENV
+# SENTRY_TRACES_SAMPLE_RATE=0          # 0..1; 0 = errors only (no perf tracing)
+# SENTRY_RELEASE=mcp-server@0.1.0
 ```
 
 ## Installation

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@octokit/rest": "^22.0.1",
                 "@prisma/adapter-pg": "^7.3.0",
                 "@prisma/client": "^7.3.0",
+                "@sentry/node": "^10.55.0",
                 "@tsoa/runtime": "^7.0.0-alpha.0",
                 "cors": "^2.8.5",
                 "dotenv": "^17.3.1",
@@ -1766,6 +1767,106 @@
                 "@octokit/openapi-types": "^27.0.0"
             }
         },
+        "node_modules/@opentelemetry/api": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/api-logs": {
+            "version": "0.214.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+            "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@opentelemetry/core": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+            "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.0.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/instrumentation": {
+            "version": "0.214.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+            "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.214.0",
+                "import-in-the-middle": "^3.0.0",
+                "require-in-the-middle": "^8.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@opentelemetry/resources": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+            "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/core": "2.7.1",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/sdk-trace-base": {
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+            "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@opentelemetry/core": "2.7.1",
+                "@opentelemetry/resources": "2.7.1",
+                "@opentelemetry/semantic-conventions": "^1.29.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": ">=1.3.0 <1.10.0"
+            }
+        },
+        "node_modules/@opentelemetry/semantic-conventions": {
+            "version": "1.41.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+            "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/@paralleldrive/cuid2": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -2531,6 +2632,95 @@
             "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
             "hasInstallScript": true,
             "license": "Apache-2.0"
+        },
+        "node_modules/@sentry/core": {
+            "version": "10.55.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.55.0.tgz",
+            "integrity": "sha512-XUyoNtDSYCvgJnoNzlh+YeAXfIPhCRIXbhWqqM3GQ3AFtZICi85lkyfsrwXEl9wzlPGYnU+Eg8F4tOfScx+FcQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/node": {
+            "version": "10.55.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.55.0.tgz",
+            "integrity": "sha512-+fB/ByoHVWPLGgoafYciiMatTNyX1FHj1bsqZBN+Pw3McbuEU1nwCPLt9zuyZZiWlQtXKsyuACS4ZhXnID5l8A==",
+            "license": "MIT",
+            "dependencies": {
+                "@opentelemetry/api": "^1.9.1",
+                "@opentelemetry/core": "^2.6.1",
+                "@opentelemetry/instrumentation": "^0.214.0",
+                "@opentelemetry/sdk-trace-base": "^2.6.1",
+                "@opentelemetry/semantic-conventions": "^1.40.0",
+                "@sentry/core": "10.55.0",
+                "@sentry/node-core": "10.55.0",
+                "@sentry/opentelemetry": "10.55.0",
+                "import-in-the-middle": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@sentry/node-core": {
+            "version": "10.55.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.55.0.tgz",
+            "integrity": "sha512-M8XMMIk9Y0PGZoEt37Oe5dQCdqDdJlBcwLXidpz/s5k4QtJvCO/BbtcivcuKI2htw5FwxJkSrHUzRvT36tlDpg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.55.0",
+                "@sentry/opentelemetry": "10.55.0",
+                "import-in-the-middle": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+                "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+                "@opentelemetry/instrumentation": ">=0.57.1 <1",
+                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.39.0"
+            },
+            "peerDependenciesMeta": {
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@opentelemetry/core": {
+                    "optional": true
+                },
+                "@opentelemetry/exporter-trace-otlp-http": {
+                    "optional": true
+                },
+                "@opentelemetry/instrumentation": {
+                    "optional": true
+                },
+                "@opentelemetry/sdk-trace-base": {
+                    "optional": true
+                },
+                "@opentelemetry/semantic-conventions": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@sentry/opentelemetry": {
+            "version": "10.55.0",
+            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.55.0.tgz",
+            "integrity": "sha512-0+YrNmVNrttki4rWP4DW+UTt5MziepwDLNBde39tgc3cGCcy5fLSdDfhb4JfTaE5TXt4kd5XrkgvS/sDgm3RZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@sentry/core": "10.55.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0",
+                "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+                "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+                "@opentelemetry/semantic-conventions": "^1.39.0"
+            }
         },
         "node_modules/@sinclair/typebox": {
             "version": "0.34.48",
@@ -3403,7 +3593,6 @@
             "version": "8.15.0",
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-            "dev": true,
             "license": "MIT",
             "peer": true,
             "bin": {
@@ -3411,6 +3600,15 @@
             },
             "engines": {
                 "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-attributes": {
+            "version": "1.9.5",
+            "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+            "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^8"
             }
         },
         "node_modules/acorn-jsx": {
@@ -3867,6 +4065,12 @@
             "dependencies": {
                 "consola": "^3.2.3"
             }
+        },
+        "node_modules/cjs-module-lexer": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+            "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+            "license": "MIT"
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -5461,6 +5665,21 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/import-in-the-middle": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+            "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-import-attributes": "^1.9.5",
+                "cjs-module-lexer": "^2.2.0",
+                "module-details-from-path": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -6055,6 +6274,12 @@
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
+        },
+        "node_modules/module-details-from-path": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+            "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+            "license": "MIT"
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -7022,6 +7247,19 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/require-in-the-middle": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+            "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.5",
+                "module-details-from-path": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=9.3.0 || >=8.10.0 <9.0.0"
             }
         },
         "node_modules/resolve-from": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "@octokit/rest": "^22.0.1",
         "@prisma/adapter-pg": "^7.3.0",
         "@prisma/client": "^7.3.0",
+        "@sentry/node": "^10.55.0",
         "@tsoa/runtime": "^7.0.0-alpha.0",
         "cors": "^2.8.5",
         "dotenv": "^17.3.1",

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,6 +105,18 @@ const envSchema = z.object({
     // ── GitHub ────────────────────────────────────────────────────────────
     GITHUB_TOKEN: z.string().optional(),
 
+    // ── Sentry ────────────────────────────────────────────────────────────
+    SENTRY_DSN: z.string().optional(),
+    SENTRY_ENVIRONMENT: z.string().optional(),
+    SENTRY_RELEASE: z.string().optional(),
+    SENTRY_TRACES_SAMPLE_RATE: z
+        .string()
+        .optional()
+        .transform((val) => {
+            const n = Number(val ?? 0);
+            return Number.isFinite(n) && n >= 0 && n <= 1 ? n : 0;
+        }),
+
     // ── Test / CI flags ───────────────────────────────────────────────────
     RUN_DB_INTEGRATION: boolFlag,
     RUN_GITHUB_PROJECTS_INTEGRATION: boolFlag,
@@ -210,6 +222,13 @@ export const config = {
 
     github: {
         token: env.GITHUB_TOKEN,
+    },
+
+    sentry: {
+        dsn: env.SENTRY_DSN,
+        environment: env.SENTRY_ENVIRONMENT ?? env.NODE_ENV,
+        release: env.SENTRY_RELEASE,
+        tracesSampleRate: env.SENTRY_TRACES_SAMPLE_RATE,
     },
 
     ci: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,15 @@
 // config.ts loads dotenv at module init — import it before anything else.
 import { config } from "./config.js";
 import { logger } from "./logger.js";
+import { initSentry, flushSentry } from "./sentry.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./server.js";
 import { registerTools } from "./tools/index.js";
+
+// Initialize error reporting first so startup failures are captured. No-op
+// unless SENTRY_DSN is set. Bridges logger.error and installs Sentry's
+// uncaught-exception / unhandled-rejection handlers.
+initSentry();
 
 /**
  * Main entry point for the MCP server.
@@ -84,7 +90,8 @@ async function main(): Promise<void> {
     }
 }
 
-main().catch((error) => {
+main().catch(async (error) => {
     logger.error("Fatal error:", error);
+    await flushSentry();
     process.exit(1);
 });

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -38,9 +38,19 @@ type LogFn = (...args: unknown[]) => void;
  * renaming `console.*` to `logger.*` without rewriting each call, while new code
  * can pass a context object for proper structured logging.
  *
- * This is also the single choke point for error reporting — a future Sentry
- * bridge can hook the `error` level here without touching call sites.
+ * This is also the single choke point for error reporting — an error reporter
+ * (e.g. Sentry) can be attached via `setErrorReporter` to receive every
+ * `logger.error` call without coupling this module to the reporter.
  */
+export type ErrorReporter = (err: unknown, context: Record<string, unknown>, message: string) => void;
+
+let errorReporter: ErrorReporter | null = null;
+
+/** Attach (or clear) a reporter invoked for every `logger.error` call. */
+export function setErrorReporter(reporter: ErrorReporter | null): void {
+    errorReporter = reporter;
+}
+
 function adapt(level: 'debug' | 'info' | 'warn' | 'error'): LogFn {
     return (...args: unknown[]) => {
         const ctx: Record<string, unknown> = {};
@@ -53,6 +63,11 @@ function adapt(level: 'debug' | 'info' | 'warn' | 'error'): LogFn {
         const msg = parts.join(' ');
         if (Object.keys(ctx).length) base[level](ctx, msg);
         else base[level](msg);
+
+        if (level === 'error' && errorReporter) {
+            // Never let error reporting break logging.
+            try { errorReporter(ctx.err, ctx, msg); } catch { /* noop */ }
+        }
     };
 }
 

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,0 +1,68 @@
+import * as Sentry from '@sentry/node';
+import { config } from './config.js';
+import { logger, setErrorReporter } from './logger.js';
+
+let initialized = false;
+
+/** Keys whose values must never be sent to Sentry. */
+const SENSITIVE_KEY = /(authorization|cookie|token|secret|password|api[-_]?key|jwt|dsn)/i;
+
+/** Recursively redact sensitive-looking keys from an object before sending. */
+function scrub(value: unknown): unknown {
+    if (!value || typeof value !== 'object') return value;
+    if (Array.isArray(value)) return value.map(scrub);
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+        out[k] = SENSITIVE_KEY.test(k) ? '[redacted]' : scrub(v);
+    }
+    return out;
+}
+
+/**
+ * Initialize Sentry error reporting. No-op unless `SENTRY_DSN` is set, so dev,
+ * tests, and any environment without a DSN are unaffected. Once initialized,
+ * every `logger.error` is forwarded to Sentry (and Sentry's default integrations
+ * capture uncaught exceptions / unhandled rejections at the process level).
+ */
+export function initSentry(): void {
+    if (initialized || !config.sentry.dsn) return;
+
+    Sentry.init({
+        dsn: config.sentry.dsn,
+        environment: config.sentry.environment,
+        release: config.sentry.release,
+        tracesSampleRate: config.sentry.tracesSampleRate,
+        // Don't attach request bodies / headers / cookies automatically.
+        sendDefaultPii: false,
+        beforeSend(event) {
+            if (event.extra) event.extra = scrub(event.extra) as Record<string, unknown>;
+            if (event.request) {
+                delete event.request.headers;
+                delete event.request.cookies;
+            }
+            return event;
+        },
+    });
+    initialized = true;
+
+    // Bridge: forward every logger.error to Sentry (Error → exception, else message).
+    setErrorReporter((err, context, message) => {
+        if (err instanceof Error) {
+            Sentry.captureException(err, { extra: scrub(context) as Record<string, unknown> });
+        } else {
+            Sentry.captureMessage(message || 'error', 'error');
+        }
+    });
+
+    logger.info('Sentry error reporting initialized', { environment: config.sentry.environment });
+}
+
+/** Flush buffered events — call before an intentional process exit. */
+export async function flushSentry(timeoutMs = 2000): Promise<void> {
+    if (!initialized) return;
+    try {
+        await Sentry.flush(timeoutMs);
+    } catch {
+        /* noop */
+    }
+}

--- a/test/sentry.test.ts
+++ b/test/sentry.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { config } from '../src/config.js'
+import { logger, setErrorReporter } from '../src/logger.js'
+import { initSentry } from '../src/sentry.js'
+
+describe('Sentry / logger error bridge', () => {
+    afterEach(() => setErrorReporter(null))
+
+    it('logger.error invokes an attached error reporter with err, context, and message', () => {
+        const reporter = vi.fn()
+        setErrorReporter(reporter)
+
+        const err = new Error('boom')
+        logger.error('something failed', err, { route: '/x' })
+
+        expect(reporter).toHaveBeenCalledTimes(1)
+        const [errArg, ctxArg, msgArg] = reporter.mock.calls[0]
+        expect(errArg).toBe(err)
+        expect(ctxArg).toMatchObject({ err, route: '/x' })
+        expect(msgArg).toContain('something failed')
+    })
+
+    it('non-error levels do not invoke the reporter', () => {
+        const reporter = vi.fn()
+        setErrorReporter(reporter)
+
+        logger.info('hello')
+        logger.warn('careful')
+        logger.debug('details')
+
+        expect(reporter).not.toHaveBeenCalled()
+    })
+
+    it('initSentry is a no-op when no DSN is configured (does not install a reporter)', () => {
+        const sentinel = vi.fn()
+        setErrorReporter(sentinel)
+
+        const origDsn = config.sentry.dsn
+        config.sentry.dsn = undefined
+        try {
+            initSentry() // should return early and leave our sentinel in place
+            logger.error('x')
+            expect(sentinel).toHaveBeenCalled()
+        } finally {
+            config.sentry.dsn = origDsn
+        }
+    })
+})


### PR DESCRIPTION
## Summary

Closes #99. Adds production **error alerting** via Sentry, complementing the structured logs from #93. **No-op unless `SENTRY_DSN` is set**, so dev/test and any DSN-less environment are unaffected.

## Design

- **`src/sentry.ts`** — `initSentry()` (gated on `SENTRY_DSN`) configures `@sentry/node` with environment/release/sample-rate from config, **scrubs sensitive keys** (`authorization`, `cookie`, `token`, `secret`, `password`, `api-key`, `jwt`, `dsn`) in `beforeSend`, and relies on Sentry's default integrations to capture **process-level** uncaught exceptions / unhandled rejections. `flushSentry()` drains events before an intentional exit.
- **Logger bridge (decoupled)** — `src/logger.ts` gains `setErrorReporter`, a hook invoked for every `logger.error`. The logger does **not** import Sentry; `initSentry()` wires the hook to `captureException`/`captureMessage`. So every `logger.error` — including the Express global error handler — is reported **with zero call-site changes** (this is what #93's "single error choke point" set up).
- **Config** — `SENTRY_DSN`, `SENTRY_ENVIRONMENT` (defaults to `NODE_ENV`), `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE` (0..1, default `0` = errors only).
- **`index.ts`** — `initSentry()` runs first; flush before fatal exit.

## Why no double-capture

HTTP errors are captured once (Express handler → `logger.error` → bridge). Process-level errors are captured once (Sentry's default integrations). No Sentry Express middleware is added, so there's no overlap.

## Verification

- `npm run build` + `npm run typecheck` clean.
- `npm test` — **205 passing** (+3 new): the logger→reporter bridge, that non-error levels skip it, and that `initSentry` no-ops without a DSN (so tests never reach real Sentry even though `.env.local` has a DSN).
- `npm run lint` at baseline.

## Note

End-to-end delivery (a real event landing in the Sentry `mcp-server` project) can't be asserted in CI — worth one manual smoke test after deploy (or locally) to confirm the DSN/project wiring.
