### PR TITLE
test(http): de-flake server.import-failure with a 30s timeout

### DIFF
--- a/test/http/server.import-failure.test.ts
+++ b/test/http/server.import-failure.test.ts
@@ -7,11 +7,14 @@ describe('createHttpApp import failure behavior', () => {
         vi.resetModules()
     })
 
+    // Generous timeout: this dynamically imports the whole server module graph
+    // (express, tsoa-routes, MCP transport), which can exceed Vitest's default
+    // 5s under machine load — a flake unrelated to what's being asserted.
     it('does not throw if mcp-http import fails', async () => {
         vi.doMock('../../src/http/mcp-http', () => {
             throw new Error(ERROR_MSG)
         })
         const { createHttpApp } = await import('../../src/http/server')
         await expect(createHttpApp()).resolves.toBeTruthy()
-    })
+    }, 30_000)
 })


### PR DESCRIPTION
## Summary

`test/http/server.import-failure.test.ts` intermittently fails with *"Test timed out in 5000ms"* — not a real regression. The test does `await import('../../src/http/server')`, which pulls the **whole server module graph** (express, tsoa-routes, MCP transport); under machine load that dynamic import occasionally exceeds Vitest's default 5s `testTimeout` (observed ~5.2s; normal ~1.6–2.3s).

Fix: give just this test a **30s** timeout. No production code change.

## Verification
- Passes in isolation (~2.4s); lint clean.

This is the recurring flake seen across recent PRs (#125, #128, #129 runs) — should stop now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)