### PR TITLE
feat(bets): Phase 1 bet tracker — model, MCP tools, REST, intuition-vs-AI analytics (#128)

### DIFF
--- a/prisma/migrations/20260628120000_add_bets/migration.sql
+++ b/prisma/migrations/20260628120000_add_bets/migration.sql
@@ -1,0 +1,52 @@
+-- Add Bet resource: personal sports-betting tracker (issue #128 / epic #127).
+
+CREATE TYPE "BetStatus" AS ENUM ('PENDING', 'WON', 'LOST', 'PUSH', 'VOID');
+CREATE TYPE "BetSource" AS ENUM ('INTUITION', 'AI_ASSISTED');
+CREATE TYPE "BetMarket" AS ENUM ('moneyline', 'spread', 'total', 'prop', 'parlay');
+
+CREATE TABLE "Bet" (
+    "id" SERIAL NOT NULL,
+    "placed_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "sport" TEXT NOT NULL,
+    "league" TEXT,
+    "event" TEXT NOT NULL,
+    "market" "BetMarket" NOT NULL,
+    "selection" TEXT NOT NULL,
+    "line" DOUBLE PRECISION,
+    "odds_american" INTEGER NOT NULL,
+    "stake" DOUBLE PRECISION NOT NULL,
+    "book" TEXT NOT NULL DEFAULT 'DraftKings',
+    "status" "BetStatus" NOT NULL DEFAULT 'PENDING',
+    "settled_at" TIMESTAMP(3),
+    "payout" DOUBLE PRECISION,
+    "source" "BetSource" NOT NULL,
+    "ai_model" TEXT,
+    "ai_rationale" TEXT,
+    "ai_est_prob" DOUBLE PRECISION,
+    "ai_ev" DOUBLE PRECISION,
+    "closing_line" DOUBLE PRECISION,
+    "closing_odds_american" INTEGER,
+    "legs" JSONB,
+    "notes" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Bet_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "Bet_source_idx" ON "Bet"("source");
+CREATE INDEX "Bet_status_idx" ON "Bet"("status");
+CREATE INDEX "Bet_sport_idx" ON "Bet"("sport");
+CREATE INDEX "Bet_placedAt_idx" ON "Bet"("placed_at");
+
+-- Row-Level Security: bets are private personal data — admin only (no public
+-- select). The app connects with a privileged role; this is defense-in-depth
+-- against any direct (PostgREST/anon) access.
+ALTER TABLE "Bet" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Bet_admin_all" ON "Bet";
+CREATE POLICY "Bet_admin_all" ON "Bet" FOR ALL USING (
+  current_setting('request.jwt.claims.role', true) = 'admin'
+) WITH CHECK (
+  current_setting('request.jwt.claims.role', true) = 'admin'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,27 @@ enum ArticleStatus {
   published
 }
 
+enum BetStatus {
+  PENDING
+  WON
+  LOST
+  PUSH
+  VOID
+}
+
+enum BetSource {
+  INTUITION
+  AI_ASSISTED
+}
+
+enum BetMarket {
+  moneyline
+  spread
+  total
+  prop
+  parlay
+}
+
 // Note: Prisma 7 requires the datasource URL to be configured in `prisma.config.ts`.
 // See `prisma.config.ts` for local dev config and CI usage.
 
@@ -149,4 +170,40 @@ model Article {
 
   @@index([status])
   @@index([publishedAt])
+}
+
+// Personal sports-betting tracker. Core purpose: compare bets made on intuition
+// vs. with AI assistance, graded on closing-line value (CLV) + ROI. See #127/#128.
+// Private data — admin-only at the RLS layer.
+model Bet {
+  id                  Int       @id @default(autoincrement())
+  placedAt            DateTime  @default(now()) @map("placed_at")
+  sport               String
+  league              String?
+  event               String // human-readable event description
+  market              BetMarket
+  selection           String // what was bet (team/over/player prop, etc.)
+  line                Float? // spread/total line, if applicable
+  oddsAmerican        Int       @map("odds_american") // e.g. -110, +150
+  stake               Float
+  book                String    @default("DraftKings")
+  status              BetStatus @default(PENDING)
+  settledAt           DateTime? @map("settled_at")
+  payout              Float? // total returned on a win (incl. stake)
+  source              BetSource
+  aiModel             String?   @map("ai_model")
+  aiRationale         String?   @map("ai_rationale")
+  aiEstProb           Float?    @map("ai_est_prob") // AI's estimated win prob (0..1)
+  aiEV                Float?    @map("ai_ev") // AI's estimated EV at placement
+  closingLine         Float?    @map("closing_line") // filled in Phase 2 (#129)
+  closingOddsAmerican Int?      @map("closing_odds_american")
+  legs                Json? // parlay legs, when market = parlay
+  notes               String?
+  createdAt           DateTime  @default(now())
+  updatedAt           DateTime  @updatedAt
+
+  @@index([source])
+  @@index([status])
+  @@index([sport])
+  @@index([placedAt])
 }

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -29,6 +29,7 @@ const MODEL_NAMES = [
     'videoGame',
     'contentCreator',
     'article',
+    'bet',
     'rating',
 ] as const
 

--- a/src/http/controllers/BetsController.ts
+++ b/src/http/controllers/BetsController.ts
@@ -1,0 +1,295 @@
+import {
+    Body,
+    Controller,
+    Delete,
+    Get,
+    Path,
+    Post,
+    Put,
+    Query,
+    Response,
+    Route,
+    Security,
+    SuccessResponse,
+    Tags,
+} from 'tsoa'
+import { callTool } from '../../tools/local.js'
+import { httpError, isNotFound } from './_http-errors.js'
+
+export type BetMarket = 'moneyline' | 'spread' | 'total' | 'prop' | 'parlay'
+export type BetSource = 'INTUITION' | 'AI_ASSISTED'
+export type BetStatus = 'PENDING' | 'WON' | 'LOST' | 'PUSH' | 'VOID'
+
+export interface Bet {
+    id: number
+    placedAt: string
+    sport: string
+    league?: string | null
+    event: string
+    market: BetMarket
+    selection: string
+    line?: number | null
+    oddsAmerican: number
+    stake: number
+    book: string
+    status: BetStatus
+    settledAt?: string | null
+    payout?: number | null
+    source: BetSource
+    aiModel?: string | null
+    aiRationale?: string | null
+    aiEstProb?: number | null
+    aiEV?: number | null
+    closingLine?: number | null
+    closingOddsAmerican?: number | null
+    legs?: unknown
+    notes?: string | null
+    createdAt: string
+    updatedAt: string
+}
+
+export interface ListBetsResponse {
+    bets: Bet[]
+    total: number
+}
+
+export interface BetMetrics {
+    count: number
+    pending: number
+    settled: number
+    wins: number
+    losses: number
+    pushes: number
+    voids: number
+    hitRate: number | null
+    staked: number
+    profit: number
+    roi: number | null
+    units: number | null
+    clvCount: number
+    avgClvPct: number | null
+}
+
+export interface BetAnalyticsResponse {
+    overall: BetMetrics
+    bySource: { INTUITION: BetMetrics; AI_ASSISTED: BetMetrics }
+}
+
+export interface BetLeg {
+    event: string
+    selection: string
+    oddsAmerican: number
+    line?: number
+}
+
+export interface CreateBetRequest {
+    sport: string
+    event: string
+    market: BetMarket
+    selection: string
+    oddsAmerican: number
+    stake: number
+    source: BetSource
+    league?: string
+    line?: number
+    book?: string
+    placedAt?: string
+    aiModel?: string
+    aiRationale?: string
+    aiEstProb?: number
+    aiEV?: number
+    legs?: BetLeg[]
+    notes?: string
+}
+
+export interface UpdateBetRequest {
+    sport?: string
+    league?: string
+    event?: string
+    market?: BetMarket
+    selection?: string
+    line?: number
+    oddsAmerican?: number
+    stake?: number
+    book?: string
+    source?: BetSource
+    aiModel?: string
+    aiRationale?: string
+    aiEstProb?: number
+    aiEV?: number
+    closingLine?: number
+    closingOddsAmerican?: number
+    legs?: BetLeg[]
+    notes?: string
+}
+
+export interface SettleBetRequest {
+    status: 'WON' | 'LOST' | 'PUSH' | 'VOID'
+    payout?: number
+}
+
+/**
+ * Sports-bet tracker (#128). Reads are gated by the MCP gateway key; writes
+ * require admin auth. Bets are private (admin-only at the RLS layer too).
+ */
+@Route('api/bets')
+@Tags('Bets')
+export class BetsController extends Controller {
+    /**
+     * List bets with optional filters.
+     * @param source Filter by source (INTUITION | AI_ASSISTED)
+     * @param status Filter by status
+     * @param sport Filter by sport
+     * @param market Filter by market
+     */
+    @Get()
+    @Security('api_key')
+    @SuccessResponse('200', 'Bets retrieved successfully')
+    public async listBets(
+        @Query() source?: BetSource,
+        @Query() status?: BetStatus,
+        @Query() sport?: string,
+        @Query() market?: BetMarket,
+        @Query() limit?: number,
+        @Query() offset?: number,
+    ): Promise<ListBetsResponse> {
+        const result = await callTool('list-bets', {
+            source,
+            status,
+            sport,
+            market,
+            limit,
+            offset,
+        })
+        return result as ListBetsResponse
+    }
+
+    /**
+     * Performance analytics (ROI, hit-rate, units, CLV) segmented by source —
+     * the intuition-vs-AI scoreboard. Declared before `{id}` to avoid a route clash.
+     */
+    @Get('analytics')
+    @Security('api_key')
+    @SuccessResponse('200', 'Analytics computed')
+    public async getAnalytics(
+        @Query() source?: BetSource,
+        @Query() sport?: string,
+        @Query() market?: BetMarket,
+        @Query() from?: string,
+        @Query() to?: string,
+    ): Promise<BetAnalyticsResponse> {
+        const result = await callTool('bet-analytics', {
+            source,
+            sport,
+            market,
+            from,
+            to,
+        })
+        return result as BetAnalyticsResponse
+    }
+
+    /**
+     * Get a bet by ID.
+     * @param id Bet ID
+     */
+    @Get('{id}')
+    @Security('api_key')
+    @SuccessResponse('200', 'Bet retrieved successfully')
+    @Response('404', 'Bet not found')
+    public async getBet(@Path() id: number): Promise<Bet> {
+        try {
+            const result = await callTool('get-bet', { id })
+            return result as Bet
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Bet not found')
+            throw err
+        }
+    }
+
+    /**
+     * Log a new bet (admin only).
+     */
+    @Post()
+    @Security('jwt', ['admin'])
+    @SuccessResponse('201', 'Bet created successfully')
+    @Response('400', 'Invalid request')
+    @Response('401', 'Unauthorized')
+    public async createBet(@Body() body: CreateBetRequest): Promise<Bet> {
+        for (const field of [
+            'sport',
+            'event',
+            'market',
+            'selection',
+            'source',
+        ] as const) {
+            if (!body[field]) throw httpError(400, `${field} is required`)
+        }
+        if (typeof body.oddsAmerican !== 'number')
+            throw httpError(400, 'oddsAmerican is required')
+        if (typeof body.stake !== 'number')
+            throw httpError(400, 'stake is required')
+        const result = await callTool('create-bet', body)
+        this.setStatus(201)
+        return result as Bet
+    }
+
+    /**
+     * Update a bet by ID (admin only) — edit details or set closing line for CLV.
+     * @param id Bet ID
+     */
+    @Put('{id}')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Bet updated successfully')
+    @Response('404', 'Bet not found')
+    public async updateBet(
+        @Path() id: number,
+        @Body() body: UpdateBetRequest,
+    ): Promise<Bet> {
+        try {
+            const result = await callTool('update-bet', { ...body, id })
+            return result as Bet
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Bet not found')
+            throw err
+        }
+    }
+
+    /**
+     * Settle a bet outcome (admin only). Payout auto-computed on a win.
+     * @param id Bet ID
+     */
+    @Post('{id}/settle')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Bet settled')
+    @Response('404', 'Bet not found')
+    public async settleBet(
+        @Path() id: number,
+        @Body() body: SettleBetRequest,
+    ): Promise<Bet> {
+        try {
+            const result = await callTool('settle-bet', { ...body, id })
+            return result as Bet
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Bet not found')
+            throw err
+        }
+    }
+
+    /**
+     * Delete a bet by ID (admin only).
+     * @param id Bet ID
+     */
+    @Delete('{id}')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Bet deleted successfully')
+    @Response('404', 'Bet not found')
+    public async deleteBet(@Path() id: number): Promise<{ success: boolean }> {
+        try {
+            await callTool('delete-bet', { id })
+            return { success: true }
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Bet not found')
+            throw err
+        }
+    }
+}

--- a/src/tools/db/bets/bet-analytics.ts
+++ b/src/tools/db/bets/bet-analytics.ts
@@ -1,0 +1,58 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { computeMetrics } from './metrics.js'
+import { BetAnalyticsInputSchema } from './schemas.js'
+
+const name = 'bet-analytics'
+const config = {
+    title: 'Bet Analytics',
+    description:
+        'Betting performance (ROI, hit-rate, units, CLV) segmented by source (intuition vs AI-assisted)',
+    inputSchema: BetAnalyticsInputSchema,
+}
+
+export function registerBetAnalyticsTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { source, sport, market, from, to } = args
+                const where: any = {}
+                if (source) where.source = source
+                if (sport) where.sport = sport
+                if (market) where.market = market
+                if (from || to) {
+                    where.placedAt = {}
+                    if (from) where.placedAt.gte = new Date(from)
+                    if (to) where.placedAt.lte = new Date(to)
+                }
+
+                const bets = await prisma.bet.findMany({ where })
+
+                return createSuccessResult({
+                    overall: computeMetrics(bets),
+                    bySource: {
+                        INTUITION: computeMetrics(
+                            bets.filter((b: any) => b.source === 'INTUITION'),
+                        ),
+                        AI_ASSISTED: computeMetrics(
+                            bets.filter((b: any) => b.source === 'AI_ASSISTED'),
+                        ),
+                    },
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/bets/create-bet.ts
+++ b/src/tools/db/bets/create-bet.ts
@@ -1,0 +1,43 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { CreateBetInputSchema } from './schemas.js'
+
+const name = 'create-bet'
+const config = {
+    title: 'Create Bet',
+    description:
+        'Log a sports bet (intuition or AI-assisted) with status PENDING (admin only)',
+    inputSchema: CreateBetInputSchema,
+}
+
+export function registerCreateBetTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { book, placedAt, legs, ...rest } = args
+                const bet = await prisma.bet.create({
+                    data: {
+                        ...rest,
+                        book: book ?? 'DraftKings',
+                        ...(placedAt ? { placedAt: new Date(placedAt) } : {}),
+                        ...(legs ? { legs } : {}),
+                    },
+                })
+                return createSuccessResult(bet)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/bets/delete-bet.ts
+++ b/src/tools/db/bets/delete-bet.ts
@@ -1,0 +1,37 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { DeleteBetInputSchema } from './schemas.js'
+
+const name = 'delete-bet'
+const config = {
+    title: 'Delete Bet',
+    description: 'Delete a bet by id (admin only)',
+    inputSchema: DeleteBetInputSchema,
+}
+
+export function registerDeleteBetTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const bet = await prisma.bet.delete({ where: { id: args.id } })
+                return createSuccessResult({
+                    message: 'Bet deleted successfully',
+                    bet,
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/bets/get-bet.ts
+++ b/src/tools/db/bets/get-bet.ts
@@ -1,0 +1,37 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { GetBetInputSchema } from './schemas.js'
+
+const name = 'get-bet'
+const config = {
+    title: 'Get Bet',
+    description: 'Get a bet by id',
+    inputSchema: GetBetInputSchema,
+}
+
+export function registerGetBetTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const bet = await prisma.bet.findUnique({
+                    where: { id: args.id },
+                })
+                if (!bet) return createErrorResult('Bet not found')
+                return createSuccessResult(bet)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/bets/index.ts
+++ b/src/tools/db/bets/index.ts
@@ -1,0 +1,7 @@
+export { registerBetAnalyticsTool } from './bet-analytics.js'
+export { registerCreateBetTool } from './create-bet.js'
+export { registerDeleteBetTool } from './delete-bet.js'
+export { registerGetBetTool } from './get-bet.js'
+export { registerListBetsTool } from './list-bets.js'
+export { registerSettleBetTool } from './settle-bet.js'
+export { registerUpdateBetTool } from './update-bet.js'

--- a/src/tools/db/bets/list-bets.ts
+++ b/src/tools/db/bets/list-bets.ts
@@ -1,0 +1,59 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { ListBetsInputSchema } from './schemas.js'
+
+const name = 'list-bets'
+const config = {
+    title: 'List Bets',
+    description:
+        'List bets with optional filters (source, status, sport, market)',
+    inputSchema: ListBetsInputSchema,
+}
+
+export function registerListBetsTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const {
+                    source,
+                    status,
+                    sport,
+                    market,
+                    limit = 100,
+                    offset = 0,
+                } = args
+                const where: any = {}
+                if (source) where.source = source
+                if (status) where.status = status
+                if (sport) where.sport = sport
+                if (market) where.market = market
+
+                const bets = await prisma.bet.findMany({
+                    where,
+                    take: limit,
+                    skip: offset,
+                    orderBy: { placedAt: 'desc' },
+                })
+                return createSuccessResult({
+                    bets,
+                    total: bets.length,
+                    limit,
+                    offset,
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/bets/metrics.ts
+++ b/src/tools/db/bets/metrics.ts
@@ -1,0 +1,109 @@
+// Pure betting-math helpers + analytics aggregation (#128). No DB access here so
+// it's trivially unit-testable.
+
+/** Convert American odds to decimal odds (total return per 1 unit staked). */
+export function americanToDecimal(odds: number): number {
+    return odds > 0 ? 1 + odds / 100 : 1 + 100 / -odds
+}
+
+export interface BetLike {
+    status: string
+    stake: number
+    oddsAmerican: number
+    payout?: number | null
+    source?: string
+    closingOddsAmerican?: number | null
+}
+
+/** Realized profit for a single bet (0 for PENDING/PUSH/VOID). */
+export function betProfit(b: BetLike): number {
+    if (b.status === 'WON') {
+        return b.payout != null
+            ? b.payout - b.stake
+            : b.stake * (americanToDecimal(b.oddsAmerican) - 1)
+    }
+    if (b.status === 'LOST') return -b.stake
+    return 0
+}
+
+export interface BetMetrics {
+    count: number
+    pending: number
+    settled: number // decided: WON + LOST
+    wins: number
+    losses: number
+    pushes: number
+    voids: number
+    hitRate: number | null // wins / (wins + losses)
+    staked: number // total risked on decided bets
+    profit: number
+    roi: number | null // profit / staked
+    units: number | null // profit / average decided stake
+    clvCount: number
+    avgClvPct: number | null // mean closing-line value %, when available
+}
+
+/**
+ * Aggregate metrics over a set of bets. CLV% per bet = (yourDecimalOdds /
+ * closingDecimalOdds - 1) * 100; positive means you beat the closing line —
+ * the primary signal for the intuition-vs-AI experiment (#127).
+ */
+export function computeMetrics(bets: BetLike[]): BetMetrics {
+    let wins = 0
+    let losses = 0
+    let pushes = 0
+    let voids = 0
+    let pending = 0
+    let staked = 0
+    let profit = 0
+    let clvSum = 0
+    let clvCount = 0
+
+    for (const b of bets) {
+        switch (b.status) {
+            case 'WON':
+                wins++
+                break
+            case 'LOST':
+                losses++
+                break
+            case 'PUSH':
+                pushes++
+                break
+            case 'VOID':
+                voids++
+                break
+            default:
+                pending++
+        }
+        if (b.status === 'WON' || b.status === 'LOST') staked += b.stake
+        profit += betProfit(b)
+        if (b.closingOddsAmerican != null) {
+            clvSum +=
+                (americanToDecimal(b.oddsAmerican) /
+                    americanToDecimal(b.closingOddsAmerican) -
+                    1) *
+                100
+            clvCount++
+        }
+    }
+
+    const decided = wins + losses
+    const round = (n: number) => Math.round(n * 1e4) / 1e4
+    return {
+        count: bets.length,
+        pending,
+        settled: decided,
+        wins,
+        losses,
+        pushes,
+        voids,
+        hitRate: decided > 0 ? round(wins / decided) : null,
+        staked: round(staked),
+        profit: round(profit),
+        roi: staked > 0 ? round(profit / staked) : null,
+        units: decided > 0 ? round(profit / (staked / decided)) : null,
+        clvCount,
+        avgClvPct: clvCount > 0 ? round(clvSum / clvCount) : null,
+    }
+}

--- a/src/tools/db/bets/schemas.ts
+++ b/src/tools/db/bets/schemas.ts
@@ -1,0 +1,108 @@
+// Input schemas for bet-tracker MCP tools (#128).
+import { z } from 'zod'
+
+const MarketEnum = z.enum(['moneyline', 'spread', 'total', 'prop', 'parlay'])
+const SourceEnum = z.enum(['INTUITION', 'AI_ASSISTED'])
+const SettleStatusEnum = z.enum(['WON', 'LOST', 'PUSH', 'VOID'])
+
+const LegSchema = z.object({
+    event: z.string().describe('Leg event description'),
+    selection: z.string().describe('Leg selection'),
+    oddsAmerican: z.number().int().describe('Leg American odds'),
+    line: z.number().optional().describe('Leg line, if applicable'),
+})
+
+export const CreateBetInputSchema = {
+    sport: z.string().describe('Sport (e.g. NBA, NFL)'),
+    league: z.string().optional().describe('League/competition'),
+    event: z.string().describe('Event description (e.g. "Lakers @ Celtics")'),
+    market: MarketEnum.describe('moneyline | spread | total | prop | parlay'),
+    selection: z.string().describe('What was bet (team / over / player prop)'),
+    line: z.number().optional().describe('Spread/total line, if applicable'),
+    oddsAmerican: z.number().int().describe('American odds (e.g. -110, +150)'),
+    stake: z.number().positive().describe('Amount risked'),
+    book: z.string().optional().describe('Sportsbook (default DraftKings)'),
+    source: SourceEnum.describe('INTUITION (gut) or AI_ASSISTED'),
+    placedAt: z.string().optional().describe('Placement time (ISO 8601)'),
+    aiModel: z.string().optional().describe('AI model, if AI_ASSISTED'),
+    aiRationale: z
+        .string()
+        .optional()
+        .describe('AI reasoning captured at decision time'),
+    aiEstProb: z
+        .number()
+        .optional()
+        .describe("AI's estimated win probability (0..1)"),
+    aiEV: z.number().optional().describe("AI's estimated EV at placement"),
+    legs: z.array(LegSchema).optional().describe('Parlay legs (market=parlay)'),
+    notes: z.string().optional().describe('Freeform notes'),
+}
+
+export const UpdateBetInputSchema = {
+    id: z.number().int().describe('Bet ID'),
+    sport: z.string().optional(),
+    league: z.string().optional(),
+    event: z.string().optional(),
+    market: MarketEnum.optional(),
+    selection: z.string().optional(),
+    line: z.number().optional(),
+    oddsAmerican: z.number().int().optional(),
+    stake: z.number().positive().optional(),
+    book: z.string().optional(),
+    source: SourceEnum.optional(),
+    aiModel: z.string().optional(),
+    aiRationale: z.string().optional(),
+    aiEstProb: z.number().optional(),
+    aiEV: z.number().optional(),
+    closingLine: z
+        .number()
+        .optional()
+        .describe('Closing line (Phase 2 / #129)'),
+    closingOddsAmerican: z
+        .number()
+        .int()
+        .optional()
+        .describe('Closing American odds (for CLV)'),
+    legs: z.array(LegSchema).optional(),
+    notes: z.string().optional(),
+}
+
+export const GetBetInputSchema = {
+    id: z.number().int().describe('Bet ID'),
+}
+
+export const DeleteBetInputSchema = {
+    id: z.number().int().describe('Bet ID to delete'),
+}
+
+export const ListBetsInputSchema = {
+    source: SourceEnum.optional().describe('Filter by source'),
+    status: z
+        .enum(['PENDING', 'WON', 'LOST', 'PUSH', 'VOID'])
+        .optional()
+        .describe('Filter by status'),
+    sport: z.string().optional().describe('Filter by sport'),
+    market: MarketEnum.optional().describe('Filter by market'),
+    limit: z.number().int().optional().describe('Max results (default 100)'),
+    offset: z.number().int().optional().describe('Results to skip (default 0)'),
+}
+
+export const SettleBetInputSchema = {
+    id: z.number().int().describe('Bet ID'),
+    status: SettleStatusEnum.describe('Outcome: WON | LOST | PUSH | VOID'),
+    payout: z
+        .number()
+        .optional()
+        .describe('Total returned on a win (incl. stake); computed if omitted'),
+}
+
+export const BetAnalyticsInputSchema = {
+    source: SourceEnum.optional().describe('Restrict to one source'),
+    sport: z.string().optional().describe('Restrict to one sport'),
+    market: MarketEnum.optional().describe('Restrict to one market'),
+    from: z
+        .string()
+        .optional()
+        .describe('Only bets placed on/after (ISO 8601)'),
+    to: z.string().optional().describe('Only bets placed on/before (ISO 8601)'),
+}

--- a/src/tools/db/bets/settle-bet.ts
+++ b/src/tools/db/bets/settle-bet.ts
@@ -1,0 +1,60 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { americanToDecimal } from './metrics.js'
+import { SettleBetInputSchema } from './schemas.js'
+
+const name = 'settle-bet'
+const config = {
+    title: 'Settle Bet',
+    description:
+        'Settle a bet outcome (WON/LOST/PUSH/VOID); payout auto-computed on a win (admin only)',
+    inputSchema: SettleBetInputSchema,
+}
+
+export function registerSettleBetTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { id, status, payout } = args
+                const existing = await prisma.bet.findUnique({ where: { id } })
+                if (!existing) return createErrorResult('Bet not found')
+
+                // On a win, default payout to stake × decimal odds (total return).
+                let finalPayout: number | null = payout ?? null
+                if (status === 'WON' && finalPayout == null) {
+                    finalPayout =
+                        existing.stake *
+                        americanToDecimal(existing.oddsAmerican)
+                } else if (status !== 'WON' && payout == null) {
+                    finalPayout =
+                        status === 'PUSH' || status === 'VOID'
+                            ? existing.stake // stake returned
+                            : 0 // LOST
+                }
+
+                const bet = await prisma.bet.update({
+                    where: { id },
+                    data: {
+                        status,
+                        payout: finalPayout,
+                        settledAt: new Date(),
+                    },
+                })
+                return createSuccessResult(bet)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/bets/update-bet.ts
+++ b/src/tools/db/bets/update-bet.ts
@@ -1,0 +1,40 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { UpdateBetInputSchema } from './schemas.js'
+
+const name = 'update-bet'
+const config = {
+    title: 'Update Bet',
+    description:
+        'Update a bet by id — edit details or set closing line for CLV (admin only)',
+    inputSchema: UpdateBetInputSchema,
+}
+
+export function registerUpdateBetTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { id, ...fields } = args
+                const data: any = {}
+                for (const [k, v] of Object.entries(fields)) {
+                    if (v !== undefined) data[k] = v
+                }
+                const bet = await prisma.bet.update({ where: { id }, data })
+                return createSuccessResult(bet)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/index.ts
+++ b/src/tools/db/index.ts
@@ -15,6 +15,16 @@ import {
     registerListAuthorsTool,
     registerUpdateAuthorTool,
 } from './authors/index.js'
+// Bet tools (sports-betting tracker)
+import {
+    registerBetAnalyticsTool,
+    registerCreateBetTool,
+    registerDeleteBetTool,
+    registerGetBetTool,
+    registerListBetsTool,
+    registerSettleBetTool,
+    registerUpdateBetTool,
+} from './bets/index.js'
 // Book tools
 import {
     registerCreateBookTool,
@@ -96,4 +106,13 @@ export function registerDbTools(server: McpServer): void {
     registerDeleteArticleTool(server)
     registerGetArticleTool(server)
     registerListArticlesTool(server)
+
+    // Bet tools (sports-betting tracker)
+    registerCreateBetTool(server)
+    registerUpdateBetTool(server)
+    registerGetBetTool(server)
+    registerListBetsTool(server)
+    registerDeleteBetTool(server)
+    registerSettleBetTool(server)
+    registerBetAnalyticsTool(server)
 }

--- a/test/tools/db/bets/bets-tools.test.ts
+++ b/test/tools/db/bets/bets-tools.test.ts
@@ -1,0 +1,172 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../../../src/db/index', () => ({
+    prisma: {
+        bet: {
+            findMany: vi.fn(),
+            findUnique: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+            delete: vi.fn(),
+        },
+    },
+}))
+
+import { prisma } from '../../../../src/db/index.js'
+import { registerBetAnalyticsTool } from '../../../../src/tools/db/bets/bet-analytics.js'
+import { registerCreateBetTool } from '../../../../src/tools/db/bets/create-bet.js'
+import { registerGetBetTool } from '../../../../src/tools/db/bets/get-bet.js'
+import { registerListBetsTool } from '../../../../src/tools/db/bets/list-bets.js'
+import { registerSettleBetTool } from '../../../../src/tools/db/bets/settle-bet.js'
+
+const bet = (prisma as any).bet as Record<string, ReturnType<typeof vi.fn>>
+const handlers = new Map<string, (args: any) => Promise<any>>()
+const fake: any = {
+    registerTool: (name: string, _c: any, h: any) => handlers.set(name, h),
+}
+
+const call = async (name: string, args: any) => {
+    const res = await handlers.get(name)!(args)
+    let data: any
+    try {
+        data = JSON.parse(res.content[0].text)
+    } catch {
+        data = res.content[0].text
+    }
+    return { isError: !!res.isError, data }
+}
+
+beforeAll(() => {
+    registerCreateBetTool(fake)
+    registerGetBetTool(fake)
+    registerListBetsTool(fake)
+    registerSettleBetTool(fake)
+    registerBetAnalyticsTool(fake)
+})
+
+beforeEach(() => {
+    for (const fn of Object.values(bet)) fn.mockReset()
+})
+
+describe('bet tools — create-bet', () => {
+    it('defaults book to DraftKings and passes through fields', async () => {
+        bet.create.mockImplementation(async ({ data }: any) => ({
+            id: 1,
+            ...data,
+        }))
+        const { data } = await call('create-bet', {
+            sport: 'NBA',
+            event: 'Lakers @ Celtics',
+            market: 'moneyline',
+            selection: 'Celtics',
+            oddsAmerican: -110,
+            stake: 50,
+            source: 'AI_ASSISTED',
+            aiModel: 'claude',
+            aiRationale: 'edge vs devigged line',
+        })
+        expect(data.book).toBe('DraftKings')
+        expect(data.source).toBe('AI_ASSISTED')
+        expect(data.aiModel).toBe('claude')
+    })
+
+    it('surfaces an error result when the write fails (stub throws)', async () => {
+        bet.create.mockRejectedValueOnce(
+            new Error('DATABASE_URL not configured'),
+        )
+        const res = await handlers.get('create-bet')!({
+            sport: 'NBA',
+            event: 'x',
+            market: 'moneyline',
+            selection: 'y',
+            oddsAmerican: -110,
+            stake: 10,
+            source: 'INTUITION',
+        })
+        expect(res.isError).toBe(true)
+    })
+})
+
+describe('bet tools — settle-bet', () => {
+    it('auto-computes payout on a win from stake × decimal odds', async () => {
+        bet.findUnique.mockResolvedValueOnce({
+            id: 1,
+            stake: 100,
+            oddsAmerican: 150,
+        })
+        bet.update.mockImplementation(async ({ data }: any) => ({
+            id: 1,
+            ...data,
+        }))
+        const { data } = await call('settle-bet', { id: 1, status: 'WON' })
+        expect(data.status).toBe('WON')
+        expect(data.payout).toBeCloseTo(250) // 100 * 2.5
+        expect(bet.update).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { id: 1 } }),
+        )
+    })
+
+    it('404s a missing bet', async () => {
+        bet.findUnique.mockResolvedValueOnce(null)
+        const { isError, data } = await call('settle-bet', {
+            id: 9,
+            status: 'LOST',
+        })
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/not found/i)
+    })
+})
+
+describe('bet tools — get/list', () => {
+    it('get-bet 404s when missing', async () => {
+        bet.findUnique.mockResolvedValueOnce(null)
+        const { isError } = await call('get-bet', { id: 1 })
+        expect(isError).toBe(true)
+    })
+
+    it('list-bets builds the where filter', async () => {
+        bet.findMany.mockResolvedValueOnce([])
+        await call('list-bets', {
+            source: 'INTUITION',
+            status: 'WON',
+            sport: 'NBA',
+        })
+        const where = bet.findMany.mock.calls[0][0].where
+        expect(where).toEqual({
+            source: 'INTUITION',
+            status: 'WON',
+            sport: 'NBA',
+        })
+    })
+})
+
+describe('bet tools — bet-analytics segmentation', () => {
+    it('splits metrics by source (intuition vs AI)', async () => {
+        bet.findMany.mockResolvedValueOnce([
+            {
+                status: 'WON',
+                stake: 100,
+                oddsAmerican: 100,
+                source: 'INTUITION',
+            },
+            {
+                status: 'LOST',
+                stake: 100,
+                oddsAmerican: -110,
+                source: 'INTUITION',
+            },
+            {
+                status: 'WON',
+                stake: 100,
+                oddsAmerican: 150,
+                source: 'AI_ASSISTED',
+            },
+        ])
+        const { data } = await call('bet-analytics', {})
+        expect(data.overall.count).toBe(3)
+        expect(data.bySource.INTUITION.count).toBe(2)
+        expect(data.bySource.INTUITION.wins).toBe(1)
+        expect(data.bySource.AI_ASSISTED.count).toBe(1)
+        expect(data.bySource.AI_ASSISTED.profit).toBeCloseTo(150)
+    })
+})

--- a/test/tools/db/bets/metrics.test.ts
+++ b/test/tools/db/bets/metrics.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import {
+    americanToDecimal,
+    type BetLike,
+    betProfit,
+    computeMetrics,
+} from '../../../../src/tools/db/bets/metrics.js'
+
+describe('betting metrics math (#128)', () => {
+    it('converts American odds to decimal', () => {
+        expect(americanToDecimal(100)).toBeCloseTo(2.0)
+        expect(americanToDecimal(150)).toBeCloseTo(2.5)
+        expect(americanToDecimal(-110)).toBeCloseTo(1.9091, 3)
+        expect(americanToDecimal(-200)).toBeCloseTo(1.5)
+    })
+
+    it('computes per-bet profit', () => {
+        // WON, explicit payout (total return incl. stake)
+        expect(
+            betProfit({
+                status: 'WON',
+                stake: 100,
+                oddsAmerican: -110,
+                payout: 190.91,
+            }),
+        ).toBeCloseTo(90.91, 2)
+        // WON, payout omitted → derived from odds
+        expect(
+            betProfit({ status: 'WON', stake: 100, oddsAmerican: 150 }),
+        ).toBeCloseTo(150)
+        // LOST → -stake; PUSH/VOID/PENDING → 0
+        expect(
+            betProfit({ status: 'LOST', stake: 50, oddsAmerican: -110 }),
+        ).toBe(-50)
+        expect(
+            betProfit({ status: 'PUSH', stake: 50, oddsAmerican: -110 }),
+        ).toBe(0)
+        expect(
+            betProfit({ status: 'VOID', stake: 50, oddsAmerican: -110 }),
+        ).toBe(0)
+        expect(
+            betProfit({ status: 'PENDING', stake: 50, oddsAmerican: -110 }),
+        ).toBe(0)
+    })
+
+    it('aggregates metrics: hit-rate, staked, profit, roi', () => {
+        const bets: BetLike[] = [
+            { status: 'WON', stake: 100, oddsAmerican: 100 }, // +100 profit
+            { status: 'LOST', stake: 100, oddsAmerican: -110 }, // -100
+            { status: 'WON', stake: 100, oddsAmerican: -110 }, // +90.91
+            { status: 'PUSH', stake: 100, oddsAmerican: -110 }, // 0, not counted in decided
+            { status: 'PENDING', stake: 100, oddsAmerican: -110 },
+        ]
+        const m = computeMetrics(bets)
+        expect(m.count).toBe(5)
+        expect(m.pending).toBe(1)
+        expect(m.settled).toBe(3) // WON+WON+LOST
+        expect(m.wins).toBe(2)
+        expect(m.losses).toBe(1)
+        expect(m.pushes).toBe(1)
+        expect(m.hitRate).toBeCloseTo(2 / 3, 3)
+        expect(m.staked).toBe(300) // decided bets only
+        expect(m.profit).toBeCloseTo(90.91, 2)
+        expect(m.roi).toBeCloseTo(90.91 / 300, 3)
+    })
+
+    it('computes CLV only from bets with a closing line (positive = beat the close)', () => {
+        const bets: BetLike[] = [
+            // bet -110 (1.909), closed -130 (1.769) → beat the close (+)
+            {
+                status: 'WON',
+                stake: 100,
+                oddsAmerican: -110,
+                closingOddsAmerican: -130,
+            },
+            // no closing line → excluded from CLV
+            { status: 'LOST', stake: 100, oddsAmerican: -110 },
+        ]
+        const m = computeMetrics(bets)
+        expect(m.clvCount).toBe(1)
+        expect(m.avgClvPct).not.toBeNull()
+        expect(m.avgClvPct as number).toBeGreaterThan(0)
+    })
+
+    it('returns null rates when nothing is decided', () => {
+        const m = computeMetrics([
+            { status: 'PENDING', stake: 100, oddsAmerican: -110 },
+        ])
+        expect(m.hitRate).toBeNull()
+        expect(m.roi).toBeNull()
+        expect(m.units).toBeNull()
+        expect(m.avgClvPct).toBeNull()
+    })
+})

--- a/tools/bruno/Bets/CreateBet.bru
+++ b/tools/bruno/Bets/CreateBet.bru
@@ -1,0 +1,240 @@
+meta {
+  name: CreateBet
+  type: http
+  seq: 2
+  tags: [
+    Bets
+  ]
+}
+
+post {
+  url: {{baseUrl}}/api/bets
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "sport": "",
+    "event": "",
+    "market": "moneyline",
+    "selection": "",
+    "oddsAmerican": 0,
+    "stake": 0,
+    "source": "INTUITION",
+    "league": "",
+    "line": 0,
+    "book": "",
+    "placedAt": "",
+    "aiModel": "",
+    "aiRationale": "",
+    "aiEstProb": 0,
+    "aiEV": 0,
+    "legs": [
+      {
+        "event": "",
+        "selection": "",
+        "oddsAmerican": 0,
+        "line": 0
+      }
+    ],
+    "notes": ""
+  }
+}
+
+docs {
+  Log a new bet (admin only).
+}
+
+example {
+  name: 201 Response
+  description: Bet created successfully
+  
+  request: {
+    url: {{baseUrl}}/api/bets
+    method: POST
+    mode: json
+    body:json: {
+      {
+        "sport": "",
+        "event": "",
+        "market": "moneyline",
+        "selection": "",
+        "oddsAmerican": 0,
+        "stake": 0,
+        "source": "INTUITION",
+        "league": "",
+        "line": 0,
+        "book": "",
+        "placedAt": "",
+        "aiModel": "",
+        "aiRationale": "",
+        "aiEstProb": 0,
+        "aiEV": 0,
+        "legs": [
+          {
+            "event": "",
+            "selection": "",
+            "oddsAmerican": 0,
+            "line": 0
+          }
+        ],
+        "notes": ""
+      }
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 201
+      text: Created
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": 0,
+          "placedAt": "",
+          "sport": "",
+          "league": "",
+          "event": "",
+          "market": "moneyline",
+          "selection": "",
+          "line": 0,
+          "oddsAmerican": 0,
+          "stake": 0,
+          "book": "",
+          "status": "PENDING",
+          "settledAt": "",
+          "payout": 0,
+          "source": "INTUITION",
+          "aiModel": "",
+          "aiRationale": "",
+          "aiEstProb": 0,
+          "aiEV": 0,
+          "closingLine": 0,
+          "closingOddsAmerican": 0,
+          "legs": "",
+          "notes": "",
+          "createdAt": "",
+          "updatedAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 400 Response
+  description: Invalid request
+  
+  request: {
+    url: {{baseUrl}}/api/bets
+    method: POST
+    mode: json
+    body:json: {
+      {
+        "sport": "",
+        "event": "",
+        "market": "moneyline",
+        "selection": "",
+        "oddsAmerican": 0,
+        "stake": 0,
+        "source": "INTUITION",
+        "league": "",
+        "line": 0,
+        "book": "",
+        "placedAt": "",
+        "aiModel": "",
+        "aiRationale": "",
+        "aiEstProb": 0,
+        "aiEV": 0,
+        "legs": [
+          {
+            "event": "",
+            "selection": "",
+            "oddsAmerican": 0,
+            "line": 0
+          }
+        ],
+        "notes": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 400
+      text: Bad Request
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 401 Response
+  description: Unauthorized
+  
+  request: {
+    url: {{baseUrl}}/api/bets
+    method: POST
+    mode: json
+    body:json: {
+      {
+        "sport": "",
+        "event": "",
+        "market": "moneyline",
+        "selection": "",
+        "oddsAmerican": 0,
+        "stake": 0,
+        "source": "INTUITION",
+        "league": "",
+        "line": 0,
+        "book": "",
+        "placedAt": "",
+        "aiModel": "",
+        "aiRationale": "",
+        "aiEstProb": 0,
+        "aiEV": 0,
+        "legs": [
+          {
+            "event": "",
+            "selection": "",
+            "oddsAmerican": 0,
+            "line": 0
+          }
+        ],
+        "notes": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 401
+      text: Unauthorized
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Bets/DeleteBet.bru
+++ b/tools/bruno/Bets/DeleteBet.bru
@@ -1,0 +1,88 @@
+meta {
+  name: DeleteBet
+  type: http
+  seq: 6
+  tags: [
+    Bets
+  ]
+}
+
+delete {
+  url: {{baseUrl}}/api/bets/:id
+  body: none
+  auth: bearer
+}
+
+params:path {
+  id: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Delete a bet by ID (admin only).
+}
+
+example {
+  name: 200 Response
+  description: Bet deleted successfully
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id
+    method: DELETE
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "success": false
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Bet not found
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id
+    method: DELETE
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Bets/GetAnalytics.bru
+++ b/tools/bruno/Bets/GetAnalytics.bru
@@ -1,0 +1,138 @@
+meta {
+  name: GetAnalytics
+  type: http
+  seq: 3
+  tags: [
+    Bets
+  ]
+}
+
+get {
+  url: {{baseUrl}}/api/bets/analytics
+  body: none
+  auth: apikey
+}
+
+params:query {
+  ~source: INTUITION
+  ~source: AI_ASSISTED
+  ~sport: 
+  ~market: moneyline
+  ~market: spread
+  ~market: total
+  ~market: prop
+  ~market: parlay
+  ~from: 
+  ~to: 
+}
+
+headers {
+  X-Mcp-Api-Key: {{apiKey}}
+}
+
+auth:apikey {
+  key: X-Mcp-Api-Key
+  value: {{apiKey}}
+  placement: header
+}
+
+docs {
+  Performance analytics (ROI, hit-rate, units, CLV) segmented by source —
+  the intuition-vs-AI scoreboard. Declared before `{id}` to avoid a route clash.
+}
+
+example {
+  name: 200 Response
+  description: Analytics computed
+  
+  request: {
+    url: {{baseUrl}}/api/bets/analytics
+    method: GET
+    mode: none
+    params:query: {
+      ~source: INTUITION
+      ~source: AI_ASSISTED
+      ~sport: 
+      ~market: moneyline
+      ~market: spread
+      ~market: total
+      ~market: prop
+      ~market: parlay
+      ~from: 
+      ~to: 
+    }
+  
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "overall": {
+            "count": 0,
+            "pending": 0,
+            "settled": 0,
+            "wins": 0,
+            "losses": 0,
+            "pushes": 0,
+            "voids": 0,
+            "hitRate": 0,
+            "staked": 0,
+            "profit": 0,
+            "roi": 0,
+            "units": 0,
+            "clvCount": 0,
+            "avgClvPct": 0
+          },
+          "bySource": {
+            "AI_ASSISTED": {
+              "count": 0,
+              "pending": 0,
+              "settled": 0,
+              "wins": 0,
+              "losses": 0,
+              "pushes": 0,
+              "voids": 0,
+              "hitRate": 0,
+              "staked": 0,
+              "profit": 0,
+              "roi": 0,
+              "units": 0,
+              "clvCount": 0,
+              "avgClvPct": 0
+            },
+            "INTUITION": {
+              "count": 0,
+              "pending": 0,
+              "settled": 0,
+              "wins": 0,
+              "losses": 0,
+              "pushes": 0,
+              "voids": 0,
+              "hitRate": 0,
+              "staked": 0,
+              "profit": 0,
+              "roi": 0,
+              "units": 0,
+              "clvCount": 0,
+              "avgClvPct": 0
+            }
+          }
+        }
+      '''
+    }
+  }
+}

--- a/tools/bruno/Bets/GetBet.bru
+++ b/tools/bruno/Bets/GetBet.bru
@@ -1,0 +1,126 @@
+meta {
+  name: GetBet
+  type: http
+  seq: 4
+  tags: [
+    Bets
+  ]
+}
+
+get {
+  url: {{baseUrl}}/api/bets/:id
+  body: none
+  auth: apikey
+}
+
+params:path {
+  id: 
+}
+
+headers {
+  X-Mcp-Api-Key: {{apiKey}}
+}
+
+auth:apikey {
+  key: X-Mcp-Api-Key
+  value: {{apiKey}}
+  placement: header
+}
+
+docs {
+  Get a bet by ID.
+}
+
+example {
+  name: 200 Response
+  description: Bet retrieved successfully
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id
+    method: GET
+    mode: none
+    params:path: {
+      id: 
+    }
+  
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": 0,
+          "placedAt": "",
+          "sport": "",
+          "league": "",
+          "event": "",
+          "market": "moneyline",
+          "selection": "",
+          "line": 0,
+          "oddsAmerican": 0,
+          "stake": 0,
+          "book": "",
+          "status": "PENDING",
+          "settledAt": "",
+          "payout": 0,
+          "source": "INTUITION",
+          "aiModel": "",
+          "aiRationale": "",
+          "aiEstProb": 0,
+          "aiEV": 0,
+          "closingLine": 0,
+          "closingOddsAmerican": 0,
+          "legs": "",
+          "notes": "",
+          "createdAt": "",
+          "updatedAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Bet not found
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id
+    method: GET
+    mode: none
+    params:path: {
+      id: 
+    }
+  
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Bets/ListBets.bru
+++ b/tools/bruno/Bets/ListBets.bru
@@ -1,0 +1,127 @@
+meta {
+  name: ListBets
+  type: http
+  seq: 1
+  tags: [
+    Bets
+  ]
+}
+
+get {
+  url: {{baseUrl}}/api/bets
+  body: none
+  auth: apikey
+}
+
+params:query {
+  ~source: INTUITION
+  ~source: AI_ASSISTED
+  ~status: PENDING
+  ~status: WON
+  ~status: LOST
+  ~status: PUSH
+  ~status: VOID
+  ~sport: 
+  ~market: moneyline
+  ~market: spread
+  ~market: total
+  ~market: prop
+  ~market: parlay
+  ~limit: 
+  ~offset: 
+}
+
+headers {
+  X-Mcp-Api-Key: {{apiKey}}
+}
+
+auth:apikey {
+  key: X-Mcp-Api-Key
+  value: {{apiKey}}
+  placement: header
+}
+
+docs {
+  List bets with optional filters.
+}
+
+example {
+  name: 200 Response
+  description: Bets retrieved successfully
+  
+  request: {
+    url: {{baseUrl}}/api/bets
+    method: GET
+    mode: none
+    params:query: {
+      ~source: INTUITION
+      ~source: AI_ASSISTED
+      ~status: PENDING
+      ~status: WON
+      ~status: LOST
+      ~status: PUSH
+      ~status: VOID
+      ~sport: 
+      ~market: moneyline
+      ~market: spread
+      ~market: total
+      ~market: prop
+      ~market: parlay
+      ~limit: 
+      ~offset: 
+    }
+  
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "bets": [
+            {
+              "id": 0,
+              "placedAt": "",
+              "sport": "",
+              "league": "",
+              "event": "",
+              "market": "moneyline",
+              "selection": "",
+              "line": 0,
+              "oddsAmerican": 0,
+              "stake": 0,
+              "book": "",
+              "status": "PENDING",
+              "settledAt": "",
+              "payout": 0,
+              "source": "INTUITION",
+              "aiModel": "",
+              "aiRationale": "",
+              "aiEstProb": 0,
+              "aiEV": 0,
+              "closingLine": 0,
+              "closingOddsAmerican": 0,
+              "legs": "",
+              "notes": "",
+              "createdAt": "",
+              "updatedAt": ""
+            }
+          ],
+          "total": 0
+        }
+      '''
+    }
+  }
+}

--- a/tools/bruno/Bets/SettleBet.bru
+++ b/tools/bruno/Bets/SettleBet.bru
@@ -1,0 +1,133 @@
+meta {
+  name: SettleBet
+  type: http
+  seq: 7
+  tags: [
+    Bets
+  ]
+}
+
+post {
+  url: {{baseUrl}}/api/bets/:id/settle
+  body: json
+  auth: bearer
+}
+
+params:path {
+  id: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "status": "WON",
+    "payout": 0
+  }
+}
+
+docs {
+  Settle a bet outcome (admin only). Payout auto-computed on a win.
+}
+
+example {
+  name: 200 Response
+  description: Bet settled
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id/settle
+    method: POST
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "status": "WON",
+        "payout": 0
+      }
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": 0,
+          "placedAt": "",
+          "sport": "",
+          "league": "",
+          "event": "",
+          "market": "moneyline",
+          "selection": "",
+          "line": 0,
+          "oddsAmerican": 0,
+          "stake": 0,
+          "book": "",
+          "status": "PENDING",
+          "settledAt": "",
+          "payout": 0,
+          "source": "INTUITION",
+          "aiModel": "",
+          "aiRationale": "",
+          "aiEstProb": 0,
+          "aiEV": 0,
+          "closingLine": 0,
+          "closingOddsAmerican": 0,
+          "legs": "",
+          "notes": "",
+          "createdAt": "",
+          "updatedAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Bet not found
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id/settle
+    method: POST
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "status": "WON",
+        "payout": 0
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Bets/UpdateBet.bru
+++ b/tools/bruno/Bets/UpdateBet.bru
@@ -1,0 +1,202 @@
+meta {
+  name: UpdateBet
+  type: http
+  seq: 5
+  tags: [
+    Bets
+  ]
+}
+
+put {
+  url: {{baseUrl}}/api/bets/:id
+  body: json
+  auth: bearer
+}
+
+params:path {
+  id: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "sport": "",
+    "league": "",
+    "event": "",
+    "market": "moneyline",
+    "selection": "",
+    "line": 0,
+    "oddsAmerican": 0,
+    "stake": 0,
+    "book": "",
+    "source": "INTUITION",
+    "aiModel": "",
+    "aiRationale": "",
+    "aiEstProb": 0,
+    "aiEV": 0,
+    "closingLine": 0,
+    "closingOddsAmerican": 0,
+    "legs": [
+      {
+        "event": "",
+        "selection": "",
+        "oddsAmerican": 0,
+        "line": 0
+      }
+    ],
+    "notes": ""
+  }
+}
+
+docs {
+  Update a bet by ID (admin only) — edit details or set closing line for CLV.
+}
+
+example {
+  name: 200 Response
+  description: Bet updated successfully
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id
+    method: PUT
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "sport": "",
+        "league": "",
+        "event": "",
+        "market": "moneyline",
+        "selection": "",
+        "line": 0,
+        "oddsAmerican": 0,
+        "stake": 0,
+        "book": "",
+        "source": "INTUITION",
+        "aiModel": "",
+        "aiRationale": "",
+        "aiEstProb": 0,
+        "aiEV": 0,
+        "closingLine": 0,
+        "closingOddsAmerican": 0,
+        "legs": [
+          {
+            "event": "",
+            "selection": "",
+            "oddsAmerican": 0,
+            "line": 0
+          }
+        ],
+        "notes": ""
+      }
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": 0,
+          "placedAt": "",
+          "sport": "",
+          "league": "",
+          "event": "",
+          "market": "moneyline",
+          "selection": "",
+          "line": 0,
+          "oddsAmerican": 0,
+          "stake": 0,
+          "book": "",
+          "status": "PENDING",
+          "settledAt": "",
+          "payout": 0,
+          "source": "INTUITION",
+          "aiModel": "",
+          "aiRationale": "",
+          "aiEstProb": 0,
+          "aiEV": 0,
+          "closingLine": 0,
+          "closingOddsAmerican": 0,
+          "legs": "",
+          "notes": "",
+          "createdAt": "",
+          "updatedAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Bet not found
+  
+  request: {
+    url: {{baseUrl}}/api/bets/:id
+    method: PUT
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "sport": "",
+        "league": "",
+        "event": "",
+        "market": "moneyline",
+        "selection": "",
+        "line": 0,
+        "oddsAmerican": 0,
+        "stake": 0,
+        "book": "",
+        "source": "INTUITION",
+        "aiModel": "",
+        "aiRationale": "",
+        "aiEstProb": 0,
+        "aiEV": 0,
+        "closingLine": 0,
+        "closingOddsAmerican": 0,
+        "legs": [
+          {
+            "event": "",
+            "selection": "",
+            "oddsAmerican": 0,
+            "line": 0
+          }
+        ],
+        "notes": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Bets/folder.bru
+++ b/tools/bruno/Bets/folder.bru
@@ -1,0 +1,7 @@
+meta {
+  name: Bets
+}
+
+auth {
+  mode: inherit
+}


### PR DESCRIPTION
## Summary

Phase 1 of the sports-betting tooling epic (#127): the **bet-tracker backend**, whose point is the intuition-vs-AI experiment. Backend only — the MCP client is the interface; the bryandebaun.dev dashboard is Phase 4.

Closes #128.

## Changes

- **Prisma `Bet` model** + `BetStatus` / `BetSource` / `BetMarket` enums; migration with **admin-only RLS** (bets are private personal data). `'bet'` added to the `MODEL_NAMES` stub contract.
- **MCP tools:** `create-bet`, `update-bet`, `get-bet`, `list-bets`, `delete-bet`, `settle-bet` (auto-computes payout on a win), and **`bet-analytics`** — ROI / hit-rate / units / **CLV**, **segmented by `source` (INTUITION vs AI_ASSISTED)**. Betting math lives in `metrics.ts` (pure, unit-tested); CLV = beat-the-close %.
- **REST (`BetsController`):** `api_key` reads (incl. `/api/bets/analytics`, declared before `{id}` to avoid a route clash); admin-gated writes + `POST /{id}/settle`.
- **Intuition-vs-AI capture:** AI `model` / `rationale` / `estProb` / `EV` recorded at placement; `closingLine` / `closingOddsAmerican` fields ready for **Phase 2 (#129)** CLV grading.

## Methodology (per #127)

Analytics lead with **CLV**, not W/L — short-run W/L is noise. `closingOddsAmerican` is null until Phase 2 supplies closing lines, and the math handles nulls (CLV reported only when present).

## Verification

- typecheck + lint clean; full suite **272 passed / 5 skipped / 0 failed**.
- Tests: metrics math (odds conversion, profit, ROI, CLV, null-safety), tool handlers (create defaults, settle payout calc, 404s, list filters), **source segmentation**, stub behavior; RLS lint + stub-coverage satisfied.
- The **Bruno drift guard from #8 caught the new endpoints** — collection auto-synced via `pnpm run bruno:sync` (new `Bets/` folder). Nice end-to-end proof of the auto-discovery loop.

## Try it (MCP client)

> "Log a $50 AI-assisted bet: Celtics ML -110, NBA, with rationale X" → `create-bet`
> "Settle bet 1 as WON" → `settle-bet`
> "How am I doing — intuition vs AI?" → `bet-analytics`

Next: **Phase 2 (#129)** — The Odds API integration (EV/arb/devig/parlay tools + closing-line capture for CLV).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
