### PR TITLE
fix(docker): copy pnpm-workspace.yaml so the container install passes on pnpm 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ RUN corepack enable
 ARG DATABASE_URL
 ENV DATABASE_URL=$DATABASE_URL
 
-# Install full deps (with frozen lockfile) — leverage layer caching on lockfile changes
-COPY package.json pnpm-lock.yaml .npmrc ./
+# Install full deps (with frozen lockfile) — leverage layer caching on lockfile changes.
+# pnpm-workspace.yaml carries the pnpm 11 `allowBuilds` approval; without it the
+# strict build-script check fails the install (ERR_PNPM_IGNORED_BUILDS).
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 RUN pnpm install --frozen-lockfile
 
 # Copy source and build (prisma generate + tsoa routes + tsc + seed compile)
@@ -36,7 +38,7 @@ ENV NODE_ENV=production
 RUN corepack enable
 
 # Copy package manifests, the pruned (production) node_modules, and built artifacts
-COPY --from=build /app/package.json /app/pnpm-lock.yaml /app/.npmrc ./
+COPY --from=build /app/package.json /app/pnpm-lock.yaml /app/pnpm-workspace.yaml /app/.npmrc ./
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/build ./build


### PR DESCRIPTION
## Production down — hotfix
The Render deploy of `main` (commit after #142, the pnpm 10→11 upgrade) fails at the Docker `pnpm install --frozen-lockfile` step:

```
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: @prisma/engines, @scarf/scarf, esbuild, prisma, protobufjs
```

## Root cause
pnpm 11 reads build-script approval (the `allowBuilds` map) from **`pnpm-workspace.yaml`**. The Dockerfile's build stage copied only `package.json pnpm-lock.yaml .npmrc` before installing, so inside the container pnpm 11 never sees the approval and its strict build-script check aborts the install. This is a regression from #142 — locally and in CI the full repo is checked out (so the file is present), but the container copies files selectively.

## Fix
Add `pnpm-workspace.yaml` to:
- the **build-stage** COPY (the failing step), and
- the **runtime-stage** COPY (consistency for the boot-time `pnpm exec prisma migrate deploy`).

## Verification
1. **Reproduced the failure without Docker**: in a temp dir with only `{package.json, pnpm-lock.yaml, .npmrc}`, `pnpm install --frozen-lockfile` fails with the exact prod error; adding `pnpm-workspace.yaml` makes it pass (build scripts run, exit 0).
2. **Full container build**: `docker build --target build` now completes **exit 0** — corepack, install, `pnpm run build` (prisma generate + tsoa + tsc + seed compile), and `pnpm prune --prod` all succeed under pnpm 11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)