### PR TITLE
feat(articles): add Article resource — Prisma model, MCP tools, REST, seed (#120)

### DIFF
--- a/prisma/migrations/20260620120000_add_articles/migration.sql
+++ b/prisma/migrations/20260620120000_add_articles/migration.sql
@@ -1,0 +1,46 @@
+-- Add Article resource: DB-backed site philosophy content (issue #120).
+-- Public reads are restricted to `published`; drafts require admin auth,
+-- enforced in the application layer (ArticlesController + MCP tools).
+
+-- CreateEnum
+CREATE TYPE "ArticleStatus" AS ENUM ('draft', 'published');
+
+-- CreateTable
+CREATE TABLE "Article" (
+    "id" SERIAL NOT NULL,
+    "slug" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "summary" TEXT,
+    "body" TEXT NOT NULL,
+    "status" "ArticleStatus" NOT NULL DEFAULT 'draft',
+    "tags" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "published_at" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Article_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Article_slug_key" ON "Article"("slug");
+
+-- CreateIndex
+CREATE INDEX "Article_status_idx" ON "Article"("status");
+
+-- CreateIndex
+CREATE INDEX "Article_publishedAt_idx" ON "Article"("published_at");
+
+-- Row-Level Security: public can read only `published`; admins do everything.
+-- The application also enforces published-only at its layer; this is
+-- defense-in-depth for any direct (PostgREST/anon) access.
+ALTER TABLE "Article" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Article_public_select_published" ON "Article";
+CREATE POLICY "Article_public_select_published" ON "Article" FOR SELECT USING (status = 'published');
+
+DROP POLICY IF EXISTS "Article_admin_all" ON "Article";
+CREATE POLICY "Article_admin_all" ON "Article" FOR ALL USING (
+  current_setting('request.jwt.claims.role', true) = 'admin'
+) WITH CHECK (
+  current_setting('request.jwt.claims.role', true) = 'admin'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,11 @@ enum ItemStatus {
   COMPLETED
 }
 
+enum ArticleStatus {
+  draft
+  published
+}
+
 // Note: Prisma 7 requires the datasource URL to be configured in `prisma.config.ts`.
 // See `prisma.config.ts` for local dev config and CI usage.
 
@@ -125,4 +130,23 @@ model ContentCreator {
   updatedAt   DateTime @updatedAt
 
   @@index([name])
+}
+
+// DB-backed site articles (philosophy content). Drafts stay out of public
+// source and publishing doesn't require a redeploy. Public reads are
+// restricted to `published`; drafts require admin auth. See issue #120.
+model Article {
+  id          Int           @id @default(autoincrement())
+  slug        String        @unique
+  title       String
+  summary     String?
+  body        String // Markdown source
+  status      ArticleStatus @default(draft)
+  tags        String[]      @default([])
+  publishedAt DateTime?     @map("published_at")
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+
+  @@index([status])
+  @@index([publishedAt])
 }

--- a/prisma/seed-data/cptsd.ts
+++ b/prisma/seed-data/cptsd.ts
@@ -1,0 +1,186 @@
+// CPTSD article — the one real Article data point, seeded as `published` (#120).
+// Body ported verbatim from bryandebaun.dev/src/content/philosophy/cptsd.mdx
+// (frontmatter title/date/summary/tags mapped to DB fields below).
+
+export const cptsdArticle = {
+    slug: 'cptsd',
+    title: 'CPTSD — Thoughts & Reflections',
+    summary:
+        'Living document discussing Complex PTSD (CPTSD): experiences, research, and how it shapes my thinking.',
+    status: 'published' as const,
+    tags: ['CPTSD', 'mental-health', 'personal', 'philosophy'],
+    publishedAt: new Date('2026-01-29'),
+    body: `# CPTSD — Thoughts & Reflections
+
+## TL;DR
+
+This is my experience with Complex PTSD—what I've learned so far, what's helped, what I'm still figuring out. I spent nearly fifteen years treating symptoms without understanding their source. Getting the right diagnosis ten months ago changed everything. This post is part processing, part resource-sharing for anyone on a similar path.
+
+## Context
+
+I was accurately diagnosed with CPTSD about ten months ago. Before that, I'd spent roughly fifteen years treating depression and anxiety—addressing symptoms without understanding the underlying trauma that shaped them. The diagnosis wasn't just a label; it reframed my entire experience and opened up treatment approaches that actually worked.
+
+The last year has been difficult, but it's also been the most productive therapeutic work I've done. Understanding CPTSD allowed me to adapt my treatments more specifically and re-contextualize patterns I'd been living with for years. This post exists to externalize some of that work and offer what resources and observations might be useful to others navigating similar terrain.
+
+This is written for a public audience, but it's deeply personal. I'm sharing what feels relevant without exposing details that belong to other people or that don't serve the larger point. If you're struggling with similar issues, I hope some of this resonates or points you toward something helpful.
+
+## Personal Observations
+
+### Relational
+
+**Trust patterns:**
+I established a pattern early of trusting too quickly—likely shaped by my parents' divorce and the significant age gap with my siblings (15 and 18 years). Without stable, consistent relationships during formative years, I learned to attach fast and hold on tight. The underlying foundation was an overwhelming fear that everyone would eventually abandon me, or that I was fundamentally unworthy of love.
+
+This showed up as investing deeply in relationships that hadn't been tested, which meant getting burned repeatedly. I'm learning now to let relationships prove themselves before offering full trust—not out of cynicism, but out of self-preservation and discernment.
+
+I also treated relationships as all-or-nothing for a long time. Someone was either safe or dangerous, worthy of trust or not. I'm still working on holding the nuance that people can be trustworthy in some contexts and not others, that imperfection doesn't equal abandonment.
+
+**Progress:**
+I'm getting much better at noticing my instinctive self-guilt and perfectionism when they show up in relationships. I used to rigorously analyze every thought and emotion before expressing it—needing to be rational, defensible, correct. Now I'm learning to just explore how things feel, to let others reflect back to me without having to have it all figured out first.
+
+My boundaries have improved significantly. Part of my journey has been flipping the script: instead of being so readily available and constantly seeking to give, I'm letting others give if they're worth it. I'm learning to identify people who won't take advantage of me, rather than assuming I need to earn my place by being useful.
+
+I'm always open to repairing relationships, but I'm more mature now about forcing things when the other person isn't as emotionally intelligent or willing to do the work. Repair requires two people.
+
+Vulnerability used to feel dangerous. Now, with people I fully trust, it feels incredibly rewarding.
+
+### Professional
+
+**Decision-making under pressure:**
+Under pressure, I tend to be incredibly deferring—avoiding conflict when possible, which lines up directly with my trauma response. My perfectionism was present but inconsistent: I could obsess over details in some contexts, then completely disengage if I felt my effort wasn't tied to meaningful impact.
+
+I was often too quick to delegate or too afraid to take ownership of items. Looking back, this was about avoiding responsibility that could lead to criticism or failure. When criticism did come, I took it too much to heart, let it define me rather than just inform my work.
+
+**Communication dynamics:**
+I ruminate constantly. I'd find myself replaying work interactions or second-guessing technical approaches well beyond working hours—most of which were probably mundane in the end. I read too much into some things (tone in Slack messages, a manager's offhand comment) while simultaneously not reading into other things enough (actual warning signs, patterns that mattered).
+
+I always yearned for critiques, but I think that was a defense mechanism. If my inner critic is loud enough, I might be too quick to accept that something is my fault. Conflict-avoidant throughout. I may have been guilty of over-explaining depending on context, though I'm not sure I over-justified—the line between helpful context and defensive explanation is blurry for me.
+
+**Progress:**
+I'm comfortable asking questions now without the same level of shame. I can set professional boundaries more clearly than I used to. But I'm still on a journey here—I need to get over feeling fundamentally incompetent and learn to silence (or at least turn down) my inner critic.
+
+Part of my path forward involves looking for more purposeful work and adapting the strides I've made in identifying personal triggers to professional contexts. Recognizing when I'm in a triggered state versus responding to actual workplace dynamics is still a work in progress.
+
+### Internal/Emotional
+
+**Emotional regulation:**
+In DBT terms, I've over-developed and relied heavily on my logical brain. I can dissociate easily, and while that's been a useful survival tool in the past, it comes with trade-offs. The strength is the ability to contain harmful interactions and thoughts, then process them productively later. The weakness is appearing emotionally flat or robotic, disconnected from what I'm actually feeling in the moment.
+
+I've detached significantly from my physical feelings—my felt-self—and reconnecting with that has been a major focus of treatment. I know I can get triggered, and I've made significant progress in identifying when it's happening, but I haven't fully figured out the regulation part yet. Learning to be present through mindfulness, meditation, breathing exercises, exploring nature and music—these have all been essential.
+
+I have a lot of thoughts, a lot of the time. Intrusive thoughts are constant. Meditation, music, and structure have been useful tools for managing the noise.
+
+**Self-perception:**
+Before diagnosis, I assumed I was just depressed and anxious—that something or someone could eventually pull me out of it. I looked to romantic partners to externalize validation, which wasn't fair to them and didn't address the actual trauma underneath.
+
+Now I'm working on taking time for myself, exploring the things that matter to me and that I care about. But I can still spiral quickly—a combination of my inner critic, relative intelligence, and tendency to internalize everything. I've made strides in identifying when it's happening, but I'm still working on improving my responses.
+
+A major breakthrough has been identifying a small "inner-parent" voice. It's quiet, but it's there, and I've been focused on cultivating it. The pattern I fall into is having a very strict and critical image of myself. If others reflect something to me that doesn't align with that image, I shrug it off as inaccurate. But if their feedback comports with my self-critique, it kicks off a cascade of thoughts about how to fix it. I'm trying to find middle ground there and incorporate feelings more instead of just analysis.
+
+My sense of self feels small. That's something I'm actively trying to take ownership of and build.
+
+**Re-contextualization:**
+A recent example with my current partner: she's on vacation and mentioned plans to go line-dancing. My immediate response was playful but dismissive—"gross" (I don't like country music, she does). She responded equally playfully: "what I'm hearing is I'm happy that my girlfriend is getting to do something she enjoys."
+
+That sparked a meta-conversation where I could reflect: yes, if my first instinct is to respond with disdain—even jokingly—it can become grating over time. Maybe I should lead with affirmation and then engage in the ribbing. It's a small example, but it illustrates the larger pattern: my default response often bypasses connection in favor of cleverness or critique.
+
+The relationship feels safe and secure, which has allowed me to notice these patterns without immediately spiraling into shame about them.
+
+**Progress:**
+I'm getting better at noticing triggers without being entirely consumed by them. The inner-parent voice is growing, even if it's still small. I can identify when I'm dissociating or when I'm in my head instead of present. Self-compassion is still difficult, but it's not completely absent anymore.
+
+I'm learning that healing isn't about eliminating the logical brain or the survival mechanisms that got me here—it's about integrating them with the parts I've had to shut down.
+
+### Physical
+
+**Somatic symptoms:**
+One major pattern that's emerged in therapy is how much stress I carry in my hands. I grip reflexively when stressed, pull my hands closer to my body, or gesticulate intensely. A lot of my work now is trying to be more open to sensations and curious without judgment about what my hands are doing. Still very much a work in progress.
+
+The hands thing makes sense when I trace it back: I rowed in college (very hand-focused, lots of muscle memory and instinct built there), played trumpet through high school (the valve buttons are still instinctual in my right hand), and I'm a software engineer (typing constantly). These activities are emblematic of my coping mechanisms: music, sports, coding. All hand-intensive, all ways of managing or escaping what I was feeling.
+
+I've been trying to learn saxophone and piano recently, which has been difficult in an interesting way. I rowed as a sweeper on the port side, so my left hand was responsible for strength while my right hand developed dexterity. But music and typing require both hands to be dextrous, which means retraining patterns that are decades old.
+
+Sleep has been an ongoing struggle. My dad has sleep issues too—there's likely something hereditary there—and I'm still exploring how to resolve it. I'm NOT a morning person, and I find myself easily fatigued by the end of each week and most mornings regardless of rest.
+
+The only chronic physical issue that's shown up consistently is sciatica.
+
+**What's helped:**
+Yoga and breathing exercises have been surprisingly effective—particularly Wim Hof's breathing techniques. The body-based work complements talk therapy in ways I didn't expect. Talk therapy helps me understand the patterns cognitively; body work helps me actually feel and release what's stored there.
+
+A lot of this work over the last year has been at the guidance of my therapist, who's been instrumental in helping me reconnect with my body.
+
+**Progress:**
+Most of the progress has been centered around body awareness. I'm better at noticing when I'm gripping, when tension is building, when I'm disconnecting from physical sensation. I don't always know what to do with that awareness yet, but recognizing it is the first step.
+
+I'm learning that my body has been keeping score this whole time, and I'm finally starting to listen.
+
+## Questions
+
+These are living questions—some clinical, some experiential, some philosophical. I'm exploring all of them.
+
+### Clinical:
+
+- How do different trauma therapies compare for developmental trauma vs. single-incident PTSD? What makes EMDR effective where talk therapy struggled?
+- What does the research say about hereditary components of sleep disorders, and how do they interact with trauma-related sleep disruption?
+- Is there a neurological basis for why body-based trauma work (somatic therapy, yoga, breathwork) complements cognitive approaches?
+
+### Experiential:
+
+- How do others navigate the tension between wanting deep connection and needing significant alone time to regulate?
+- What strategies help when you can identify you're triggered but haven't yet developed effective regulation responses?
+- How do people maintain professional boundaries and career momentum while doing intensive trauma work that requires so much energy?
+
+### Philosophical:
+
+- What does "healing" actually mean when trauma is woven into your development? Is it integration, symptom reduction, or something else entirely?
+- How do you build a coherent sense of self when so much of your identity was shaped by survival mechanisms that are no longer serving you?
+- Is there value in keeping some dissociative capacity as a tool, or does healing require fully letting go of all protective mechanisms?
+
+### Research to pursue:
+
+- Papers on CPTSD and attachment styles formed in childhood (particularly related to parental divorce and age gaps with siblings)
+- Studies on the inner critic and its role in perfectionism and self-abandonment
+- Literature on somatic markers of trauma and hand/grip tension patterns
+
+### Experiments to try:
+
+- Structured sleep hygiene protocols specifically for trauma-related sleep disruption
+- Different approaches to cultivating the "inner parent" voice (IFS therapy, reparenting exercises, compassion-focused therapy)
+- Ways to practice affirmation-first communication patterns in safe relationships
+## Sources & References
+
+### Therapy & Treatment Approaches
+
+**EMDR (Eye Movement Desensitization and Reprocessing):**
+Francine Shapiro's *Getting Past Your Past* is the foundational text. EMDR has been one of the most effective modalities for me—it works differently than talk therapy and gets at material that's hard to access through conversation alone.
+
+**Gottman Method:**
+[Gottman Institute](https://www.gottman.com/) — particularly valuable for understanding relational patterns and repair. Their research-based approach to communication and conflict has been clarifying.
+
+### Books
+
+**Complex PTSD: From Surviving to Thriving** by Pete Walker
+This book has been both invaluable and difficult to confront. Walker writes from lived experience and clinical expertise. His work on emotional flashbacks and the "4Fs" (fight, flight, freeze, fawn) gave me language for things I'd been experiencing but couldn't name.
+
+**The Body Keeps the Score** by Bessel van der Kolk
+Essential reading on how trauma lives in the body. Dense but worth it. Van der Kolk's research on somatic therapies and the neuroscience of trauma helped me understand why body-based work matters.
+
+**Get Out of Your Mind and Into Your Life** by Steven C. Hayes
+Acceptance and Commitment Therapy (ACT) framework. Useful for sitting with discomfort rather than constantly trying to fix or avoid it.
+
+**When Panic Attacks** by David Burns
+Cognitive Behavioral Therapy (CBT) techniques. Particularly helpful for the anxiety piece before I had the full CPTSD diagnosis.
+
+### Additional Resources
+
+**Pete Walker's website:** [pete-walker.com](https://pete-walker.com/index.htm)
+Free articles on emotional flashbacks, toxic shame, and the 4Fs. His writing is direct and practical.
+
+**Wim Hof Method:**
+Breathing exercises that have genuinely helped with regulation. The science is still being debated, but the technique itself has been useful for me.
+
+## Related Notes
+
+*[Placeholder: Links to related posts—philosophy notes on identity, healing, meaning-making; book notes; reflections on therapy or self-work]*
+`,
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,6 +1,7 @@
 import pkg from '@prisma/client'
 const { PrismaClient } = pkg as any
 import { PrismaPg } from '@prisma/adapter-pg'
+import { cptsdArticle } from './seed-data/cptsd.js'
 
 const dbUrl = process.env.DATABASE_URL
 if (!dbUrl) {
@@ -269,13 +270,21 @@ export async function runSeed(prismaClient?: any) {
         },
     })
 
+    // Seed the one real Article data point (CPTSD), idempotently by slug.
+    const cptsd = await db.article.upsert({
+        where: { slug: cptsdArticle.slug },
+        update: {},
+        create: cptsdArticle,
+    })
+
     console.log({
         profiles: { bryanAdmin, admin },
         authors: { author1, author2 },
         books: { book1, book2, book3 },
         movies: { movie1, movie2, movie3 },
         games: { game1, game2, game3 },
-        contentCreators: { cc1, cc2, cc3 }
+        contentCreators: { cc1, cc2, cc3 },
+        articles: { cptsd }
     })
 
     // Reset sequences to ensure they're ahead of any manually-inserted IDs (fixes CI test flakes with duplicate key violations)
@@ -285,6 +294,7 @@ export async function runSeed(prismaClient?: any) {
         { table: 'Movie', sequence: 'Movie_id_seq' },
         { table: 'VideoGame', sequence: 'VideoGame_id_seq' },
         { table: 'ContentCreator', sequence: 'ContentCreator_id_seq' },
+        { table: 'Article', sequence: 'Article_id_seq' },
     ]
 
     for (const { table, sequence } of sequenceResets) {

--- a/src/auth/optional-admin.ts
+++ b/src/auth/optional-admin.ts
@@ -1,0 +1,25 @@
+import type { Request } from 'express'
+import { resolveAppRole, verifySupabaseJwt } from './jwt.js'
+
+/**
+ * Best-effort check of whether a request carries a valid **admin** Supabase JWT.
+ *
+ * Used by endpoints gated by the MCP gateway key (`@Security('api_key')`) that
+ * want to *additionally* unlock admin-only views (e.g. draft articles) when an
+ * admin JWT is also presented — mirroring the "JWT + API key" admin path (#120).
+ *
+ * Never throws: a missing/invalid/non-JWT bearer (including the gateway key
+ * presented as the bearer token) resolves to `false`, so callers safely fall
+ * back to the public (published-only) view.
+ */
+export async function requestIsAdmin(req: Request): Promise<boolean> {
+    const auth = req.headers.authorization
+    if (!auth || !auth.startsWith('Bearer ')) return false
+    try {
+        const payload = await verifySupabaseJwt(auth.slice('Bearer '.length))
+        const { isAdmin } = await resolveAppRole(payload)
+        return isAdmin
+    } catch {
+        return false
+    }
+}

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -28,6 +28,7 @@ const MODEL_NAMES = [
     'movie',
     'videoGame',
     'contentCreator',
+    'article',
     'rating',
 ] as const
 

--- a/src/http/controllers/ArticlesController.ts
+++ b/src/http/controllers/ArticlesController.ts
@@ -1,0 +1,210 @@
+import type { Request as ExpressRequest } from 'express'
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Path,
+    Post,
+    Put,
+    Query,
+    Request,
+    Response,
+    Route,
+    Security,
+    SuccessResponse,
+    Tags,
+} from 'tsoa'
+import { requestIsAdmin } from '../../auth/optional-admin.js'
+import { callTool } from '../../tools/local.js'
+import { httpError, isNotFound, isUniqueViolation } from './_http-errors.js'
+
+export type ArticleStatus = 'draft' | 'published'
+/** Read visibility filter. `all` returns both; `draft`/`all` require admin. */
+export type ArticleReadStatus = 'draft' | 'published' | 'all'
+
+export interface Article {
+    id: number
+    slug: string
+    title: string
+    summary?: string | null
+    body: string
+    status: ArticleStatus
+    tags: string[]
+    publishedAt?: string | null
+    createdAt: string
+    updatedAt: string
+}
+
+export interface ListArticlesResponse {
+    articles: Article[]
+    total: number
+}
+
+export interface CreateArticleRequest {
+    slug: string
+    title: string
+    body: string
+    summary?: string
+    status?: ArticleStatus
+    tags?: string[]
+    publishedAt?: string
+}
+
+export interface UpdateArticleRequest {
+    title?: string
+    body?: string
+    summary?: string
+    status?: ArticleStatus
+    tags?: string[]
+    publishedAt?: string
+    newSlug?: string
+}
+
+/**
+ * Article endpoints. Reads are gated by the MCP gateway key and return only
+ * `published` by default; an admin Supabase JWT (presented alongside the key)
+ * unlocks drafts via `?status=draft|all`. Writes require admin auth. See #120.
+ */
+@Route('api/articles')
+@Tags('Articles')
+export class ArticlesController extends Controller {
+    /**
+     * List articles (published-only unless an admin requests drafts).
+     * @param status Visibility filter; `draft`/`all` require an admin JWT.
+     * @param tag Filter by a single tag
+     * @param search Search in title and summary
+     * @param limit Maximum number of results (default 50)
+     * @param offset Number of results to skip (default 0)
+     */
+    @Get()
+    @Security('api_key')
+    @SuccessResponse('200', 'Articles retrieved successfully')
+    public async listArticles(
+        @Request() request: ExpressRequest,
+        @Query() status?: ArticleReadStatus,
+        @Query() tag?: string,
+        @Query() search?: string,
+        @Query() limit?: number,
+        @Query() offset?: number,
+    ): Promise<ListArticlesResponse> {
+        const effectiveStatus = await this.resolveReadStatus(request, status)
+        const result = await callTool('list-articles', {
+            status: effectiveStatus,
+            tag,
+            search,
+            limit,
+            offset,
+        })
+        return result as ListArticlesResponse
+    }
+
+    /**
+     * Get an article by slug (published-only unless an admin requests drafts).
+     * @param slug Article slug
+     * @param status Visibility filter; `draft`/`all` require an admin JWT.
+     */
+    @Get('{slug}')
+    @Security('api_key')
+    @SuccessResponse('200', 'Article retrieved successfully')
+    @Response('404', 'Article not found')
+    public async getArticle(
+        @Request() request: ExpressRequest,
+        @Path() slug: string,
+        @Query() status?: ArticleReadStatus,
+    ): Promise<Article> {
+        const effectiveStatus = await this.resolveReadStatus(request, status)
+        try {
+            const result = await callTool('get-article', {
+                slug,
+                status: effectiveStatus,
+            })
+            return result as Article
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Article not found')
+            throw err
+        }
+    }
+
+    /**
+     * Create a new article (admin only).
+     */
+    @Post()
+    @Security('jwt', ['admin'])
+    @SuccessResponse('201', 'Article created successfully')
+    @Response('400', 'Invalid request')
+    @Response('401', 'Unauthorized')
+    public async createArticle(
+        @Body() body: CreateArticleRequest,
+    ): Promise<Article> {
+        if (!body.slug) throw httpError(400, 'slug is required')
+        if (!body.title) throw httpError(400, 'title is required')
+        if (!body.body) throw httpError(400, 'body is required')
+        try {
+            const result = await callTool('create-article', body)
+            this.setStatus(201)
+            return result as Article
+        } catch (err: any) {
+            if (isUniqueViolation(err))
+                throw httpError(400, 'slug already exists')
+            throw err
+        }
+    }
+
+    /**
+     * Update an article by slug (admin only).
+     * @param slug Article slug
+     */
+    @Put('{slug}')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Article updated successfully')
+    @Response('400', 'Invalid request')
+    @Response('404', 'Article not found')
+    public async updateArticle(
+        @Path() slug: string,
+        @Body() body: UpdateArticleRequest,
+    ): Promise<Article> {
+        try {
+            const result = await callTool('update-article', { ...body, slug })
+            return result as Article
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Article not found')
+            if (isUniqueViolation(err))
+                throw httpError(400, 'slug already exists')
+            throw err
+        }
+    }
+
+    /**
+     * Delete an article by slug (admin only).
+     * @param slug Article slug
+     */
+    @Delete('{slug}')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Article deleted successfully')
+    @Response('404', 'Article not found')
+    public async deleteArticle(
+        @Path() slug: string,
+    ): Promise<{ success: boolean }> {
+        try {
+            await callTool('delete-article', { slug })
+            return { success: true }
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Article not found')
+            throw err
+        }
+    }
+
+    /**
+     * Non-admin callers are always restricted to `published`, regardless of the
+     * requested `status`. Only a valid admin JWT unlocks `draft`/`all`.
+     */
+    private async resolveReadStatus(
+        request: ExpressRequest,
+        requested?: ArticleReadStatus,
+    ): Promise<ArticleReadStatus> {
+        const wantsNonPublic = requested === 'draft' || requested === 'all'
+        if (!wantsNonPublic) return 'published'
+        return (await requestIsAdmin(request)) ? requested : 'published'
+    }
+}

--- a/src/tools/db/articles/create-article.ts
+++ b/src/tools/db/articles/create-article.ts
@@ -1,0 +1,61 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { CreateArticleInputSchema } from './schemas.js'
+
+const name = 'create-article'
+const config = {
+    title: 'Create Article',
+    description: 'Create a new article (admin only)',
+    inputSchema: CreateArticleInputSchema,
+}
+
+export function registerCreateArticleTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const {
+                    slug,
+                    title,
+                    summary,
+                    body,
+                    status,
+                    tags,
+                    publishedAt,
+                } = args
+                const finalStatus = status ?? 'draft'
+
+                const article = await prisma.article.create({
+                    data: {
+                        slug,
+                        title,
+                        summary,
+                        body,
+                        status: finalStatus,
+                        tags: tags ?? [],
+                        // Stamp publishedAt when publishing without an explicit date.
+                        publishedAt: publishedAt
+                            ? new Date(publishedAt)
+                            : finalStatus === 'published'
+                              ? new Date()
+                              : null,
+                    },
+                })
+
+                return createSuccessResult(article)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/articles/delete-article.ts
+++ b/src/tools/db/articles/delete-article.ts
@@ -1,0 +1,40 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { DeleteArticleInputSchema } from './schemas.js'
+
+const name = 'delete-article'
+const config = {
+    title: 'Delete Article',
+    description: 'Delete an article by slug (admin only)',
+    inputSchema: DeleteArticleInputSchema,
+}
+
+export function registerDeleteArticleTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { slug } = args
+                const article = await prisma.article.delete({
+                    where: { slug },
+                })
+                return createSuccessResult({
+                    message: 'Article deleted successfully',
+                    article,
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/articles/get-article.ts
+++ b/src/tools/db/articles/get-article.ts
@@ -1,0 +1,48 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { GetArticleInputSchema } from './schemas.js'
+import { statusFilter } from './status.js'
+
+const name = 'get-article'
+const config = {
+    title: 'Get Article',
+    description:
+        'Get an article by slug. Returns only published unless an admin context requests drafts.',
+    inputSchema: GetArticleInputSchema,
+}
+
+export function registerGetArticleTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { slug, status } = args
+                const article = await prisma.article.findUnique({
+                    where: { slug },
+                })
+                if (!article) return createErrorResult('Article not found')
+
+                // Hide drafts from non-admin reads: a published-only filter must
+                // 404 a draft rather than leak its existence.
+                const filter = statusFilter(status)
+                if (filter.status && article.status !== filter.status) {
+                    return createErrorResult('Article not found')
+                }
+
+                return createSuccessResult(article)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/articles/index.ts
+++ b/src/tools/db/articles/index.ts
@@ -1,0 +1,5 @@
+export { registerCreateArticleTool } from './create-article.js'
+export { registerDeleteArticleTool } from './delete-article.js'
+export { registerGetArticleTool } from './get-article.js'
+export { registerListArticlesTool } from './list-articles.js'
+export { registerUpdateArticleTool } from './update-article.js'

--- a/src/tools/db/articles/list-articles.ts
+++ b/src/tools/db/articles/list-articles.ts
@@ -1,0 +1,58 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { ListArticlesInputSchema } from './schemas.js'
+import { statusFilter } from './status.js'
+
+const name = 'list-articles'
+const config = {
+    title: 'List Articles',
+    description:
+        'List articles. Returns only published unless an admin context requests drafts.',
+    inputSchema: ListArticlesInputSchema,
+}
+
+export function registerListArticlesTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { status, tag, search, limit = 50, offset = 0 } = args
+
+                const where: any = { ...statusFilter(status) }
+                if (tag) where.tags = { has: tag }
+                if (search)
+                    where.OR = [
+                        { title: { contains: search, mode: 'insensitive' } },
+                        { summary: { contains: search, mode: 'insensitive' } },
+                    ]
+
+                const articles = await prisma.article.findMany({
+                    where,
+                    take: limit,
+                    skip: offset,
+                    // Newest published first; fall back to creation order.
+                    orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
+                })
+
+                return createSuccessResult({
+                    articles,
+                    total: articles.length,
+                    limit,
+                    offset,
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/articles/schemas.ts
+++ b/src/tools/db/articles/schemas.ts
@@ -1,0 +1,65 @@
+// Input schemas for article-related MCP tools
+import { z } from 'zod'
+
+const ArticleStatusEnum = z.enum(['draft', 'published'])
+
+/** Read filter: which statuses a list/get may return. `all` = both. */
+export const ArticleReadStatusEnum = z.enum(['draft', 'published', 'all'])
+
+export const CreateArticleInputSchema = {
+    slug: z.string().describe('URL slug (unique, e.g. "cptsd")'),
+    title: z.string().describe('Article title'),
+    summary: z.string().optional().describe('Short summary / excerpt'),
+    body: z.string().describe('Article body (Markdown source)'),
+    status: ArticleStatusEnum.optional().describe(
+        'Publication status (draft | published); defaults to draft',
+    ),
+    tags: z.array(z.string()).optional().describe('Tags'),
+    publishedAt: z
+        .string()
+        .optional()
+        .describe('Publication date (ISO 8601); set when publishing'),
+}
+
+export const UpdateArticleInputSchema = {
+    slug: z.string().describe('Slug of the article to update'),
+    title: z.string().optional().describe('Article title'),
+    summary: z.string().optional().describe('Short summary / excerpt'),
+    body: z.string().optional().describe('Article body (Markdown source)'),
+    status: ArticleStatusEnum.optional().describe(
+        'Publication status (draft | published)',
+    ),
+    tags: z.array(z.string()).optional().describe('Tags'),
+    publishedAt: z.string().optional().describe('Publication date (ISO 8601)'),
+    newSlug: z
+        .string()
+        .optional()
+        .describe('Rename the slug (must stay unique)'),
+}
+
+export const DeleteArticleInputSchema = {
+    slug: z.string().describe('Slug of the article to delete'),
+}
+
+export const GetArticleInputSchema = {
+    slug: z.string().describe('Slug of the article to retrieve'),
+    status: ArticleReadStatusEnum.optional().describe(
+        'Visibility filter (default published). draft/all require admin context.',
+    ),
+}
+
+export const ListArticlesInputSchema = {
+    status: ArticleReadStatusEnum.optional().describe(
+        'Visibility filter (default published). draft/all require admin context.',
+    ),
+    tag: z.string().optional().describe('Filter by a single tag'),
+    search: z.string().optional().describe('Search in title and summary'),
+    limit: z
+        .number()
+        .optional()
+        .describe('Maximum number of results (default 50)'),
+    offset: z
+        .number()
+        .optional()
+        .describe('Number of results to skip (default 0)'),
+}

--- a/src/tools/db/articles/status.ts
+++ b/src/tools/db/articles/status.ts
@@ -1,0 +1,14 @@
+/** Read visibility for articles. `all` means both draft and published. */
+export type ArticleReadStatus = 'draft' | 'published' | 'all'
+
+/**
+ * Build the Prisma status filter for a read. Defaults to `published` (the safe
+ * public view); `all` returns an empty filter (both statuses). Callers gate
+ * non-published access by admin auth before passing `draft`/`all` here.
+ */
+export function statusFilter(status?: string): {
+    status?: 'draft' | 'published'
+} {
+    const s = status ?? 'published'
+    return s === 'all' ? {} : { status: s as 'draft' | 'published' }
+}

--- a/src/tools/db/articles/update-article.ts
+++ b/src/tools/db/articles/update-article.ts
@@ -1,0 +1,60 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { UpdateArticleInputSchema } from './schemas.js'
+
+const name = 'update-article'
+const config = {
+    title: 'Update Article',
+    description: 'Update an existing article by slug (admin only)',
+    inputSchema: UpdateArticleInputSchema,
+}
+
+export function registerUpdateArticleTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const {
+                    slug,
+                    title,
+                    summary,
+                    body,
+                    status,
+                    tags,
+                    publishedAt,
+                    newSlug,
+                } = args
+
+                const data: any = {}
+                if (title !== undefined) data.title = title
+                if (summary !== undefined) data.summary = summary
+                if (body !== undefined) data.body = body
+                if (tags !== undefined) data.tags = tags
+                if (status !== undefined) data.status = status
+                if (newSlug !== undefined) data.slug = newSlug
+                if (publishedAt !== undefined)
+                    data.publishedAt = publishedAt
+                        ? new Date(publishedAt)
+                        : null
+
+                const article = await prisma.article.update({
+                    where: { slug },
+                    data,
+                })
+                return createSuccessResult(article)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/index.ts
+++ b/src/tools/db/index.ts
@@ -1,4 +1,12 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+// Article tools
+import {
+    registerCreateArticleTool,
+    registerDeleteArticleTool,
+    registerGetArticleTool,
+    registerListArticlesTool,
+    registerUpdateArticleTool,
+} from './articles/index.js'
 // Author tools
 import {
     registerCreateAuthorTool,
@@ -81,4 +89,11 @@ export function registerDbTools(server: McpServer): void {
     registerListContentCreatorsTool(server)
     registerUpdateContentCreatorTool(server)
     registerDeleteContentCreatorTool(server)
+
+    // Article tools
+    registerCreateArticleTool(server)
+    registerUpdateArticleTool(server)
+    registerDeleteArticleTool(server)
+    registerGetArticleTool(server)
+    registerListArticlesTool(server)
 }

--- a/test/http/articles-controller.test.ts
+++ b/test/http/articles-controller.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the tool layer and the admin resolver so we can assert the controller's
+// draft-gating logic in isolation (no DB, no JWKS).
+vi.mock('../../src/tools/local.js', () => ({ callTool: vi.fn() }))
+vi.mock('../../src/auth/optional-admin.js', () => ({
+    requestIsAdmin: vi.fn(),
+}))
+
+import { requestIsAdmin } from '../../src/auth/optional-admin.js'
+import { ArticlesController } from '../../src/http/controllers/ArticlesController'
+import { callTool } from '../../src/tools/local.js'
+
+const mockCallTool = callTool as unknown as ReturnType<typeof vi.fn>
+const mockIsAdmin = requestIsAdmin as unknown as ReturnType<typeof vi.fn>
+const req = () => ({ headers: {} }) as any
+
+describe('ArticlesController draft gating (#120)', () => {
+    beforeEach(() => {
+        mockCallTool.mockReset()
+        mockIsAdmin.mockReset()
+        mockCallTool.mockResolvedValue({ articles: [], total: 0 })
+    })
+
+    it('forces published-only for a non-admin requesting all', async () => {
+        mockIsAdmin.mockResolvedValue(false)
+        await new ArticlesController().listArticles(req(), 'all')
+        expect(mockCallTool).toHaveBeenCalledWith(
+            'list-articles',
+            expect.objectContaining({ status: 'published' }),
+        )
+    })
+
+    it('honors status=all for an admin', async () => {
+        mockIsAdmin.mockResolvedValue(true)
+        await new ArticlesController().listArticles(req(), 'all')
+        expect(mockCallTool).toHaveBeenCalledWith(
+            'list-articles',
+            expect.objectContaining({ status: 'all' }),
+        )
+    })
+
+    it('defaults to published without checking admin when no draft is requested', async () => {
+        await new ArticlesController().listArticles(req())
+        expect(mockCallTool).toHaveBeenCalledWith(
+            'list-articles',
+            expect.objectContaining({ status: 'published' }),
+        )
+        expect(mockIsAdmin).not.toHaveBeenCalled()
+    })
+
+    it('getArticle: a non-admin draft request stays published and 404s a hidden draft', async () => {
+        mockIsAdmin.mockResolvedValue(false)
+        mockCallTool.mockRejectedValueOnce(new Error('Article not found'))
+        await expect(
+            new ArticlesController().getArticle(req(), 'secret', 'draft'),
+        ).rejects.toMatchObject({ status: 404 })
+        expect(mockCallTool).toHaveBeenCalledWith('get-article', {
+            slug: 'secret',
+            status: 'published',
+        })
+    })
+
+    it('getArticle: an admin can request all statuses', async () => {
+        mockIsAdmin.mockResolvedValue(true)
+        mockCallTool.mockResolvedValueOnce({ slug: 'd', status: 'draft' })
+        const res = await new ArticlesController().getArticle(req(), 'd', 'all')
+        expect(res).toMatchObject({ slug: 'd' })
+        expect(mockCallTool).toHaveBeenCalledWith('get-article', {
+            slug: 'd',
+            status: 'all',
+        })
+    })
+
+    it('createArticle validates required fields', async () => {
+        await expect(
+            new ArticlesController().createArticle({
+                slug: '',
+                title: 't',
+                body: 'b',
+            } as any),
+        ).rejects.toMatchObject({ status: 400 })
+    })
+})

--- a/test/tools/db/articles/articles-tools.test.ts
+++ b/test/tools/db/articles/articles-tools.test.ts
@@ -1,0 +1,185 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the shared prisma object's `article` model so tool handlers are
+// deterministic without a database (mirrors the no-op stub contract). The mock
+// fns are created inside the factory (vi.mock is hoisted) and read back below.
+vi.mock('../../../../src/db/index', () => ({
+    prisma: {
+        article: {
+            findMany: vi.fn(),
+            findUnique: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+        },
+    },
+}))
+
+import { prisma } from '../../../../src/db/index.js'
+import { registerCreateArticleTool } from '../../../../src/tools/db/articles/create-article.js'
+import { registerDeleteArticleTool } from '../../../../src/tools/db/articles/delete-article.js'
+import { registerGetArticleTool } from '../../../../src/tools/db/articles/get-article.js'
+import { registerListArticlesTool } from '../../../../src/tools/db/articles/list-articles.js'
+import { registerUpdateArticleTool } from '../../../../src/tools/db/articles/update-article.js'
+
+const article = (prisma as any).article as Record<
+    string,
+    ReturnType<typeof vi.fn>
+>
+
+const handlers = new Map<string, (args: any) => Promise<any>>()
+const fake: any = {
+    registerTool: (name: string, _cfg: any, handler: any) =>
+        handlers.set(name, handler),
+}
+
+const call = async (name: string, args: any) => {
+    const res = await handlers.get(name)!(args)
+    const text = res.content[0].text
+    let data: any
+    try {
+        data = JSON.parse(text)
+    } catch {
+        data = text // error results carry a plain "Error: ..." string
+    }
+    return { isError: !!res.isError, data }
+}
+
+beforeAll(() => {
+    registerCreateArticleTool(fake)
+    registerUpdateArticleTool(fake)
+    registerDeleteArticleTool(fake)
+    registerGetArticleTool(fake)
+    registerListArticlesTool(fake)
+})
+
+beforeEach(() => {
+    for (const fn of Object.values(article)) fn.mockReset()
+})
+
+describe('article tools — create-article', () => {
+    it('stamps publishedAt when publishing without an explicit date', async () => {
+        article.create.mockImplementation(async ({ data }: any) => ({
+            id: 1,
+            ...data,
+        }))
+        const { data } = await call('create-article', {
+            slug: 's',
+            title: 't',
+            body: 'b',
+            status: 'published',
+        })
+        expect(data.status).toBe('published')
+        expect(data.publishedAt).toBeTruthy()
+        expect(data.tags).toEqual([])
+    })
+
+    it('defaults to draft with no publishedAt', async () => {
+        article.create.mockImplementation(async ({ data }: any) => ({
+            id: 1,
+            ...data,
+        }))
+        const { data } = await call('create-article', {
+            slug: 's',
+            title: 't',
+            body: 'b',
+        })
+        expect(data.status).toBe('draft')
+        expect(data.publishedAt).toBeNull()
+    })
+
+    it('surfaces an error result when the write fails (stub throws)', async () => {
+        article.create.mockRejectedValueOnce(
+            new Error('DATABASE_URL not configured'),
+        )
+        const res = await handlers.get('create-article')!({
+            slug: 's',
+            title: 't',
+            body: 'b',
+        })
+        expect(res.isError).toBe(true)
+    })
+})
+
+describe('article tools — list-articles (published-only by default)', () => {
+    it('filters to published when no status is given', async () => {
+        article.findMany.mockResolvedValueOnce([])
+        await call('list-articles', {})
+        expect(article.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { status: 'published' } }),
+        )
+    })
+
+    it('returns both statuses for status=all (no status filter)', async () => {
+        article.findMany.mockResolvedValueOnce([])
+        await call('list-articles', { status: 'all' })
+        const where = article.findMany.mock.calls[0][0].where
+        expect(where.status).toBeUndefined()
+    })
+
+    it('filters by tag', async () => {
+        article.findMany.mockResolvedValueOnce([])
+        await call('list-articles', { tag: 'philosophy' })
+        const where = article.findMany.mock.calls[0][0].where
+        expect(where.tags).toEqual({ has: 'philosophy' })
+    })
+})
+
+describe('article tools — get-article (visibility)', () => {
+    it('hides a draft from a published-only read (404)', async () => {
+        article.findUnique.mockResolvedValueOnce({ slug: 'd', status: 'draft' })
+        const { isError, data } = await call('get-article', { slug: 'd' })
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/not found/i)
+    })
+
+    it('returns a draft when status=all (admin context)', async () => {
+        article.findUnique.mockResolvedValueOnce({ slug: 'd', status: 'draft' })
+        const { isError, data } = await call('get-article', {
+            slug: 'd',
+            status: 'all',
+        })
+        expect(isError).toBe(false)
+        expect(data.slug).toBe('d')
+    })
+
+    it('returns a published article on a default read', async () => {
+        article.findUnique.mockResolvedValueOnce({
+            slug: 'p',
+            status: 'published',
+        })
+        const { isError, data } = await call('get-article', { slug: 'p' })
+        expect(isError).toBe(false)
+        expect(data.slug).toBe('p')
+    })
+
+    it('404s a missing article', async () => {
+        article.findUnique.mockResolvedValueOnce(null)
+        const { isError } = await call('get-article', { slug: 'nope' })
+        expect(isError).toBe(true)
+    })
+})
+
+describe('article tools — update/delete', () => {
+    it('update maps fields and renames via newSlug', async () => {
+        article.update.mockImplementation(async ({ data }: any) => ({
+            id: 1,
+            ...data,
+        }))
+        await call('update-article', {
+            slug: 'old',
+            title: 'New',
+            newSlug: 'new',
+        })
+        const arg = article.update.mock.calls[0][0]
+        expect(arg.where).toEqual({ slug: 'old' })
+        expect(arg.data).toMatchObject({ title: 'New', slug: 'new' })
+    })
+
+    it('delete removes by slug', async () => {
+        article.delete.mockResolvedValueOnce({ id: 1, slug: 'x' })
+        const { isError } = await call('delete-article', { slug: 'x' })
+        expect(isError).toBe(false)
+        expect(article.delete).toHaveBeenCalledWith({ where: { slug: 'x' } })
+    })
+})


### PR DESCRIPTION
## Summary

Adds the **Article** resource — DB-backed site philosophy content so drafts stay out of public source and publishing doesn't require a redeploy. This is the backend half of bryandebaun.dev's move off file-based MDX.

Closes #120.

## Changes

**Schema + migration**
- `Article` model + `ArticleStatus` enum (`draft | published`): unique `slug`, `title`, `summary`, `body` (Markdown), `tags String[]`, `publishedAt`, timestamps; indexes on `status`/`published_at`.
- Hand-written SQL migration with **RLS** (defense-in-depth): public reads see only `published`; admins do everything. App-layer filtering remains the primary enforcement.
- `'article'` added to the `MODEL_NAMES` stub contract so the server still starts with no DB.

**MCP tools** (`src/tools/db/articles/`, mirroring movies): `create/update/delete/get/list-article(s)`, slug-addressed, Zod schemas. `list`/`get` take a visibility filter (default `published`).

**REST** (`ArticlesController`, slug-addressed since the site fetches `/api/articles/cptsd`):
- `GET /api/articles`, `GET /api/articles/{slug}` — `@Security('api_key')`, **published-only by default**. An admin Supabase JWT presented alongside the gateway key unlocks drafts via `?status=draft|all` (`requestIsAdmin` helper; falls back to published-only for non-admins). Mirrors the "JWT + API key" admin path.
- `POST/PUT/DELETE` — `@Security('jwt', ['admin'])`.

**Seed**: the CPTSD article, upserted by slug as `published`, body ported verbatim.

## Verification

- `pnpm run typecheck` clean; full suite **252 passed / 5 skipped / 0 failed**; lint clean; migration passes `sql:parse` (10 statements); RLS lint satisfied.
- Tests: tool handlers (create/list/get/update/delete), published-only filtering, draft visibility, admin draft gating, required-field validation, stub behavior.

## Notes

- Frontend rendering / the admin authoring UI are out of scope (tracked separately — a WYSIWYG editor issue is being filed).
- The publish-revalidation webhook (#120 "Follow-up") is deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
