### PR TITLE
fix(bets): make per-leg parlay odds optional for same-game parlays (#137)

### DIFF
--- a/src/http/controllers/BetsController.ts
+++ b/src/http/controllers/BetsController.ts
@@ -78,7 +78,8 @@ export interface BetAnalyticsResponse {
 export interface BetLeg {
     event: string
     selection: string
-    oddsAmerican: number
+    /** Optional: same-game parlays expose only the combined price, not per-leg odds (#137). */
+    oddsAmerican?: number
     line?: number
 }
 

--- a/src/tools/db/bets/prepare-bet-slip.ts
+++ b/src/tools/db/bets/prepare-bet-slip.ts
@@ -4,7 +4,11 @@ import {
     createErrorResult,
     createSuccessResult,
 } from '../../github-issues/results.js'
-import { americanToDecimal, buildParlay } from '../../odds/odds-math.js'
+import {
+    americanToDecimal,
+    buildParlay,
+    PARLAY_CAVEAT,
+} from '../../odds/odds-math.js'
 import { registerTool } from '../../registration.js'
 import { draftkingsLink } from './draftkings.js'
 import { PrepareBetSlipInputSchema } from './schemas.js'
@@ -43,11 +47,17 @@ export function registerPrepareBetSlipTool(server: McpServer): void {
                 } = args
 
                 const isParlay = Array.isArray(legs) && legs.length >= 2
-                let effectiveOdds: number
-                let parlay: ReturnType<typeof buildParlay> | undefined
+                const legsHaveOdds =
+                    isParlay &&
+                    legs.every((l: any) => typeof l.oddsAmerican === 'number')
 
-                if (isParlay) {
-                    parlay = buildParlay(
+                let effectiveOdds: number
+                let fp: number | null
+                let caveat: string | undefined
+
+                if (isParlay && legsHaveOdds) {
+                    // Standard parlay: derive combined odds from the legs.
+                    const parlay = buildParlay(
                         legs.map((l: any) => ({
                             oddsAmerican: l.oddsAmerican,
                             fairProb: l.fairProb,
@@ -55,6 +65,19 @@ export function registerPrepareBetSlipTool(server: McpServer): void {
                         })),
                     )
                     effectiveOdds = parlay.combinedAmerican
+                    fp = parlay.fairProb
+                    caveat = parlay.caveat
+                } else if (isParlay) {
+                    // Same-game parlay: legs lack per-leg odds, so use the
+                    // provided combined price (#137). Legs are descriptive.
+                    if (typeof oddsAmerican !== 'number') {
+                        return createErrorResult(
+                            'For a same-game parlay (legs without odds), provide the combined oddsAmerican.',
+                        )
+                    }
+                    effectiveOdds = oddsAmerican
+                    fp = fairProb ?? null
+                    caveat = PARLAY_CAVEAT
                 } else {
                     if (typeof oddsAmerican !== 'number') {
                         return createErrorResult(
@@ -62,13 +85,12 @@ export function registerPrepareBetSlipTool(server: McpServer): void {
                         )
                     }
                     effectiveOdds = oddsAmerican
+                    fp = fairProb ?? null
+                    caveat = undefined
                 }
 
                 const decimal = americanToDecimal(effectiveOdds)
                 const potentialPayout = round(stake * decimal)
-                const fp = isParlay
-                    ? (parlay?.fairProb ?? null)
-                    : (fairProb ?? null)
                 const ev = fp != null ? round(fp * decimal - 1) : null
                 const market = isParlay
                     ? 'parlay'
@@ -96,7 +118,7 @@ export function registerPrepareBetSlipTool(server: McpServer): void {
                     fairProb: fp,
                     ev,
                     edgePct: ev != null ? round(ev * 100) : null,
-                    caveat: isParlay ? parlay?.caveat : undefined,
+                    caveat,
                 }
 
                 // Exact args to log this once placed (preserves source + AI metadata).

--- a/src/tools/db/bets/schemas.ts
+++ b/src/tools/db/bets/schemas.ts
@@ -8,7 +8,14 @@ const SettleStatusEnum = z.enum(['WON', 'LOST', 'PUSH', 'VOID'])
 const LegSchema = z.object({
     event: z.string().describe('Leg event description'),
     selection: z.string().describe('Leg selection'),
-    oddsAmerican: z.number().int().describe('Leg American odds'),
+    // Optional: same-game parlays (SGPs) only expose the combined price, not
+    // per-leg odds. The bet's economics come from the top-level combined
+    // oddsAmerican; leg odds are descriptive. (#137)
+    oddsAmerican: z
+        .number()
+        .int()
+        .optional()
+        .describe('Leg American odds (optional; SGPs omit it)'),
     line: z.number().optional().describe('Leg line, if applicable'),
 })
 
@@ -111,7 +118,13 @@ const SlipLegSchema = z.object({
     label: z.string().optional().describe('Leg label'),
     event: z.string().optional().describe('Leg event'),
     selection: z.string().optional().describe('Leg selection'),
-    oddsAmerican: z.number().int().describe('Leg American odds'),
+    // Optional for same-game parlays — provide the top-level combined
+    // oddsAmerican instead (#137).
+    oddsAmerican: z
+        .number()
+        .int()
+        .optional()
+        .describe('Leg American odds (optional; SGPs omit it)'),
     line: z.number().optional(),
     fairProb: z
         .number()

--- a/src/tools/odds/odds-math.ts
+++ b/src/tools/odds/odds-math.ts
@@ -6,6 +6,12 @@ const round = (n: number, dp = 4) => {
     return Math.round(n * f) / f
 }
 
+/** Honest framing for any parlay (compounded vig + correlation risk). */
+export const PARLAY_CAVEAT =
+    "Parlays compound the books' vig and assume independent legs. " +
+    'Correlated legs are often limited/voided and erode real value — ' +
+    'treat as longshot/entertainment unless every leg is independently +EV.'
+
 /** American odds → decimal odds (total return per 1 unit staked). */
 export function americanToDecimal(odds: number): number {
     return odds > 0 ? 1 + odds / 100 : 1 + 100 / -odds
@@ -136,9 +142,6 @@ export function buildParlay(legs: ParlayLeg[]): ParlayResult {
         fairProb: fairProb != null ? round(fairProb) : null,
         ev: ev != null ? round(ev) : null,
         edgePct: ev != null ? round(ev * 100) : null,
-        caveat:
-            "Parlays compound the books' vig and assume independent legs. " +
-            'Correlated legs are often limited/voided and erode real value — ' +
-            'treat as longshot/entertainment unless every leg is independently +EV.',
+        caveat: PARLAY_CAVEAT,
     }
 }

--- a/test/tools/db/bets/leg-odds-optional.test.ts
+++ b/test/tools/db/bets/leg-odds-optional.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
+import {
+    CreateBetInputSchema,
+    UpdateBetInputSchema,
+} from '../../../../src/tools/db/bets/schemas.js'
+
+// Validates the #137 change at the schema layer (the MCP framework enforces these
+// on the tool input, so this is where the contract actually lives).
+const createSchema = z.object(CreateBetInputSchema)
+const updateSchema = z.object(UpdateBetInputSchema)
+
+const baseParlay = {
+    sport: 'NBA',
+    event: 'Lakers @ Celtics (SGP)',
+    market: 'parlay' as const,
+    selection: '3-leg SGP',
+    oddsAmerican: 450, // top-level combined price — still required
+    stake: 20,
+    source: 'INTUITION' as const,
+}
+
+describe('parlay leg odds optional (#137)', () => {
+    it('accepts a parlay whose legs omit oddsAmerican (same-game parlay)', () => {
+        const parsed = createSchema.parse({
+            ...baseParlay,
+            legs: [
+                { event: 'Lakers @ Celtics', selection: 'Tatum 30+ pts' },
+                {
+                    event: 'Lakers @ Celtics',
+                    selection: 'Over 220.5',
+                    line: 220.5,
+                },
+            ],
+        })
+        expect(parsed.legs).toHaveLength(2)
+        expect(parsed.legs?.[0].oddsAmerican).toBeUndefined()
+    })
+
+    it('still accepts legs WITH oddsAmerican (unchanged)', () => {
+        const parsed = createSchema.parse({
+            ...baseParlay,
+            legs: [
+                { event: 'g1', selection: 'A', oddsAmerican: -110 },
+                { event: 'g2', selection: 'B', oddsAmerican: 150 },
+            ],
+        })
+        expect(parsed.legs?.[0].oddsAmerican).toBe(-110)
+    })
+
+    it('still requires event + selection on each leg', () => {
+        const bad = createSchema.safeParse({
+            ...baseParlay,
+            legs: [{ selection: 'no event' }],
+        })
+        expect(bad.success).toBe(false)
+    })
+
+    it('still requires the top-level combined oddsAmerican', () => {
+        const { oddsAmerican, ...noOdds } = baseParlay
+        const bad = createSchema.safeParse({
+            ...noOdds,
+            legs: [{ event: 'g', selection: 'A' }],
+        })
+        expect(bad.success).toBe(false)
+    })
+
+    it('update-bet legs likewise accept missing odds', () => {
+        const parsed = updateSchema.parse({
+            id: 1,
+            legs: [{ event: 'g', selection: 'A' }],
+        })
+        expect(parsed.legs?.[0].oddsAmerican).toBeUndefined()
+    })
+})

--- a/test/tools/db/bets/prepare-bet-slip.test.ts
+++ b/test/tools/db/bets/prepare-bet-slip.test.ts
@@ -84,6 +84,42 @@ describe('prepare-bet-slip (#130) — places nothing, prepares everything', () =
         expect(data.draftBet.legs).toHaveLength(2)
     })
 
+    it('handles a same-game parlay (legs without odds) using the combined price', async () => {
+        const { data } = await call({
+            event: 'Lakers @ Celtics (SGP)',
+            stake: 20,
+            oddsAmerican: 450, // combined SGP price (legs have no per-leg odds)
+            legs: [
+                { event: 'Lakers @ Celtics', selection: 'Tatum 30+' },
+                {
+                    event: 'Lakers @ Celtics',
+                    selection: 'Over 220.5',
+                    line: 220.5,
+                },
+            ],
+            sport: 'basketball_nba',
+        })
+        expect(data.slip.market).toBe('parlay')
+        expect(data.slip.oddsAmerican).toBe(450) // uses the provided combined price
+        expect(Number.isNaN(data.slip.oddsAmerican)).toBe(false)
+        expect(data.slip.potentialPayout).toBeCloseTo(110) // 20 * 5.5
+        expect(data.slip.caveat).toMatch(/correlat/i)
+        expect(data.draftBet.legs).toHaveLength(2)
+    })
+
+    it('errors on a same-game parlay with no per-leg odds AND no combined price', async () => {
+        const { isError, data } = await call({
+            event: 'SGP',
+            stake: 20,
+            legs: [
+                { event: 'g', selection: 'A' },
+                { event: 'g', selection: 'B' },
+            ],
+        })
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/same-game parlay/i)
+    })
+
     it('errors when a single bet has no oddsAmerican', async () => {
         const { isError, data } = await call({
             event: 'A @ B',


### PR DESCRIPTION
## Summary

Same-game parlays (SGPs) only display the **combined** price, not per-leg odds — so an SGP couldn't be recorded with structured legs. Per-leg odds are now **optional** (descriptive); the bet's economics still come from the **top-level combined `oddsAmerican`**, which stays required.

Closes #137.

## Changes

- **`schemas.ts`** — `LegSchema.oddsAmerican` and the place-assist `SlipLegSchema.oddsAmerican` → `optional()`. `event` + `selection` stay required; top-level combined `oddsAmerican` unchanged (required for parlay & single).
- **`BetsController` `BetLeg`** — `oddsAmerican?` optional, so the OpenAPI `BetLeg` requires only `event`/`selection` (verified: `required: ["event","selection"]`). The regenerated `@bryandebaun/mcp-client` will reflect it.
- **`prepare-bet-slip`** — when parlay legs lack odds, fall back to the provided combined `oddsAmerican` (clear error if neither is given) instead of computing `NaN` from legs; the parlay caveat still applies (extracted to a shared `PARLAY_CAVEAT`).
- **`metrics`/analytics** — confirmed they use only bet-level `oddsAmerican`, never leg odds → unaffected.

## Verification

- typecheck + lint clean; full suite **300 passed / 0 failed**.
- New `leg-odds-optional.test.ts`: a parlay with legs missing odds parses; legs still require event/selection; top-level combined odds still required; update-bet likewise.
- `prepare-bet-slip`: SGP path uses the combined price (no NaN, caveat present) + errors when neither leg nor combined odds are present.
- Bruno collection unchanged (no endpoint/body drift).

## Follow-up (bryandebaun.dev)
Regenerate the website's MCP client so the bet form's parlay-legs editor can capture SGP legs (event + selection + optional line) structurally instead of in `notes` — noted in #137 alongside PR #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)