### PR TITLE
feat(health): add deep /healthz?deep=1 keep-alive DB check (#119)

### DIFF
--- a/docs/runbooks/deploy-render.md
+++ b/docs/runbooks/deploy-render.md
@@ -56,6 +56,47 @@ Health & Readiness
   - Server process is running
   - Critical subsystems (Spotify token store if persisted, metrics exporter) are reachable or in acceptable state
 - Add `/metrics` as a Prometheus-compatible endpoint for metrics scraping or export.
+- `/healthz?deep=1` additionally runs a trivial `SELECT 1` against Postgres and
+  returns `{ status, db: "ok", db_latency_ms }`. It returns `503 { db: "error" }`
+  when the DB is configured but unreachable, and `200 { db: "skipped" }` when
+  `DATABASE_URL` is unset (so CI / no-DB startups stay green). The plain
+  `/healthz` stays dependency-free and is what Render's own health check uses.
+
+Keep-alive (preventing cold starts) — issue #119
+-------------------------------------------------
+
+The service runs on Render's free web tier, which spins down after ~15 min idle
+(next request pays a ~30–60s cold start). Underneath that, the Supabase free
+project pauses after 7 days of inactivity and must be restored. Both surface as
+slow first loads for `bryandebaun.dev`, which calls this server at runtime for
+its catalog data.
+
+Mitigation — an **external scheduled ping** keeps both layers warm:
+
+- **Endpoint:** `GET /healthz?deep=1` (the deep variant — touches the DB, so the
+  same ping covers both Render spin-down and the Supabase 7-day pause).
+- **Scheduler:** a free external monitor — [cron-job.org](https://cron-job.org)
+  or UptimeRobot. (External, on purpose: Supabase's pause detector keys off
+  *external* activity, so an internal `pg_cron` self-ping does not reliably reset
+  the timer.)
+- **Cadence:** every **~10 minutes** (driven by Render's ~15-min idle window;
+  Supabase's weekly window is comfortably covered by the same schedule).
+- **Alerting:** configure the monitor to alert on non-200 so a `503 { db:
+  "error" }` (a genuine DB outage or a Supabase still restoring) is surfaced.
+
+Setup steps:
+
+1. Create a free account at cron-job.org (or UptimeRobot).
+2. Add a cron job / monitor for `https://<service-url>/healthz?deep=1` at a
+   ~10-minute interval.
+3. Enable failure notifications (email) on non-2xx responses.
+4. Verify warmth: leave the service idle >15 min, then `curl` it — the first
+   request should respond without a cold-start delay.
+
+Caveats: the self-ping consumes a small slice of Render's free monthly compute
+and a little Supabase egress (negligible at this cadence), and a keep-alive can
+mask genuine startup-latency regressions. Revisit (or move to paid tiers, which
+remove both spin-down and pause) if real traffic grows.
 
 Secrets & Token Management
 --------------------------
@@ -86,7 +127,7 @@ Logging & Monitoring
 
 - Use Render's log streaming in the dashboard for debugging and live logs.
 - Add metric counters for: `poll_success_total`, `poll_failure_total`, `intent_success_total`, `intent_failure_total`, `token_refresh_success_total`, `token_refresh_failure_total`.
-- Configure an external monitor (UptimeRobot, Pingdom) to check `/healthz` and alert on failures.
+- Configure an external monitor (cron-job.org, UptimeRobot, Pingdom) to ping `/healthz?deep=1` every ~10 min — this doubles as the keep-alive (see "Keep-alive" above) and alerts on failures.
 
 Deployment Workflow
 -------------------

--- a/src/http/health-route.ts
+++ b/src/http/health-route.ts
@@ -1,16 +1,60 @@
 import type { Request, Response } from 'express'
+import { config } from '../config.js'
+import { initPrisma, prisma } from '../db/index.js'
+import { logger } from '../logger.js'
 import { isReady } from './readiness.js'
 
+/**
+ * Run a trivial `SELECT 1` to keep the database connection (and a paused
+ * Supabase free project) warm, reporting round-trip latency. Returns
+ * `{ db: 'skipped' }` without touching Prisma when no `DATABASE_URL` is
+ * configured, so CI / no-DB startups and the stub contract stay green (#119).
+ */
+async function checkDatabase(): Promise<{
+    db: 'ok' | 'skipped' | 'error'
+    db_latency_ms?: number
+}> {
+    if (!config.database.url) return { db: 'skipped' }
+
+    // Ensure Prisma has been initialized — `/healthz` is registered before DB
+    // init in hosted mode, so an early deep ping could otherwise race it.
+    await initPrisma()
+
+    const start = performance.now()
+    await prisma.$queryRaw`SELECT 1`
+    const db_latency_ms = Math.round((performance.now() - start) * 100) / 100
+    return { db: 'ok', db_latency_ms }
+}
+
 export function registerHealthRoute(app: any): void {
-    // Liveness probe — always returns 200 to indicate process is alive
-    app.get('/healthz', (_req: Request, res: Response) => {
-        const uptime = process.uptime()
-        const version = process.version
-        res.status(200).json({
+    // Liveness probe — always returns 200 to indicate the process is alive.
+    // `?deep=1` additionally exercises the DB (keep-alive for Render + Supabase,
+    // #119); the default form stays dependency-free for Render's own health check.
+    app.get('/healthz', async (req: Request, res: Response) => {
+        const base = {
             status: 'ok',
-            uptime_seconds: uptime,
-            node: version,
-        })
+            uptime_seconds: process.uptime(),
+            node: process.version,
+        }
+
+        const deep = req.query.deep === '1' || req.query.deep === 'true'
+        if (!deep) return res.status(200).json(base)
+
+        try {
+            const db = await checkDatabase()
+            return res.status(200).json({ ...base, ...db })
+        } catch (err) {
+            // DB is configured but unreachable — surface a 503 so an external
+            // monitor alerts on a genuine outage (a paused/restoring Supabase or
+            // a connection failure), rather than masking it as healthy.
+            logger.warn(
+                'deep /healthz DB check failed',
+                (err as any)?.message ?? err,
+            )
+            return res
+                .status(503)
+                .json({ ...base, status: 'degraded', db: 'error' })
+        }
     })
 
     // Readiness probe — returns 200 when the app is ready to serve traffic,

--- a/test/http/health-deep.test.ts
+++ b/test/http/health-deep.test.ts
@@ -1,0 +1,78 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the DB module so the deep check is deterministic without a real Postgres.
+vi.mock('../../src/db/index.js', () => ({
+    initPrisma: vi.fn(async () => {}),
+    prisma: { $queryRaw: vi.fn() },
+}))
+
+import { config } from '../../src/config.js'
+import { initPrisma, prisma } from '../../src/db/index.js'
+import { registerHealthRoute } from '../../src/http/health-route'
+
+const mockQueryRaw = prisma.$queryRaw as unknown as ReturnType<typeof vi.fn>
+const mockInitPrisma = initPrisma as unknown as ReturnType<typeof vi.fn>
+
+const makeApp = () => {
+    const app = express()
+    registerHealthRoute(app)
+    return app
+}
+
+const ORIGINAL_DB_URL = config.database.url
+const setDbUrl = (url: string | undefined) => {
+    ;(config as any).database.url = url
+}
+
+describe('GET /healthz?deep=1 (#119 keep-alive deep check)', () => {
+    beforeEach(() => {
+        mockQueryRaw.mockReset()
+        mockInitPrisma.mockClear()
+    })
+    afterEach(() => {
+        setDbUrl(ORIGINAL_DB_URL)
+    })
+
+    it('default /healthz stays dependency-free (no DB query, even with DB configured)', async () => {
+        setDbUrl('postgres://example')
+        const res = await request(makeApp()).get('/healthz').expect(200)
+        expect(res.body).toMatchObject({ status: 'ok' })
+        expect(res.body).not.toHaveProperty('db')
+        expect(mockQueryRaw).not.toHaveBeenCalled()
+    })
+
+    it('skips the query and stays 200 when DATABASE_URL is unset', async () => {
+        setDbUrl(undefined)
+        const res = await request(makeApp()).get('/healthz?deep=1').expect(200)
+        expect(res.body).toMatchObject({ status: 'ok', db: 'skipped' })
+        expect(mockQueryRaw).not.toHaveBeenCalled()
+        expect(mockInitPrisma).not.toHaveBeenCalled()
+    })
+
+    it('runs SELECT 1 and reports latency when DB is configured', async () => {
+        setDbUrl('postgres://example')
+        mockQueryRaw.mockResolvedValueOnce([{ ok: 1 }])
+        const res = await request(makeApp()).get('/healthz?deep=1').expect(200)
+        expect(res.body).toMatchObject({ status: 'ok', db: 'ok' })
+        expect(typeof res.body.db_latency_ms).toBe('number')
+        expect(mockQueryRaw).toHaveBeenCalledOnce()
+        expect(mockInitPrisma).toHaveBeenCalledOnce()
+    })
+
+    it('returns 503 degraded when the configured DB query fails', async () => {
+        setDbUrl('postgres://example')
+        mockQueryRaw.mockRejectedValueOnce(new Error('connection refused'))
+        const res = await request(makeApp()).get('/healthz?deep=1').expect(503)
+        expect(res.body).toMatchObject({ status: 'degraded', db: 'error' })
+    })
+
+    it('also accepts deep=true', async () => {
+        setDbUrl(undefined)
+        const res = await request(makeApp())
+            .get('/healthz?deep=true')
+            .expect(200)
+        expect(res.body).toMatchObject({ db: 'skipped' })
+    })
+})


### PR DESCRIPTION
## Summary

Adds a deep health endpoint that exercises the database, so a single external ping keeps both cold-start layers warm: Render's free-tier spin-down (~15 min idle) and the Supabase free-project pause (7 days inactivity).

Addresses #119 (code complete; two operational ACs remain — see below).

## Changes

- **`GET /healthz?deep=1`** ([`health-route.ts`](../src/http/health-route.ts)) runs a trivial `SELECT 1` and returns `200 { status, db: "ok", db_latency_ms }`.
  - Returns **`200 { db: "skipped" }`** when `DATABASE_URL` is unset — honors the Prisma stub contract so CI / no-DB startups stay green.
  - Returns **`503 { db: "error" }`** when a configured DB is unreachable, so the monitor alerts on a genuine outage (or a still-restoring Supabase).
  - `await initPrisma()` first to avoid racing the early-registered route in hosted mode.
- **Default `/healthz` is unchanged** — stays dependency-free for Render's own health check.
- **Tests:** 5 new in [`health-deep.test.ts`](../test/http/health-deep.test.ts) — default stays shallow, skipped-when-no-DB, ok + latency, 503-on-failure, `deep=true`.
- **Docs:** "Keep-alive" section in [`deploy-render.md`](../docs/runbooks/deploy-render.md) — endpoint, external scheduler (cron-job.org / UptimeRobot), ~10-min cadence, the two cold-start layers, setup steps, caveats.

## Verification

- `pnpm run typecheck` clean; full suite **216 passed / 5 skipped / 0 failed**; lint clean.

## Remaining (operational — not in this PR)

- [ ] Configure an external monitor against `…/healthz?deep=1` at ~10-min cadence.
- [ ] Verify the service stays warm across a >15-min idle window after deploy.

I left #119 open (rather than auto-closing) so it can be closed once the monitor is configured and warmth is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
