### PR TITLE
chore: upgrade pnpm 10.34.1 → 11.9.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -7,5 +7,5 @@
 # (see Dockerfile / issue #106).
 node-linker=isolated
 
-# Allowed dependency build scripts are declared in package.json -> pnpm.onlyBuiltDependencies
-# (@prisma/engines, esbuild, prisma). @scarf/scarf telemetry is intentionally left blocked.
+# Dependency build-script approval is declared in pnpm-workspace.yaml (the
+# `allowBuilds` map). As of pnpm 11 the package.json "pnpm" field is no longer read.

--- a/package.json
+++ b/package.json
@@ -42,10 +42,10 @@
     ],
     "author": "bryan-debaun",
     "license": "MIT",
-    "packageManager": "pnpm@10.34.1",
+    "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
     "engines": {
         "node": ">=20.0.0",
-        "pnpm": ">=10.0.0"
+        "pnpm": ">=11.0.0"
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.0",
@@ -95,12 +95,5 @@
     },
     "prisma": {
         "schema": "prisma/schema.prisma"
-    },
-    "pnpm": {
-        "onlyBuiltDependencies": [
-            "@prisma/engines",
-            "esbuild",
-            "prisma"
-        ]
     }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+# pnpm 11 reads build-script approval from here — the package.json "pnpm" field
+# is no longer read as of pnpm 11 (see https://pnpm.io/settings). pnpm 11 also
+# replaced the onlyBuiltDependencies / ignoredBuiltDependencies lists with a single
+# allowBuilds map (package -> boolean); true = run its install/build script.
+allowBuilds:
+  '@prisma/engines': true   # native Prisma query engine — required
+  esbuild: true             # tsx / vitest binary — required
+  prisma: true              # Prisma CLI preinstall — required
+  '@scarf/scarf': false     # telemetry only
+  protobufjs: false         # optional CJS/codegen optimization; not needed at runtime


### PR DESCRIPTION
## Why
Upgrade the pinned package manager from pnpm 10.34.1 to the current latest stable **11.9.0**.

pnpm 11 is a **breaking config change**: it stopped reading the `pnpm` field in `package.json` and replaced the `onlyBuiltDependencies` list with a single `allowBuilds` map (package → boolean) in `pnpm-workspace.yaml`. Without migrating, install fails fatally with `ERR_PNPM_IGNORED_BUILDS` under pnpm 11's strict build-script check.

## What
- Pin `packageManager` → `pnpm@11.9.0` (via `corepack use`, with integrity hash); bump `engines.pnpm` → `>=11.0.0`.
- Move build-script approval into `pnpm-workspace.yaml` `allowBuilds`: enable `@prisma/engines`, `esbuild`, `prisma`; disable `@scarf/scarf`, `protobufjs` (explicitly, so the strict check passes cleanly).
- Remove the now-ignored `pnpm` field from `package.json`; refresh `.npmrc` comment.
- `node-linker=isolated` in `.npmrc` is unchanged.

## Notes
- CI (`pnpm/action-setup@v4`) and Docker (corepack) read the version from the `packageManager` field, so 11.9.0 propagates automatically — no workflow/Dockerfile edits needed.
- Lockfile format unchanged (v9.0) → **no `pnpm-lock.yaml` churn**.

## Verification
`pnpm install` (build scripts run, no fatal) · `prisma generate` · `pnpm typecheck` (exit 0) · full suite **300 passed / 5 env-gated skips** — all green on pnpm 11.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)