### PR TITLE
fix(config): load .env.local (overriding .env) in non-production

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,10 +6,16 @@
  */
 
 // Load dotenv before reading process.env. Only in non-production — hosted
-// environments (Render) inject vars directly. Safe to call multiple times.
+// environments (Render) inject vars directly. Load `.env.local` first so its
+// values take precedence over `.env`, while real shell env vars still win over
+// both (dotenv's default `override: false` never clobbers what's already set).
+// This matches the test setup (vitest loads `.env.local`) and the conventional
+// "`.env.local` = local overrides" behavior. Safe to call multiple times.
 if (process.env.NODE_ENV !== 'production') {
     try {
-        await import('dotenv/config')
+        const { config: loadEnv } = await import('dotenv')
+        loadEnv({ path: '.env.local' })
+        loadEnv() // .env — fills anything not already set
     } catch {
         // dotenv not installed or not available; env vars provided by platform
     }


### PR DESCRIPTION
## Summary

The app's `config.ts` only loaded `.env` (via `dotenv/config`), but `.env.local` is the conventional local-overrides file — and what the test setup (vitest) and local workflows already use. Result: vars placed in `.env.local` (e.g. `ODDS_API_KEY`) were invisible to the running server/MCP tools, even though tests saw them.

## Change

Non-production startup now loads `.env.local` then `.env` with dotenv's default (no override), so precedence is **shell > `.env.local` > `.env`**. Production is unaffected — `NODE_ENV=production` skips dotenv entirely (Render injects vars).

## Verification

- The live Odds API adapter now picks up `ODDS_API_KEY` from `.env.local` — `getSports()` returns 42 sports (real API, end-to-end). Previously: *"Odds API not configured"*.
- typecheck + lint clean; full suite **286 passed / 0 failed**.

Unblocks local use of the Phase 2 odds tools (#129) and removes a `.env`/`.env.local` footgun for future vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)