### PR TITLE
feat(observability): audit-log admin catalog mutations + Sentry breadcrumbs (#37)

### DIFF
--- a/docs/runbooks/deploy-render.md
+++ b/docs/runbooks/deploy-render.md
@@ -128,6 +128,7 @@ Logging & Monitoring
 - Use Render's log streaming in the dashboard for debugging and live logs.
 - Add metric counters for: `poll_success_total`, `poll_failure_total`, `intent_success_total`, `intent_failure_total`, `token_refresh_success_total`, `token_refresh_failure_total`.
 - Configure an external monitor (cron-job.org, UptimeRobot, Pingdom) to ping `/healthz?deep=1` every ~10 min — this doubles as the keep-alive (see "Keep-alive" above) and alerts on failures.
+- **Admin audit trail (#37):** every successful admin catalog mutation (create/update/delete of books, authors, movies, videogames, content-creators) emits a structured `logger.info` entry tagged `audit: true` with the actor (`sub`/`email`), action, entity type + id, request id, and ip. These are log-only (no DB table); to review, filter the log stream for `"audit":true`. They do **not** raise Sentry *events* (only `logger.error` does), but when Sentry is enabled each is also recorded as a `category: "audit"` **breadcrumb**, so the recent admin-action trail is attached to any subsequent error event for context.
 
 Deployment Workflow
 -------------------

--- a/src/http/middleware/audit.ts
+++ b/src/http/middleware/audit.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto'
+import type { NextFunction, Request, Response } from 'express'
+import { logger } from '../../logger.js'
+
+/**
+ * Admin **catalog mutation** audit logging (#37).
+ *
+ * A single post-response middleware records one structured `logger.info` entry
+ * per successful admin write (create/update/delete) to the catalog resources —
+ * rather than duplicating the logic across ~15 controller handlers. Audit events
+ * are emitted at `info` level so they land in the structured log stream (JSON in
+ * prod / Render logs); they are intentionally NOT errors, so they do not page
+ * Sentry (only `logger.error` bridges there). The decision is log-only — no DB
+ * `AuditLog` table — given structured logs + Sentry already exist and the single
+ * user scope.
+ *
+ * Captured fields: actor (Supabase `sub` + `email`), action, entity type + id,
+ * request id, and ip. pino adds the timestamp (`time`). No request bodies or
+ * tokens are logged, so no secrets leak into the audit trail.
+ */
+
+/** Catalog route segment → singular entity name used in the audit record. */
+const ENTITY_BY_SEGMENT: Record<string, string> = {
+    books: 'book',
+    authors: 'author',
+    movies: 'movie',
+    videogames: 'videogame',
+    'content-creators': 'content-creator',
+}
+
+/** HTTP method → audit action. Reads (GET) are intentionally absent. */
+const ACTION_BY_METHOD: Record<string, 'create' | 'update' | 'delete'> = {
+    POST: 'create',
+    PUT: 'update',
+    PATCH: 'update',
+    DELETE: 'delete',
+}
+
+const CATALOG_PATH = /^\/api\/([^/]+)(?:\/([^/?]+))?\/?$/
+
+export function auditAdminCatalogMutations(
+    req: Request,
+    res: Response,
+    next: NextFunction,
+): void {
+    const action = ACTION_BY_METHOD[req.method]
+    if (!action) return next()
+
+    const match = CATALOG_PATH.exec(req.path)
+    const entityType = match ? ENTITY_BY_SEGMENT[match[1]] : undefined
+    if (!entityType) return next()
+
+    const pathId = match?.[2]
+    const requestId =
+        (req.headers['x-request-id'] as string | undefined) || randomUUID()
+
+    // For creates the id only exists on the response body — capture it without
+    // altering what is sent. Updates/deletes carry the id in the path already.
+    let createdId: unknown
+    if (action === 'create') {
+        const originalJson = res.json.bind(res)
+        res.json = (body: any): Response => {
+            if (body && typeof body === 'object' && 'id' in body) {
+                createdId = body.id
+            }
+            return originalJson(body)
+        }
+    }
+
+    res.on('finish', () => {
+        // Only audit mutations that actually took effect.
+        if (res.statusCode >= 400) return
+
+        const user = (req as { user?: Record<string, unknown> }).user ?? {}
+        const entityId = pathId ?? createdId
+        const actor = {
+            sub: user.sub,
+            email: user.email,
+            ...(user.service ? { service: true } : {}),
+        }
+        const summary = `audit: ${action} ${entityType}${entityId != null ? ` #${entityId}` : ''}`
+
+        logger.info(
+            {
+                audit: true,
+                action,
+                entityType,
+                entityId,
+                actor,
+                requestId,
+                ip: req.ip,
+                method: req.method,
+                path: req.path,
+                status: res.statusCode,
+            },
+            summary,
+        )
+
+        // Also leave a Sentry breadcrumb so the recent admin-action trail is
+        // attached to any later error event (no-op unless Sentry is enabled).
+        logger.breadcrumb({
+            category: 'audit',
+            message: summary,
+            level: 'info',
+            data: { action, entityType, entityId, actor, requestId },
+        })
+    })
+
+    next()
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -9,6 +9,7 @@ import {
     httpRequestsTotal,
     registerMetricsRoute,
 } from './metrics-route.js'
+import { auditAdminCatalogMutations } from './middleware/audit.js'
 import { registerPlaybackRoute } from './playback-route.js'
 import { registerSwaggerRoute } from './swagger-route.js'
 import { RegisterRoutes } from './tsoa-routes.js'
@@ -62,6 +63,8 @@ export async function createHttpApp(): Promise<express.Application> {
     } catch (e) {
         logger.error('failed to register spotify-route', e)
     }
+    // Audit admin catalog mutations (one place; logs successful writes) — #37
+    app.use(auditAdminCatalogMutations)
     // Register tsoa-generated routes
     RegisterRoutes(app)
 
@@ -194,6 +197,9 @@ export async function registerDbDependentRoutes(app: any) {
     } catch (e) {
         logger.error('failed to register spotify-route', e)
     }
+
+    // Audit admin catalog mutations (one place; logs successful writes) — #37
+    app.use(auditAdminCatalogMutations)
 
     // Register tsoa-generated routes
     RegisterRoutes(app)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -59,6 +59,29 @@ export function setErrorReporter(reporter: ErrorReporter | null): void {
     errorReporter = reporter
 }
 
+/** A diagnostic breadcrumb — context attached to later error reports, not an event itself. */
+export interface Breadcrumb {
+    category: string
+    message: string
+    level?: 'info' | 'warning' | 'error'
+    data?: Record<string, unknown>
+}
+
+export type BreadcrumbReporter = (crumb: Breadcrumb) => void
+
+let breadcrumbReporter: BreadcrumbReporter | null = null
+
+/**
+ * Attach (or clear) a reporter for `logger.breadcrumb` — the second observability
+ * choke point (alongside `setErrorReporter`). Lets e.g. Sentry record breadcrumbs
+ * without coupling callers to the reporter. No-op until a reporter is attached.
+ */
+export function setBreadcrumbReporter(
+    reporter: BreadcrumbReporter | null,
+): void {
+    breadcrumbReporter = reporter
+}
+
 function adapt(level: 'debug' | 'info' | 'warn' | 'error'): LogFn {
     return (...args: unknown[]) => {
         const ctx: Record<string, unknown> = {}
@@ -88,6 +111,18 @@ export const logger = {
     info: adapt('info'),
     warn: adapt('warn'),
     error: adapt('error'),
+    /**
+     * Record a diagnostic breadcrumb via the attached reporter (e.g. Sentry).
+     * No-op when no reporter is set, and never throws into the caller.
+     */
+    breadcrumb(crumb: Breadcrumb): void {
+        if (!breadcrumbReporter) return
+        try {
+            breadcrumbReporter(crumb)
+        } catch {
+            /* noop — breadcrumbs must never break the request path */
+        }
+    },
     /** The underlying pino instance, for child loggers / advanced use. */
     raw: base,
 }

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/node'
 import { config } from './config.js'
-import { logger, setErrorReporter } from './logger.js'
+import { logger, setBreadcrumbReporter, setErrorReporter } from './logger.js'
 
 let initialized = false
 
@@ -56,6 +56,17 @@ export function initSentry(): void {
         } else {
             Sentry.captureMessage(message || 'error', 'error')
         }
+    })
+
+    // Bridge: record breadcrumbs (e.g. admin audit events) so the recent trail is
+    // attached to any subsequent error event, without raising events themselves.
+    setBreadcrumbReporter((crumb) => {
+        Sentry.addBreadcrumb({
+            category: crumb.category,
+            message: crumb.message,
+            level: crumb.level ?? 'info',
+            data: scrub(crumb.data ?? {}) as Record<string, unknown>,
+        })
     })
 
     logger.info('Sentry error reporting initialized', {

--- a/test/http/audit-middleware.test.ts
+++ b/test/http/audit-middleware.test.ts
@@ -1,0 +1,168 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { auditAdminCatalogMutations } from '../../src/http/middleware/audit'
+import { logger } from '../../src/logger'
+
+type AuditCtx = Record<string, any>
+
+let infoSpy: ReturnType<typeof vi.spyOn>
+let breadcrumbSpy: ReturnType<typeof vi.spyOn>
+
+const auditEntries = (): AuditCtx[] =>
+    infoSpy.mock.calls
+        .map((c) => c[0] as AuditCtx)
+        .filter((ctx) => ctx?.audit === true)
+
+const DEFAULT_USER = { sub: 'user-123', email: 'admin@example.com' }
+
+function makeApp(user: unknown = DEFAULT_USER) {
+    const app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+        if (user) (req as any).user = user
+        next()
+    })
+    app.use(auditAdminCatalogMutations)
+
+    app.post('/api/books', (req, res) => {
+        if ((req.body as any)?.fail) {
+            return res.status(400).json({ error: 'bad request' })
+        }
+        res.status(201).json({ id: 42, title: (req.body as any)?.title })
+    })
+    app.put('/api/authors/:id', (_req, res) => res.json({ id: 7 }))
+    app.delete('/api/movies/:id', (_req, res) =>
+        res.status(200).json({ success: true }),
+    )
+    app.get('/api/books', (_req, res) => res.json({ books: [] }))
+    app.post('/api/admin/spotify/oauth-callback', (_req, res) =>
+        res.status(200).json({ ok: true }),
+    )
+    return app
+}
+
+describe('auditAdminCatalogMutations (#37 — admin catalog audit logging)', () => {
+    beforeEach(() => {
+        infoSpy = vi.spyOn(logger, 'info').mockImplementation(() => {})
+        breadcrumbSpy = vi
+            .spyOn(logger, 'breadcrumb')
+            .mockImplementation(() => {})
+    })
+    afterEach(() => {
+        infoSpy.mockRestore()
+        breadcrumbSpy.mockRestore()
+    })
+
+    it('logs a create with the id captured from the response body', async () => {
+        await request(makeApp())
+            .post('/api/books')
+            .send({ title: 'Dune' })
+            .expect(201)
+
+        const entries = auditEntries()
+        expect(entries).toHaveLength(1)
+        expect(entries[0]).toMatchObject({
+            audit: true,
+            action: 'create',
+            entityType: 'book',
+            entityId: 42,
+            actor: { sub: 'user-123', email: 'admin@example.com' },
+            status: 201,
+        })
+    })
+
+    it('logs an update with the id taken from the path', async () => {
+        await request(makeApp())
+            .put('/api/authors/7')
+            .send({ name: 'x' })
+            .expect(200)
+        const entries = auditEntries()
+        expect(entries).toHaveLength(1)
+        expect(entries[0]).toMatchObject({
+            action: 'update',
+            entityType: 'author',
+            entityId: '7',
+        })
+    })
+
+    it('logs a delete with the id taken from the path', async () => {
+        await request(makeApp()).delete('/api/movies/9').expect(200)
+        expect(auditEntries()[0]).toMatchObject({
+            action: 'delete',
+            entityType: 'movie',
+            entityId: '9',
+        })
+    })
+
+    it('does not log reads (GET)', async () => {
+        await request(makeApp()).get('/api/books').expect(200)
+        expect(auditEntries()).toHaveLength(0)
+    })
+
+    it('does not log failed mutations (4xx)', async () => {
+        await request(makeApp())
+            .post('/api/books')
+            .send({ fail: true })
+            .expect(400)
+        expect(auditEntries()).toHaveLength(0)
+    })
+
+    it('does not log non-catalog routes', async () => {
+        await request(makeApp())
+            .post('/api/admin/spotify/oauth-callback')
+            .expect(200)
+        expect(auditEntries()).toHaveLength(0)
+    })
+
+    it('never logs request-body content (no PII/secrets beyond actor)', async () => {
+        await request(makeApp())
+            .post('/api/books')
+            .send({ title: 'Sensitive Working Title' })
+            .expect(201)
+
+        const ctx = auditEntries()[0]
+        expect(ctx).not.toHaveProperty('title')
+        expect(JSON.stringify(ctx)).not.toContain('Sensitive Working Title')
+    })
+
+    it('passes through an incoming X-Request-Id, else generates one', async () => {
+        await request(makeApp())
+            .post('/api/books')
+            .set('X-Request-Id', 'req-abc-123')
+            .send({ title: 'x' })
+            .expect(201)
+        expect(auditEntries()[0].requestId).toBe('req-abc-123')
+
+        infoSpy.mockClear()
+        await request(makeApp()).delete('/api/movies/9').expect(200)
+        // Generated fallback is a non-empty string (UUID).
+        expect(typeof auditEntries()[0].requestId).toBe('string')
+        expect(auditEntries()[0].requestId.length).toBeGreaterThan(0)
+    })
+
+    it('emits a Sentry breadcrumb for a successful mutation, but not for reads', async () => {
+        const app = makeApp()
+        await request(app).post('/api/books').send({ title: 'x' }).expect(201)
+        expect(breadcrumbSpy).toHaveBeenCalledTimes(1)
+        expect(breadcrumbSpy.mock.calls[0][0]).toMatchObject({
+            category: 'audit',
+            level: 'info',
+            data: { action: 'create', entityType: 'book' },
+        })
+
+        breadcrumbSpy.mockClear()
+        await request(app).get('/api/books').expect(200)
+        expect(breadcrumbSpy).not.toHaveBeenCalled()
+    })
+
+    it('flags service-role actors', async () => {
+        await request(makeApp({ sub: 'service', service: true }))
+            .delete('/api/movies/9')
+            .expect(200)
+        expect(auditEntries()[0].actor).toMatchObject({
+            sub: 'service',
+            service: true,
+        })
+    })
+})

--- a/test/sentry.test.ts
+++ b/test/sentry.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { config } from '../src/config.js'
-import { logger, setErrorReporter } from '../src/logger.js'
+import {
+    logger,
+    setBreadcrumbReporter,
+    setErrorReporter,
+} from '../src/logger.js'
 import { initSentry } from '../src/sentry.js'
 
 describe('Sentry / logger error bridge', () => {
@@ -29,6 +33,41 @@ describe('Sentry / logger error bridge', () => {
         logger.debug('details')
 
         expect(reporter).not.toHaveBeenCalled()
+    })
+
+    it('logger.breadcrumb invokes an attached breadcrumb reporter', () => {
+        const reporter = vi.fn()
+        setBreadcrumbReporter(reporter)
+        try {
+            logger.breadcrumb({ category: 'audit', message: 'create book #1' })
+            expect(reporter).toHaveBeenCalledTimes(1)
+            expect(reporter.mock.calls[0][0]).toMatchObject({
+                category: 'audit',
+                message: 'create book #1',
+            })
+        } finally {
+            setBreadcrumbReporter(null)
+        }
+    })
+
+    it('logger.breadcrumb is a silent no-op when no reporter is attached', () => {
+        setBreadcrumbReporter(null)
+        expect(() =>
+            logger.breadcrumb({ category: 'audit', message: 'x' }),
+        ).not.toThrow()
+    })
+
+    it('a throwing breadcrumb reporter never propagates into the caller', () => {
+        setBreadcrumbReporter(() => {
+            throw new Error('reporter blew up')
+        })
+        try {
+            expect(() =>
+                logger.breadcrumb({ category: 'audit', message: 'x' }),
+            ).not.toThrow()
+        } finally {
+            setBreadcrumbReporter(null)
+        }
     })
 
     it('initSentry is a no-op when no DSN is configured (does not install a reporter)', () => {


### PR DESCRIPTION
## Summary

Records an audit entry for every successful admin **catalog mutation** (create/update/delete of books, authors, movies, videogames, content-creators), and attaches the recent admin-action trail to Sentry error events via breadcrumbs.

Closes #37.

## Decision

**Log-only, no `AuditLog` table** — structured logs + Sentry already exist and the scope is single-user, so a DB table isn't worth its weight. Audit entries are emitted at `info` level via the existing pino logger.

## Changes

- **One place, no per-handler duplication:** a post-response middleware [`auditAdminCatalogMutations`](../src/http/middleware/audit.ts), wired before `RegisterRoutes` in both registration paths in [`server.ts`](../src/http/server.ts).
- Emits `logger.info({ audit: true, ... })` capturing: **actor** (`sub` + `email`, plus a `service` flag for the service-role path), **action**, **entity type + id**, **request id** (`X-Request-Id` or a generated UUID), and **ip**. pino adds the timestamp.
  - Entity id comes from the path for update/delete, and from the response body for create (via a scoped `res.json` wrap).
- **No PII/secrets:** request bodies are never logged (test asserts a sensitive title never appears). Skips reads, 4xx failures, and non-catalog routes.
- **Sentry breadcrumbs:** adds a second observability choke point mirroring `setErrorReporter` — `logger.breadcrumb` + `setBreadcrumbReporter` ([`logger.ts`](../src/logger.ts)), bridged to `Sentry.addBreadcrumb` in `initSentry` ([`sentry.ts`](../src/sentry.ts), scrubbed). The middleware records a `category: "audit"` breadcrumb, so the recent admin-action trail is attached to any subsequent error event. No-op unless Sentry is enabled.

## Observability behavior

Audit events are **not** Sentry events (they aren't errors — only `logger.error` raises events, which would be noisy). They land in the structured log stream (Render logs / prod JSON); filter for `"audit":true`. When Sentry is on, they additionally enrich error context as breadcrumbs.

## Verification

- `pnpm run typecheck` clean; full suite **234 passed / 5 skipped / 0 failed**; lint clean.
- 10 middleware tests + 3 breadcrumb-bridge tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
