### PR TITLE
feat(odds): Phase 2 odds analysis — The Odds API tools + EV/arb/devig/parlay (#129)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,10 @@ SPOTIFY_REFRESH_TOKEN=
 SPOTIFY_REDIRECT_URI=http://localhost:3000/api/admin/spotify/oauth-callback
 SPOTIFY_POLL_INTERVAL_MS=15000        # Polling interval in ms (default 15000)
 
+# ── Odds (The Odds API) ───────────────────────────────────────────────────────
+ODDS_API_KEY=                         # the-odds-api.com key; odds tools degrade gracefully when unset
+ODDS_API_BASE=https://api.the-odds-api.com/v4
+
 # ── GitHub ────────────────────────────────────────────────────────────────────
 GITHUB_TOKEN=ghp_changeme             # Personal access token for Issues/Projects API
 

--- a/docs/betting-odds.md
+++ b/docs/betting-odds.md
@@ -1,0 +1,37 @@
+# Betting odds tools (Phase 2 — #129)
+
+Read-only odds-analysis MCP tools backed by [The Odds API](https://the-odds-api.com/), plus the CLV-grading flow for the bet tracker (#128). These are the "AI-assisted" toolkit from the epic (#127). **No bets are placed** — analysis only.
+
+## Configuration
+
+Set `ODDS_API_KEY` (free tier at the-odds-api.com). When unset, the API-backed tools return a clean "Odds API not configured" error and the rest of the server is unaffected (same spirit as the Prisma stub contract). `ODDS_API_BASE` defaults to `https://api.the-odds-api.com/v4`.
+
+## Tools
+
+| Tool | API? | Purpose |
+|------|------|---------|
+| `list-sports` | yes | In-season sports + their keys (e.g. `basketball_nba`) |
+| `list-events` | yes | Upcoming events for a sport |
+| `get-odds` | yes | A game's odds across books (incl. DraftKings); `markets=h2h,spreads,totals` |
+| `devig` | no | Strip vig from a market → fair probabilities + book hold |
+| `find-positive-ev` | yes | Prices that beat the no-vig **consensus** across books |
+| `find-arbitrage` | yes | Cross-book h2h arbitrage (best price per side summing < 100%) |
+| `build-parlay` | no | Combine legs → combined odds, implied/fair prob, EV |
+
+**Honesty built in:** `build-parlay` always returns a caveat (parlays compound vig, assume independent legs, and correlated legs get limited/voided); `find-positive-ev`/`find-arbitrage` note they're most reliable for h2h and that lines move — verify before acting. Markets are sharp; these tools surface candidates, not guaranteed edges.
+
+## CLV grading flow (ties Phase 1 + Phase 2)
+
+Closing-line value is the primary intuition-vs-AI signal (#127). Capturing it:
+
+1. Near event start, fetch the closing number with `get-odds` (the price right before tip/kick is the closing line).
+2. Record it on the tracked bet with `update-bet { id, closingOddsAmerican }` (Phase 1 field).
+3. `bet-analytics` then reports `avgClvPct` (beat-the-close %) segmented by `INTUITION` vs `AI_ASSISTED`.
+
+> Auto-matching a tracked bet to its Odds-API event/outcome (to fill the closing line without manual entry) is a possible enhancement; v2 keeps capture explicit via `update-bet` to avoid brittle fuzzy matching.
+
+## Example (MCP client)
+
+> "What NBA games have +EV moneylines tonight?" → `find-positive-ev sport=basketball_nba`
+> "Devig these: -110 / -110" → `devig`
+> "Build a parlay: Celtics ML -150, Over 220 -110" → `build-parlay` (returns combined odds + caveat)

--- a/src/adapters/odds/the-odds-api.ts
+++ b/src/adapters/odds/the-odds-api.ts
@@ -1,0 +1,128 @@
+/**
+ * Thin adapter for The Odds API (https://the-odds-api.com), v4. Read-only.
+ * Mirrors the Spotify adapter pattern: a small typed surface over `fetch`, with
+ * graceful failure when `ODDS_API_KEY` is unset (callers surface a clean error).
+ */
+import { config } from '../../config.js'
+import { logger } from '../../logger.js'
+
+export interface OddsApiSport {
+    key: string
+    group: string
+    title: string
+    description: string
+    active: boolean
+    has_outcomes: boolean
+}
+
+export interface OddsApiEvent {
+    id: string
+    sport_key: string
+    sport_title?: string
+    commence_time: string
+    home_team: string | null
+    away_team: string | null
+}
+
+export interface OddsApiOutcome {
+    name: string
+    price: number // American odds (oddsFormat=american)
+    point?: number
+}
+
+export interface OddsApiMarket {
+    key: string // h2h | spreads | totals | ...
+    last_update?: string
+    outcomes: OddsApiOutcome[]
+}
+
+export interface OddsApiBookmaker {
+    key: string // e.g. "draftkings"
+    title: string
+    last_update?: string
+    markets: OddsApiMarket[]
+}
+
+export interface OddsApiEventOdds extends OddsApiEvent {
+    bookmakers: OddsApiBookmaker[]
+}
+
+export class OddsApiNotConfiguredError extends Error {
+    constructor() {
+        super('Odds API not configured: set ODDS_API_KEY')
+        this.name = 'OddsApiNotConfiguredError'
+    }
+}
+
+/** True when an API key is present. */
+export function isOddsConfigured(): boolean {
+    return Boolean(config.odds.apiKey)
+}
+
+async function request<T>(
+    path: string,
+    params: Record<string, string | undefined> = {},
+): Promise<T> {
+    if (!config.odds.apiKey) throw new OddsApiNotConfiguredError()
+
+    const url = new URL(`${config.odds.baseUrl}${path}`)
+    url.searchParams.set('apiKey', config.odds.apiKey)
+    for (const [k, v] of Object.entries(params)) {
+        if (v !== undefined && v !== '') url.searchParams.set(k, v)
+    }
+
+    const res = await fetch(url)
+    if (!res.ok) {
+        const body = await res.text().catch(() => '')
+        logger.warn('odds api request failed', {
+            path,
+            status: res.status,
+        })
+        throw new Error(`Odds API ${res.status}: ${body.slice(0, 200)}`)
+    }
+    return (await res.json()) as T
+}
+
+/** List in-season sports (and their keys). */
+export function getSports(): Promise<OddsApiSport[]> {
+    return request<OddsApiSport[]>('/sports')
+}
+
+/** List upcoming events for a sport. */
+export function getEvents(sport: string): Promise<OddsApiEvent[]> {
+    return request<OddsApiEvent[]>(`/sports/${sport}/events`)
+}
+
+export interface OddsQuery {
+    regions?: string // default "us"
+    markets?: string // default "h2h"
+    oddsFormat?: string // default "american"
+}
+
+/** Odds for all upcoming events in a sport, across books. */
+export function getOdds(
+    sport: string,
+    opts: OddsQuery = {},
+): Promise<OddsApiEventOdds[]> {
+    return request<OddsApiEventOdds[]>(`/sports/${sport}/odds`, {
+        regions: opts.regions ?? 'us',
+        markets: opts.markets ?? 'h2h',
+        oddsFormat: opts.oddsFormat ?? 'american',
+    })
+}
+
+/** Odds for a single event (supports richer markets / props). */
+export function getEventOdds(
+    sport: string,
+    eventId: string,
+    opts: OddsQuery = {},
+): Promise<OddsApiEventOdds> {
+    return request<OddsApiEventOdds>(
+        `/sports/${sport}/events/${eventId}/odds`,
+        {
+            regions: opts.regions ?? 'us',
+            markets: opts.markets ?? 'h2h',
+            oddsFormat: opts.oddsFormat ?? 'american',
+        },
+    )
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,6 +110,14 @@ const envSchema = z.object({
     SPOTIFY_REDIRECT_URI: z.string().url().optional(),
     SPOTIFY_POLL_INTERVAL_MS: posInt(15_000),
 
+    // ── Odds (The Odds API) ───────────────────────────────────────────────
+    ODDS_API_KEY: z.string().optional(),
+    ODDS_API_BASE: z
+        .string()
+        .url()
+        .optional()
+        .default('https://api.the-odds-api.com/v4'),
+
     // ── GitHub ────────────────────────────────────────────────────────────
     GITHUB_TOKEN: z.string().optional(),
 
@@ -250,6 +258,12 @@ export const config = {
         redirectUri: env.SPOTIFY_REDIRECT_URI,
         pollIntervalMs: env.SPOTIFY_POLL_INTERVAL_MS,
         enabled: spotifyEnabled,
+    },
+
+    odds: {
+        apiKey: env.ODDS_API_KEY,
+        baseUrl: env.ODDS_API_BASE,
+        enabled: Boolean(env.ODDS_API_KEY),
     },
 
     github: {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -2,6 +2,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { registerDbTools } from './db/index.js'
 import { registerGitHubIssuesTools } from './github-issues/index.js'
 import { registerGitHubProjectsTools } from './github-projects/index.js'
+import { registerOddsTools } from './odds/index.js'
 
 /**
  * Registers all tool categories with the MCP server.
@@ -21,6 +22,9 @@ export function registerTools(server: McpServer): void {
 
     // Database tools
     registerDbTools(server)
+
+    // Odds-analysis tools (The Odds API) — #129
+    registerOddsTools(server)
 
     // Future tool categories can be added here:
     // registerGitTools(server);

--- a/src/tools/odds/build-parlay.ts
+++ b/src/tools/odds/build-parlay.ts
@@ -1,0 +1,34 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../github-issues/results.js'
+import { registerTool } from '../registration.js'
+import { buildParlay } from './odds-math.js'
+import { BuildParlayInputSchema } from './schemas.js'
+
+const name = 'build-parlay'
+const config = {
+    title: 'Build Parlay',
+    description:
+        'Combine legs into a parlay: combined odds, implied/fair prob, EV — with an honest correlation/vig caveat (no API)',
+    inputSchema: BuildParlayInputSchema,
+}
+
+export function registerBuildParlayTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                return createSuccessResult(buildParlay(args.legs))
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/odds/devig.ts
+++ b/src/tools/odds/devig.ts
@@ -1,0 +1,34 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../github-issues/results.js'
+import { registerTool } from '../registration.js'
+import { devig } from './odds-math.js'
+import { DevigInputSchema } from './schemas.js'
+
+const name = 'devig'
+const config = {
+    title: 'Devig Market',
+    description:
+        'Strip the vig from a market: fair implied probabilities + the book hold (no API)',
+    inputSchema: DevigInputSchema,
+}
+
+export function registerDevigTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                return createSuccessResult(devig(args.oddsAmerican))
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/odds/find-arbitrage.ts
+++ b/src/tools/odds/find-arbitrage.ts
@@ -1,0 +1,84 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { getOdds } from '../../adapters/odds/the-odds-api.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../github-issues/results.js'
+import { registerTool } from '../registration.js'
+import { americanToDecimal, findArbitrage } from './odds-math.js'
+import { FindArbitrageInputSchema } from './schemas.js'
+
+const name = 'find-arbitrage'
+const config = {
+    title: 'Find Arbitrage',
+    description:
+        'Detect cross-book arbitrage on moneyline (h2h) markets — best price per outcome summing to <100% implied',
+    inputSchema: FindArbitrageInputSchema,
+}
+
+export function registerFindArbitrageTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { sport, markets = 'h2h', regions = 'us' } = args
+                const games = await getOdds(sport, { markets, regions })
+                const arbs: any[] = []
+
+                for (const game of games) {
+                    // h2h only: pairing is unambiguous (no points). Best price per
+                    // outcome name across books.
+                    const best = new Map<
+                        string,
+                        { american: number; book: string }
+                    >()
+                    for (const bk of game.bookmakers) {
+                        for (const m of bk.markets) {
+                            if (m.key !== 'h2h') continue
+                            for (const o of m.outcomes) {
+                                const cur = best.get(o.name)
+                                if (
+                                    !cur ||
+                                    americanToDecimal(o.price) >
+                                        americanToDecimal(cur.american)
+                                ) {
+                                    best.set(o.name, {
+                                        american: o.price,
+                                        book: bk.title,
+                                    })
+                                }
+                            }
+                        }
+                    }
+                    if (best.size < 2) continue
+                    const outcomes = [...best.entries()].map(([label, v]) => ({
+                        label: `${label} @ ${v.book}`,
+                        american: v.american,
+                    }))
+                    const arb = findArbitrage(outcomes)
+                    if (arb.isArb) {
+                        arbs.push({
+                            event: `${game.away_team} @ ${game.home_team}`,
+                            market: 'h2h',
+                            ...arb,
+                        })
+                    }
+                }
+
+                arbs.sort((a, b) => b.profitPct - a.profitPct)
+                return createSuccessResult({
+                    count: arbs.length,
+                    arbitrage: arbs,
+                    note: 'Covers h2h only. Arbs are rare, move fast, and books may limit/void — verify before acting.',
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/odds/find-positive-ev.ts
+++ b/src/tools/odds/find-positive-ev.ts
@@ -1,0 +1,118 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import {
+    getOdds,
+    type OddsApiOutcome,
+} from '../../adapters/odds/the-odds-api.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../github-issues/results.js'
+import { registerTool } from '../registration.js'
+import { devig, evPerUnit } from './odds-math.js'
+import { FindPositiveEvInputSchema } from './schemas.js'
+
+const name = 'find-positive-ev'
+const config = {
+    title: 'Find +EV',
+    description:
+        'Scan a sport for prices that beat the no-vig consensus across books (positive expected value)',
+    inputSchema: FindPositiveEvInputSchema,
+}
+
+const identity = (o: OddsApiOutcome) =>
+    o.point != null ? `${o.name} ${o.point}` : o.name
+
+export function registerFindPositiveEvTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const {
+                    sport,
+                    markets = 'h2h',
+                    regions = 'us',
+                    threshold = 0.02,
+                } = args
+                const games = await getOdds(sport, { markets, regions })
+                const opps: any[] = []
+
+                for (const game of games) {
+                    // marketKey -> identity -> { fairs: number[]; prices: {book, price}[] }
+                    const byMarket = new Map<
+                        string,
+                        Map<
+                            string,
+                            {
+                                fairs: number[]
+                                prices: { book: string; price: number }[]
+                            }
+                        >
+                    >()
+
+                    for (const bk of game.bookmakers) {
+                        for (const m of bk.markets) {
+                            if (m.outcomes.length < 2) continue
+                            const fair = devig(
+                                m.outcomes.map((o) => o.price),
+                            ).fairProbs
+                            const ids = byMarket.get(m.key) ?? new Map()
+                            m.outcomes.forEach((o, i) => {
+                                const id = identity(o)
+                                const slot = ids.get(id) ?? {
+                                    fairs: [],
+                                    prices: [],
+                                }
+                                slot.fairs.push(fair[i])
+                                slot.prices.push({
+                                    book: bk.title,
+                                    price: o.price,
+                                })
+                                ids.set(id, slot)
+                            })
+                            byMarket.set(m.key, ids)
+                        }
+                    }
+
+                    for (const [marketKey, ids] of byMarket) {
+                        for (const [id, slot] of ids) {
+                            const consensus =
+                                slot.fairs.reduce((a, b) => a + b, 0) /
+                                slot.fairs.length
+                            for (const { book, price } of slot.prices) {
+                                const ev = evPerUnit(consensus, price)
+                                if (ev >= threshold) {
+                                    opps.push({
+                                        event: `${game.away_team} @ ${game.home_team}`,
+                                        market: marketKey,
+                                        outcome: id,
+                                        book,
+                                        price,
+                                        fairProb:
+                                            Math.round(consensus * 1e4) / 1e4,
+                                        ev,
+                                        edgePct: Math.round(ev * 1e4) / 1e2,
+                                    })
+                                }
+                            }
+                        }
+                    }
+                }
+
+                opps.sort((a, b) => b.ev - a.ev)
+                return createSuccessResult({
+                    threshold,
+                    count: opps.length,
+                    opportunities: opps.slice(0, 50),
+                    note: 'Consensus = average no-vig fair prob across books. Most reliable for h2h; verify lines before betting.',
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/odds/get-odds.ts
+++ b/src/tools/odds/get-odds.ts
@@ -1,0 +1,70 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import {
+    getEventOdds,
+    getOdds,
+    type OddsApiEventOdds,
+} from '../../adapters/odds/the-odds-api.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../github-issues/results.js'
+import { registerTool } from '../registration.js'
+import { GetOddsInputSchema } from './schemas.js'
+
+const name = 'get-odds'
+const config = {
+    title: 'Get Odds',
+    description:
+        "A game's odds across books (incl. DraftKings) for the given markets (The Odds API)",
+    inputSchema: GetOddsInputSchema,
+}
+
+/** Trim the API payload to what's useful for analysis. */
+function shape(e: OddsApiEventOdds) {
+    return {
+        eventId: e.id,
+        commenceTime: e.commence_time,
+        matchup: `${e.away_team} @ ${e.home_team}`,
+        books: e.bookmakers.map((b) => ({
+            book: b.title,
+            markets: b.markets.map((m) => ({
+                market: m.key,
+                outcomes: m.outcomes.map((o) => ({
+                    name: o.name,
+                    price: o.price,
+                    point: o.point,
+                })),
+            })),
+        })),
+    }
+}
+
+export function registerGetOddsTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { sport, markets, regions, eventId } = args
+                if (eventId) {
+                    const e = await getEventOdds(sport, eventId, {
+                        markets,
+                        regions,
+                    })
+                    return createSuccessResult(shape(e))
+                }
+                const events = await getOdds(sport, { markets, regions })
+                return createSuccessResult({
+                    count: events.length,
+                    events: events.map(shape),
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/odds/index.ts
+++ b/src/tools/odds/index.ts
@@ -1,0 +1,19 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { registerBuildParlayTool } from './build-parlay.js'
+import { registerDevigTool } from './devig.js'
+import { registerFindArbitrageTool } from './find-arbitrage.js'
+import { registerFindPositiveEvTool } from './find-positive-ev.js'
+import { registerGetOddsTool } from './get-odds.js'
+import { registerListEventsTool } from './list-events.js'
+import { registerListSportsTool } from './list-sports.js'
+
+/** Register the odds-analysis tool suite (#129). */
+export function registerOddsTools(server: McpServer): void {
+    registerListSportsTool(server)
+    registerListEventsTool(server)
+    registerGetOddsTool(server)
+    registerDevigTool(server)
+    registerFindPositiveEvTool(server)
+    registerFindArbitrageTool(server)
+    registerBuildParlayTool(server)
+}

--- a/src/tools/odds/list-events.ts
+++ b/src/tools/odds/list-events.ts
@@ -1,0 +1,34 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { getEvents } from '../../adapters/odds/the-odds-api.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../github-issues/results.js'
+import { registerTool } from '../registration.js'
+import { ListEventsInputSchema } from './schemas.js'
+
+const name = 'list-events'
+const config = {
+    title: 'List Events',
+    description: 'List upcoming events for a sport (The Odds API)',
+    inputSchema: ListEventsInputSchema,
+}
+
+export function registerListEventsTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const events = await getEvents(args.sport)
+                return createSuccessResult({ count: events.length, events })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/odds/list-sports.ts
+++ b/src/tools/odds/list-sports.ts
@@ -1,0 +1,29 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { getSports } from '../../adapters/odds/the-odds-api.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../github-issues/results.js'
+import { registerTool } from '../registration.js'
+import { ListSportsInputSchema } from './schemas.js'
+
+const name = 'list-sports'
+const config = {
+    title: 'List Sports',
+    description: 'List in-season sports and their keys (The Odds API)',
+    inputSchema: ListSportsInputSchema,
+}
+
+export function registerListSportsTool(server: McpServer): void {
+    registerTool(server, name, config, async (): Promise<CallToolResult> => {
+        try {
+            const sports = await getSports()
+            return createSuccessResult({ count: sports.length, sports })
+        } catch (error) {
+            const message =
+                error instanceof Error ? error.message : String(error)
+            return createErrorResult(message)
+        }
+    })
+}

--- a/src/tools/odds/odds-math.ts
+++ b/src/tools/odds/odds-math.ts
@@ -1,0 +1,144 @@
+// Pure betting-odds math: conversions, devig, EV, consensus fair prob,
+// arbitrage, and parlay combination. No I/O — trivially unit-testable (#129).
+
+const round = (n: number, dp = 4) => {
+    const f = 10 ** dp
+    return Math.round(n * f) / f
+}
+
+/** American odds → decimal odds (total return per 1 unit staked). */
+export function americanToDecimal(odds: number): number {
+    return odds > 0 ? 1 + odds / 100 : 1 + 100 / -odds
+}
+
+/** Decimal odds → American odds (rounded). */
+export function decimalToAmerican(decimal: number): number {
+    if (decimal <= 1) return 0
+    return decimal >= 2
+        ? Math.round((decimal - 1) * 100)
+        : Math.round(-100 / (decimal - 1))
+}
+
+/** Implied probability of a single American price (includes vig). */
+export function impliedProb(odds: number): number {
+    return 1 / americanToDecimal(odds)
+}
+
+export interface DevigResult {
+    impliedProbs: number[]
+    fairProbs: number[]
+    holdPct: number
+}
+
+/**
+ * Strip the vig from a market's American prices: normalize implied probs so they
+ * sum to 1, and report the book's hold (overround) as a percentage.
+ */
+export function devig(americanOdds: number[]): DevigResult {
+    const implied = americanOdds.map(impliedProb)
+    const overround = implied.reduce((a, b) => a + b, 0)
+    const fair = implied.map((p) => p / overround)
+    return {
+        impliedProbs: implied.map((p) => round(p)),
+        fairProbs: fair.map((p) => round(p)),
+        holdPct: round((overround - 1) * 100),
+    }
+}
+
+/** Expected value per 1 unit staked at `american`, given a fair win probability. */
+export function evPerUnit(fairProb: number, american: number): number {
+    return round(fairProb * americanToDecimal(american) - 1)
+}
+
+/**
+ * Consensus fair probabilities across books: devig each book's prices for the
+ * same (ordered) outcomes, average the fair probs, and renormalize. Returns null
+ * if no usable book rows. This is the reference used to spot +EV outliers.
+ */
+export function consensusFairProbs(books: number[][]): number[] | null {
+    const usable = books.filter((b) => b.length > 1)
+    if (usable.length === 0) return null
+    const n = usable[0].length
+    const sums = new Array(n).fill(0)
+    let count = 0
+    for (const b of usable) {
+        if (b.length !== n) continue
+        devig(b).fairProbs.forEach((p, i) => {
+            sums[i] += p
+        })
+        count++
+    }
+    if (count === 0) return null
+    const avg = sums.map((s) => s / count)
+    const total = avg.reduce((a, b) => a + b, 0)
+    return avg.map((p) => round(p / total))
+}
+
+export interface ArbResult {
+    isArb: boolean
+    sumImplied: number
+    profitPct: number
+    stakes: { label: string; stakeFraction: number }[]
+}
+
+/** Detect a cross-book arbitrage from the best price per outcome. */
+export function findArbitrage(
+    outcomes: { label: string; american: number }[],
+): ArbResult {
+    const implied = outcomes.map((o) => impliedProb(o.american))
+    const sum = implied.reduce((a, b) => a + b, 0)
+    return {
+        isArb: sum < 1,
+        sumImplied: round(sum),
+        profitPct: round((1 / sum - 1) * 100),
+        stakes: outcomes.map((o, i) => ({
+            label: o.label,
+            stakeFraction: round(implied[i] / sum),
+        })),
+    }
+}
+
+export interface ParlayLeg {
+    oddsAmerican: number
+    fairProb?: number
+    label?: string
+}
+
+export interface ParlayResult {
+    legCount: number
+    combinedDecimal: number
+    combinedAmerican: number
+    impliedProb: number
+    fairProb: number | null
+    ev: number | null
+    edgePct: number | null
+    caveat: string
+}
+
+/** Combine parlay legs; report combined odds, implied/fair prob, EV — honestly. */
+export function buildParlay(legs: ParlayLeg[]): ParlayResult {
+    const combinedDecimal = legs.reduce(
+        (acc, l) => acc * americanToDecimal(l.oddsAmerican),
+        1,
+    )
+    const implied = 1 / combinedDecimal
+    const haveFair =
+        legs.length > 0 && legs.every((l) => typeof l.fairProb === 'number')
+    const fairProb = haveFair
+        ? legs.reduce((a, l) => a * (l.fairProb as number), 1)
+        : null
+    const ev = fairProb != null ? combinedDecimal * fairProb - 1 : null
+    return {
+        legCount: legs.length,
+        combinedDecimal: round(combinedDecimal),
+        combinedAmerican: decimalToAmerican(combinedDecimal),
+        impliedProb: round(implied),
+        fairProb: fairProb != null ? round(fairProb) : null,
+        ev: ev != null ? round(ev) : null,
+        edgePct: ev != null ? round(ev * 100) : null,
+        caveat:
+            "Parlays compound the books' vig and assume independent legs. " +
+            'Correlated legs are often limited/voided and erode real value — ' +
+            'treat as longshot/entertainment unless every leg is independently +EV.',
+    }
+}

--- a/src/tools/odds/schemas.ts
+++ b/src/tools/odds/schemas.ts
@@ -1,0 +1,63 @@
+// Input schemas for odds-analysis MCP tools (#129).
+import { z } from 'zod'
+
+export const ListSportsInputSchema = {}
+
+export const ListEventsInputSchema = {
+    sport: z
+        .string()
+        .describe('Sport key (e.g. basketball_nba) — see list-sports'),
+}
+
+export const GetOddsInputSchema = {
+    sport: z.string().describe('Sport key (e.g. basketball_nba)'),
+    markets: z
+        .string()
+        .optional()
+        .describe('Comma-separated markets (h2h,spreads,totals); default h2h'),
+    regions: z.string().optional().describe('Regions (default us)'),
+    eventId: z
+        .string()
+        .optional()
+        .describe(
+            'Single event id (richer markets/props) instead of all events',
+        ),
+}
+
+export const DevigInputSchema = {
+    oddsAmerican: z
+        .array(z.number())
+        .min(2)
+        .describe(
+            'American prices for all outcomes of ONE market (e.g. [-110,-110])',
+        ),
+}
+
+export const FindPositiveEvInputSchema = {
+    sport: z.string().describe('Sport key (e.g. basketball_nba)'),
+    markets: z.string().optional().describe('Markets; default h2h'),
+    regions: z.string().optional().describe('Regions (default us)'),
+    threshold: z
+        .number()
+        .optional()
+        .describe('Minimum EV per unit to report (default 0.02 = +2%)'),
+}
+
+export const FindArbitrageInputSchema = {
+    sport: z.string().describe('Sport key (e.g. basketball_nba)'),
+    markets: z.string().optional().describe('Markets; default h2h'),
+    regions: z.string().optional().describe('Regions (default us)'),
+}
+
+const ParlayLegSchema = z.object({
+    label: z.string().optional().describe('Leg label (e.g. "Celtics ML")'),
+    oddsAmerican: z.number().describe('Leg American odds'),
+    fairProb: z
+        .number()
+        .optional()
+        .describe('Fair win prob (0..1) — enables combined EV'),
+})
+
+export const BuildParlayInputSchema = {
+    legs: z.array(ParlayLegSchema).min(2).describe('Two or more parlay legs'),
+}

--- a/test/tools/odds/odds-math.test.ts
+++ b/test/tools/odds/odds-math.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest'
+import {
+    americanToDecimal,
+    buildParlay,
+    consensusFairProbs,
+    decimalToAmerican,
+    devig,
+    evPerUnit,
+    findArbitrage,
+    impliedProb,
+} from '../../../src/tools/odds/odds-math.js'
+
+describe('odds-math (#129)', () => {
+    it('converts between American and decimal', () => {
+        expect(americanToDecimal(100)).toBeCloseTo(2)
+        expect(americanToDecimal(150)).toBeCloseTo(2.5)
+        expect(americanToDecimal(-110)).toBeCloseTo(1.9091, 3)
+        expect(decimalToAmerican(2.5)).toBe(150)
+        expect(decimalToAmerican(2)).toBe(100)
+        expect(decimalToAmerican(1.5)).toBe(-200)
+    })
+
+    it('implied prob includes vig', () => {
+        expect(impliedProb(-110)).toBeCloseTo(0.5238, 3)
+    })
+
+    it('devig normalizes to fair probs and reports hold', () => {
+        const r = devig([-110, -110])
+        expect(r.fairProbs[0]).toBeCloseTo(0.5)
+        expect(r.fairProbs[1]).toBeCloseTo(0.5)
+        expect(r.fairProbs[0] + r.fairProbs[1]).toBeCloseTo(1)
+        expect(r.holdPct).toBeCloseTo(4.76, 1)
+    })
+
+    it('EV per unit is 0 at fair, positive when the price beats fair', () => {
+        expect(evPerUnit(0.5, 100)).toBeCloseTo(0)
+        expect(evPerUnit(0.55, 100)).toBeCloseTo(0.1)
+        expect(evPerUnit(0.45, 100)).toBeCloseTo(-0.1)
+    })
+
+    it('consensus fair probs average devigged books and sum to 1', () => {
+        const c = consensusFairProbs([
+            [-110, -110],
+            [120, -140],
+        ])
+        expect(c).not.toBeNull()
+        const probs = c as number[]
+        expect(probs[0] + probs[1]).toBeCloseTo(1)
+        expect(probs[0]).toBeLessThan(0.5) // home shaded by book B
+        expect(consensusFairProbs([])).toBeNull()
+    })
+
+    it('detects arbitrage when best prices imply <100%', () => {
+        const arb = findArbitrage([
+            { label: 'H', american: 110 },
+            { label: 'A', american: 110 },
+        ])
+        expect(arb.isArb).toBe(true)
+        expect(arb.sumImplied).toBeLessThan(1)
+        expect(arb.profitPct).toBeGreaterThan(0)
+        expect(
+            arb.stakes[0].stakeFraction + arb.stakes[1].stakeFraction,
+        ).toBeCloseTo(1)
+
+        const noArb = findArbitrage([
+            { label: 'H', american: -110 },
+            { label: 'A', american: -110 },
+        ])
+        expect(noArb.isArb).toBe(false)
+    })
+
+    it('builds a parlay and flags it as -EV at fair (with a caveat)', () => {
+        const p = buildParlay([
+            { oddsAmerican: -110, fairProb: 0.5 },
+            { oddsAmerican: -110, fairProb: 0.5 },
+        ])
+        expect(p.legCount).toBe(2)
+        expect(p.combinedDecimal).toBeCloseTo(3.6446, 2)
+        expect(p.fairProb).toBeCloseTo(0.25)
+        expect(p.ev as number).toBeLessThan(0) // compounded vig → -EV
+        expect(p.caveat).toMatch(/correlat/i)
+    })
+
+    it('parlay EV is null when fair probs are not all provided', () => {
+        const p = buildParlay([
+            { oddsAmerican: -110 },
+            { oddsAmerican: 150, fairProb: 0.4 },
+        ])
+        expect(p.fairProb).toBeNull()
+        expect(p.ev).toBeNull()
+        expect(p.combinedAmerican).toBeGreaterThan(0)
+    })
+})

--- a/test/tools/odds/odds-tools.test.ts
+++ b/test/tools/odds/odds-tools.test.ts
@@ -1,0 +1,186 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the adapter so the tools are deterministic and need no API key.
+vi.mock('../../../src/adapters/odds/the-odds-api.js', () => ({
+    getSports: vi.fn(),
+    getEvents: vi.fn(),
+    getOdds: vi.fn(),
+    getEventOdds: vi.fn(),
+    isOddsConfigured: vi.fn(() => true),
+}))
+
+import * as adapter from '../../../src/adapters/odds/the-odds-api.js'
+import { registerBuildParlayTool } from '../../../src/tools/odds/build-parlay.js'
+import { registerDevigTool } from '../../../src/tools/odds/devig.js'
+import { registerFindArbitrageTool } from '../../../src/tools/odds/find-arbitrage.js'
+import { registerFindPositiveEvTool } from '../../../src/tools/odds/find-positive-ev.js'
+import { registerGetOddsTool } from '../../../src/tools/odds/get-odds.js'
+import { registerListSportsTool } from '../../../src/tools/odds/list-sports.js'
+
+const getOdds = adapter.getOdds as unknown as ReturnType<typeof vi.fn>
+const getSports = adapter.getSports as unknown as ReturnType<typeof vi.fn>
+
+const handlers = new Map<string, (args: any) => Promise<any>>()
+const fake: any = {
+    registerTool: (name: string, _c: any, h: any) => handlers.set(name, h),
+}
+const call = async (name: string, args: any = {}) => {
+    const res = await handlers.get(name)!(args)
+    let data: any
+    try {
+        data = JSON.parse(res.content[0].text)
+    } catch {
+        data = res.content[0].text
+    }
+    return { isError: !!res.isError, data }
+}
+
+const h2hGame = (bookmakers: any[]) => ({
+    id: 'e1',
+    sport_key: 'basketball_nba',
+    commence_time: '2026-06-29T00:00:00Z',
+    home_team: 'Home',
+    away_team: 'Away',
+    bookmakers,
+})
+
+beforeAll(() => {
+    registerListSportsTool(fake)
+    registerGetOddsTool(fake)
+    registerDevigTool(fake)
+    registerBuildParlayTool(fake)
+    registerFindPositiveEvTool(fake)
+    registerFindArbitrageTool(fake)
+})
+
+beforeEach(() => {
+    getOdds.mockReset()
+    getSports.mockReset()
+})
+
+describe('odds tools — pure (no API)', () => {
+    it('devig returns fair probs + hold', async () => {
+        const { data } = await call('devig', { oddsAmerican: [-110, -110] })
+        expect(data.fairProbs[0]).toBeCloseTo(0.5)
+        expect(data.holdPct).toBeGreaterThan(0)
+    })
+
+    it('build-parlay combines legs with a caveat', async () => {
+        const { data } = await call('build-parlay', {
+            legs: [{ oddsAmerican: -110 }, { oddsAmerican: 150 }],
+        })
+        expect(data.legCount).toBe(2)
+        expect(data.caveat).toBeTruthy()
+    })
+})
+
+describe('odds tools — API-backed (mocked adapter)', () => {
+    it('list-sports surfaces a clean error when the API errors (e.g. no key)', async () => {
+        getSports.mockRejectedValueOnce(
+            new Error('Odds API not configured: set ODDS_API_KEY'),
+        )
+        const { isError, data } = await call('list-sports', {})
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/not configured/i)
+    })
+
+    it('get-odds shapes events across books', async () => {
+        getOdds.mockResolvedValueOnce([
+            h2hGame([
+                {
+                    key: 'dk',
+                    title: 'DraftKings',
+                    markets: [
+                        {
+                            key: 'h2h',
+                            outcomes: [
+                                { name: 'Home', price: -110 },
+                                { name: 'Away', price: -110 },
+                            ],
+                        },
+                    ],
+                },
+            ]),
+        ])
+        const { data } = await call('get-odds', { sport: 'basketball_nba' })
+        expect(data.count).toBe(1)
+        expect(data.events[0].matchup).toBe('Away @ Home')
+        expect(data.events[0].books[0].book).toBe('DraftKings')
+    })
+
+    it('find-positive-ev flags a price that beats consensus', async () => {
+        getOdds.mockResolvedValueOnce([
+            h2hGame([
+                {
+                    title: 'BookA',
+                    markets: [
+                        {
+                            key: 'h2h',
+                            outcomes: [
+                                { name: 'Home', price: -110 },
+                                { name: 'Away', price: -110 },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    title: 'BookB',
+                    markets: [
+                        {
+                            key: 'h2h',
+                            outcomes: [
+                                { name: 'Home', price: 120 },
+                                { name: 'Away', price: -140 },
+                            ],
+                        },
+                    ],
+                },
+            ]),
+        ])
+        const { data } = await call('find-positive-ev', {
+            sport: 'basketball_nba',
+        })
+        expect(data.count).toBeGreaterThanOrEqual(1)
+        const top = data.opportunities[0]
+        expect(top.ev).toBeGreaterThan(0)
+        expect(top.outcome).toBe('Home')
+        expect(top.book).toBe('BookB')
+    })
+
+    it('find-arbitrage detects a cross-book h2h arb', async () => {
+        getOdds.mockResolvedValueOnce([
+            h2hGame([
+                {
+                    title: 'BookA',
+                    markets: [
+                        {
+                            key: 'h2h',
+                            outcomes: [
+                                { name: 'Home', price: 110 },
+                                { name: 'Away', price: -130 },
+                            ],
+                        },
+                    ],
+                },
+                {
+                    title: 'BookB',
+                    markets: [
+                        {
+                            key: 'h2h',
+                            outcomes: [
+                                { name: 'Home', price: -130 },
+                                { name: 'Away', price: 110 },
+                            ],
+                        },
+                    ],
+                },
+            ]),
+        ])
+        const { data } = await call('find-arbitrage', {
+            sport: 'basketball_nba',
+        })
+        expect(data.count).toBe(1)
+        expect(data.arbitrage[0].isArb).toBe(true)
+        expect(data.arbitrage[0].profitPct).toBeGreaterThan(0)
+    })
+})


### PR DESCRIPTION
## Summary

Phase 2 of the sports-betting epic (#127): a read-only **odds-analysis MCP toolkit** backed by The Odds API — the "AI-assisted" side of the intuition-vs-AI experiment — plus the CLV-grading flow that lights up the Phase 1 analytics.

Closes #129.

## Changes

- **Config:** `ODDS_API_KEY` (+ `ODDS_API_BASE`), optional. When unset, the API-backed tools return a clean *"Odds API not configured"* error; the rest of the server is unaffected (Prisma-stub-style graceful degradation).
- **Adapter** `src/adapters/odds/the-odds-api.ts`: thin v4 client (`getSports` / `getEvents` / `getOdds` / `getEventOdds`), mirroring the Spotify adapter.
- **Pure math** `src/tools/odds/odds-math.ts`: american↔decimal, implied prob, **devig (+hold)**, **EV**, **consensus fair prob**, **arbitrage**, **parlay** combiner — no I/O, fully unit-tested.
- **MCP tools** (new `odds` category, MCP-only — no REST/spec change): `list-sports`, `list-events`, `get-odds`, `devig`, `find-positive-ev` (prices beating the no-vig consensus), `find-arbitrage` (h2h), `build-parlay`.
- **Honesty built in:** `build-parlay` always returns a vig/correlation caveat; the EV/arb tools note they're most reliable for h2h and that lines move — candidates, not guaranteed edges.
- **CLV flow** (`docs/betting-odds.md`): `get-odds` near tip → `update-bet { closingOddsAmerican }` (Phase 1 field) → `bet-analytics` reports `avgClvPct` segmented by `INTUITION` vs `AI_ASSISTED`. This completes the experiment's primary signal.

## Verification

- typecheck + lint clean; **285 passed** (the lone `server.import-failure` timeout is the pre-existing slow-machine flake — passed on adjacent runs, unrelated to odds code).
- Tests: odds-math (conversions, devig/hold, EV, consensus, arb, parlay-is-−EV) and tools (mocked adapter — get-odds shaping, **+EV detection**, **arb detection**, not-configured error).

## Notes / follow-ups

- Auto-matching a tracked bet to its Odds-API event to fill the closing line (vs. manual `update-bet`) is a deliberate v2 deferral — avoids brittle fuzzy matching.
- Arbitrage detection covers **h2h** only (sound pairing); spreads/totals pairing is a possible enhancement.
- Drop a free the-odds-api.com key into `ODDS_API_KEY` to use the live tools.

Next: **Phase 3 (#130)** — DraftKings place-assist (human-in-the-loop bet slip / deep link).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
