### PR TITLE
feat(resume): ResumeDownloadRequest resource — MCP tools + REST (#139)

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
         "prisma:seed": "node dist/seed.js",
         "prisma:seed:dev": "tsx prisma/seed.ts",
         "prisma:generate": "prisma generate",
-        "db:deploy": "prisma migrate deploy && node dist/seed.js"
+        "db:deploy": "prisma migrate deploy && node dist/seed.js",
+        "env:pull": "doppler secrets download --no-file --format env > .env.local"
     },
     "keywords": [
         "mcp",

--- a/prisma/migrations/20260703130000_add_resume_download_request/migration.sql
+++ b/prisma/migrations/20260703130000_add_resume_download_request/migration.sql
@@ -1,0 +1,60 @@
+-- Add ResumeDownloadRequest resource: gated résumé-download flow (issue #139).
+-- A signed-in user requests the contact-bearing résumé; an admin approves/denies;
+-- approval grants a 72h download window. Authorization (admin gating, owner-only
+-- create/fulfill, quota) is enforced in the application layer; RLS below is
+-- defense-in-depth mirroring the AccessRequest owner-or-admin pattern.
+
+-- CreateEnum
+CREATE TYPE "ResumeDownloadStatus" AS ENUM ('pending', 'approved', 'denied', 'fulfilled', 'expired');
+
+-- CreateTable
+CREATE TABLE "ResumeDownloadRequest" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "userEmail" TEXT NOT NULL,
+    "reason" TEXT,
+    "status" "ResumeDownloadStatus" NOT NULL DEFAULT 'pending',
+    "adminNote" TEXT,
+    "downloadCount" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "approvedAt" TIMESTAMP(3),
+    "expiresAt" TIMESTAMP(3),
+
+    CONSTRAINT "ResumeDownloadRequest_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ResumeDownloadRequest_userId_idx" ON "ResumeDownloadRequest"("userId");
+
+-- CreateIndex
+CREATE INDEX "ResumeDownloadRequest_status_idx" ON "ResumeDownloadRequest"("status");
+
+-- CreateIndex
+CREATE INDEX "ResumeDownloadRequest_userId_createdAt_idx" ON "ResumeDownloadRequest"("userId", "createdAt");
+
+-- Row-Level Security: a user may see/act on their own requests (matched by the
+-- JWT email claim against `userEmail`); admins do everything. Defense-in-depth
+-- for any direct (PostgREST/anon) access; the app also enforces this.
+ALTER TABLE "ResumeDownloadRequest" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "ResumeDownloadRequest_self_or_admin_select" ON "ResumeDownloadRequest";
+CREATE POLICY "ResumeDownloadRequest_self_or_admin_select" ON "ResumeDownloadRequest" FOR SELECT USING (
+  current_setting('request.jwt.claims.email', true) = "userEmail" OR current_setting('request.jwt.claims.role', true) = 'admin'
+);
+
+DROP POLICY IF EXISTS "ResumeDownloadRequest_self_or_admin_insert" ON "ResumeDownloadRequest";
+CREATE POLICY "ResumeDownloadRequest_self_or_admin_insert" ON "ResumeDownloadRequest" FOR INSERT WITH CHECK (
+  current_setting('request.jwt.claims.email', true) = "userEmail" OR current_setting('request.jwt.claims.role', true) = 'admin'
+);
+
+DROP POLICY IF EXISTS "ResumeDownloadRequest_self_or_admin_update" ON "ResumeDownloadRequest";
+CREATE POLICY "ResumeDownloadRequest_self_or_admin_update" ON "ResumeDownloadRequest" FOR UPDATE USING (
+  current_setting('request.jwt.claims.email', true) = "userEmail" OR current_setting('request.jwt.claims.role', true) = 'admin'
+) WITH CHECK (
+  current_setting('request.jwt.claims.email', true) = "userEmail" OR current_setting('request.jwt.claims.role', true) = 'admin'
+);
+
+DROP POLICY IF EXISTS "ResumeDownloadRequest_admin_delete" ON "ResumeDownloadRequest";
+CREATE POLICY "ResumeDownloadRequest_admin_delete" ON "ResumeDownloadRequest" FOR DELETE USING (
+  current_setting('request.jwt.claims.role', true) = 'admin'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,14 @@ enum ArticleStatus {
   published
 }
 
+enum ResumeDownloadStatus {
+  pending
+  approved
+  denied
+  fulfilled
+  expired
+}
+
 enum BetStatus {
   PENDING
   WON
@@ -170,6 +178,28 @@ model Article {
 
   @@index([status])
   @@index([publishedAt])
+}
+
+// Gated résumé-download flow for bryandebaun.dev (#139). A user requests the
+// contact-bearing ("full") résumé; an admin approves/denies; an approval grants a
+// time-limited (72h) download window. Private data — admin + owner only at the RLS
+// layer. `expired` is computed lazily at read time (no scheduler); persisted status
+// stays approved/fulfilled until an admin or a read transitions it.
+model ResumeDownloadRequest {
+  id            String               @id @default(cuid())
+  userId        String
+  userEmail     String
+  reason        String?
+  status        ResumeDownloadStatus @default(pending)
+  adminNote     String?
+  downloadCount Int                  @default(0)
+  createdAt     DateTime             @default(now())
+  approvedAt    DateTime?
+  expiresAt     DateTime?
+
+  @@index([userId])
+  @@index([status])
+  @@index([userId, createdAt]) // supports the 3-per-trailing-30-days quota count
 }
 
 // Personal sports-betting tracker. Core purpose: compare bets made on intuition

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -29,6 +29,7 @@ const MODEL_NAMES = [
     'videoGame',
     'contentCreator',
     'article',
+    'resumeDownloadRequest',
     'bet',
     'rating',
 ] as const
@@ -39,6 +40,7 @@ function makeStubModel(fail: () => never) {
         findMany: async (_opts?: any) => [],
         findUnique: async (_opts?: any) => null,
         findFirst: async (_opts?: any) => null,
+        count: async (_opts?: any) => 0,
         create: async (_data?: any) => fail(),
         update: async (_opts?: any) => fail(),
         upsert: async (_opts?: any) => fail(),

--- a/src/http/controllers/ResumeDownloadRequestsController.ts
+++ b/src/http/controllers/ResumeDownloadRequestsController.ts
@@ -1,0 +1,245 @@
+import type { Request as ExpressRequest } from 'express'
+import {
+    Body,
+    Controller,
+    Get,
+    Patch,
+    Path,
+    Post,
+    Query,
+    Request,
+    Response,
+    Route,
+    Security,
+    SuccessResponse,
+    Tags,
+} from 'tsoa'
+import { callTool } from '../../tools/local.js'
+import {
+    httpError,
+    isInvalidState,
+    isNotFound,
+    isQuotaExceeded,
+} from './_http-errors.js'
+
+export type ResumeDownloadStatus =
+    | 'pending'
+    | 'approved'
+    | 'denied'
+    | 'fulfilled'
+    | 'expired'
+/** List filter; `all` returns every status. */
+export type ResumeDownloadReadStatus = ResumeDownloadStatus | 'all'
+
+export interface ResumeDownloadRequest {
+    id: string
+    userId: string
+    userEmail: string
+    reason?: string | null
+    status: ResumeDownloadStatus
+    adminNote?: string | null
+    downloadCount: number
+    createdAt: string
+    approvedAt?: string | null
+    expiresAt?: string | null
+}
+
+export interface ListResumeDownloadRequestsResponse {
+    requests: ResumeDownloadRequest[]
+    total: number
+    limit: number
+    offset: number
+}
+
+export interface CreateResumeDownloadRequestBody {
+    /** Optional note from the user explaining the request. */
+    reason?: string
+}
+
+export interface AdminNoteBody {
+    /** Optional internal admin note. */
+    adminNote?: string
+}
+
+/**
+ * Backend for the gated résumé-download flow on bryandebaun.dev (#139).
+ *
+ * A signed-in user requests the contact-bearing résumé; an admin approves or
+ * denies; an approval grants a 72h download window. Identity (`userId`,
+ * `userEmail`) is always taken from the caller's verified JWT — never the body —
+ * so a user can only act on their own behalf.
+ */
+@Route('api/resumeDownloadRequests')
+@Tags('ResumeDownloadRequests')
+export class ResumeDownloadRequestsController extends Controller {
+    /**
+     * Create a résumé-download request for the authenticated user.
+     * Enforces a per-user quota (max 3 in the trailing 30 days) → 429.
+     */
+    @Post()
+    @Security('jwt')
+    @SuccessResponse('201', 'Request created')
+    @Response('401', 'Unauthorized')
+    @Response('429', 'Quota exceeded')
+    public async createRequest(
+        @Request() request: ExpressRequest,
+        @Body() body: CreateResumeDownloadRequestBody,
+    ): Promise<ResumeDownloadRequest> {
+        const { userId, userEmail } = this.requireUser(request)
+        try {
+            const result = await callTool('create-resume-download-request', {
+                userId,
+                userEmail,
+                reason: body?.reason,
+            })
+            this.setStatus(201)
+            return result as ResumeDownloadRequest
+        } catch (err: any) {
+            if (isQuotaExceeded(err)) throw httpError(429, err.message)
+            throw err
+        }
+    }
+
+    /**
+     * List résumé-download requests (admin).
+     * @param status Filter by stored status (default: all)
+     * @param userId Filter to a single user
+     * @param limit Maximum number of results (default 50)
+     * @param offset Number of results to skip (default 0)
+     */
+    @Get()
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Requests retrieved')
+    public async listRequests(
+        @Query() status?: ResumeDownloadReadStatus,
+        @Query() userId?: string,
+        @Query() limit?: number,
+        @Query() offset?: number,
+    ): Promise<ListResumeDownloadRequestsResponse> {
+        const result = await callTool('list-resume-download-requests', {
+            status,
+            userId,
+            limit,
+            offset,
+        })
+        return result as ListResumeDownloadRequestsResponse
+    }
+
+    /**
+     * Get a résumé-download request by id (admin).
+     * @param id Request id
+     */
+    @Get('{id}')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Request retrieved')
+    @Response('404', 'Request not found')
+    public async getRequest(
+        @Path() id: string,
+    ): Promise<ResumeDownloadRequest> {
+        try {
+            const result = await callTool('get-resume-download-request', { id })
+            return result as ResumeDownloadRequest
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Request not found')
+            throw err
+        }
+    }
+
+    /**
+     * Approve a pending request (admin). Sets approvedAt and a 72h window.
+     * @param id Request id
+     */
+    @Patch('{id}/approve')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Request approved')
+    @Response('404', 'Request not found')
+    @Response('409', 'Request is not pending')
+    public async approveRequest(
+        @Path() id: string,
+        @Body() body: AdminNoteBody,
+    ): Promise<ResumeDownloadRequest> {
+        try {
+            const result = await callTool('approve-resume-download-request', {
+                id,
+                adminNote: body?.adminNote,
+            })
+            return result as ResumeDownloadRequest
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Request not found')
+            if (isInvalidState(err)) throw httpError(409, err.message)
+            throw err
+        }
+    }
+
+    /**
+     * Deny a pending request (admin).
+     * @param id Request id
+     */
+    @Patch('{id}/deny')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Request denied')
+    @Response('404', 'Request not found')
+    @Response('409', 'Request is not pending')
+    public async denyRequest(
+        @Path() id: string,
+        @Body() body: AdminNoteBody,
+    ): Promise<ResumeDownloadRequest> {
+        try {
+            const result = await callTool('deny-resume-download-request', {
+                id,
+                adminNote: body?.adminNote,
+            })
+            return result as ResumeDownloadRequest
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Request not found')
+            if (isInvalidState(err)) throw httpError(409, err.message)
+            throw err
+        }
+    }
+
+    /**
+     * Record a download against the caller's own approved request. Increments
+     * downloadCount and flips status to fulfilled; only valid within the window.
+     * @param id Request id
+     */
+    @Patch('{id}/fulfill')
+    @Security('jwt')
+    @SuccessResponse('200', 'Download recorded')
+    @Response('401', 'Unauthorized')
+    @Response('404', 'Request not found')
+    @Response('409', 'Request is not approved or the window has expired')
+    public async fulfillRequest(
+        @Request() request: ExpressRequest,
+        @Path() id: string,
+    ): Promise<ResumeDownloadRequest> {
+        const { userId } = this.requireUser(request)
+        try {
+            const result = await callTool('fulfill-resume-download-request', {
+                id,
+                userId,
+            })
+            return result as ResumeDownloadRequest
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Request not found')
+            if (isInvalidState(err)) throw httpError(409, err.message)
+            throw err
+        }
+    }
+
+    /**
+     * Pull the caller's identity from the verified JWT that `expressAuthentication`
+     * attached to the request. `@Security('jwt')` guarantees a valid token; we
+     * still guard the claims we depend on.
+     */
+    private requireUser(request: ExpressRequest): {
+        userId: string
+        userEmail: string
+    } {
+        const user = (request as any).user
+        const userId: string | undefined = user?.sub
+        const userEmail: string | undefined = user?.email
+        if (!userId) throw httpError(401, 'Token missing subject claim')
+        if (!userEmail) throw httpError(400, 'Token missing email claim')
+        return { userId, userEmail }
+    }
+}

--- a/src/http/controllers/_http-errors.ts
+++ b/src/http/controllers/_http-errors.ts
@@ -20,6 +20,30 @@ export function isUniqueViolation(err: any): boolean {
     )
 }
 
+/** True when a tool error indicates a per-user quota was exceeded (→ 429). */
+export function isQuotaExceeded(err: any): boolean {
+    return (
+        typeof err?.message === 'string' &&
+        err.message.toLowerCase().includes('quota exceeded')
+    )
+}
+
+/**
+ * True when a tool error indicates the entity is in a state that forbids the
+ * requested transition (→ 409), e.g. approving a non-pending request or
+ * fulfilling an unapproved/expired one.
+ */
+export function isInvalidState(err: any): boolean {
+    const m = err?.message
+    if (typeof m !== 'string') return false
+    const lowered = m.toLowerCase()
+    return (
+        lowered.startsWith('cannot ') ||
+        lowered.includes('not approved') ||
+        lowered.includes('window has expired')
+    )
+}
+
 /** Create an Error carrying an HTTP status, for handlers that throw to the framework. */
 export function httpError(
     status: number,

--- a/src/tools/db/index.ts
+++ b/src/tools/db/index.ts
@@ -52,6 +52,15 @@ import {
     registerListMoviesTool,
     registerUpdateMovieTool,
 } from './movies/index.js'
+// Résumé-download-request tools (#139)
+import {
+    registerApproveResumeDownloadRequestTool,
+    registerCreateResumeDownloadRequestTool,
+    registerDenyResumeDownloadRequestTool,
+    registerFulfillResumeDownloadRequestTool,
+    registerGetResumeDownloadRequestTool,
+    registerListResumeDownloadRequestsTool,
+} from './resume-download-requests/index.js'
 // VideoGame tools
 import {
     registerCreateVideoGameTool,
@@ -107,6 +116,14 @@ export function registerDbTools(server: McpServer): void {
     registerDeleteArticleTool(server)
     registerGetArticleTool(server)
     registerListArticlesTool(server)
+
+    // Résumé-download-request tools (#139)
+    registerCreateResumeDownloadRequestTool(server)
+    registerListResumeDownloadRequestsTool(server)
+    registerGetResumeDownloadRequestTool(server)
+    registerApproveResumeDownloadRequestTool(server)
+    registerDenyResumeDownloadRequestTool(server)
+    registerFulfillResumeDownloadRequestTool(server)
 
     // Bet tools (sports-betting tracker)
     registerCreateBetTool(server)

--- a/src/tools/db/resume-download-requests/approve-resume-download-request.ts
+++ b/src/tools/db/resume-download-requests/approve-resume-download-request.ts
@@ -1,0 +1,69 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { RESUME_APPROVAL_WINDOW_HOURS } from './constants.js'
+import { ApproveResumeDownloadRequestInputSchema } from './schemas.js'
+
+const name = 'approve-resume-download-request'
+const config = {
+    title: 'Approve Résumé Download Request',
+    description:
+        'Approve a pending résumé-download request (admin). Sets approvedAt and a ' +
+        `${RESUME_APPROVAL_WINDOW_HOURS}h download window.`,
+    inputSchema: ApproveResumeDownloadRequestInputSchema,
+}
+
+export function registerApproveResumeDownloadRequestTool(
+    server: McpServer,
+): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { id, adminNote } = args
+                const existing = await prisma.resumeDownloadRequest.findUnique({
+                    where: { id },
+                })
+                if (!existing) {
+                    return createErrorResult(
+                        'Resume download request not found',
+                    )
+                }
+                if (existing.status !== 'pending') {
+                    return createErrorResult(
+                        `Cannot approve a request that is ${existing.status}`,
+                    )
+                }
+
+                const now = new Date()
+                const expiresAt = new Date(
+                    now.getTime() +
+                        RESUME_APPROVAL_WINDOW_HOURS * 60 * 60 * 1000,
+                )
+
+                const updated = await prisma.resumeDownloadRequest.update({
+                    where: { id },
+                    data: {
+                        status: 'approved',
+                        approvedAt: now,
+                        expiresAt,
+                        ...(adminNote !== undefined ? { adminNote } : {}),
+                    },
+                })
+
+                return createSuccessResult(updated)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/resume-download-requests/constants.ts
+++ b/src/tools/db/resume-download-requests/constants.ts
@@ -1,0 +1,8 @@
+// Shared constants for the gated résumé-download flow (#139).
+
+/** Max requests a single user may create within the trailing window. */
+export const RESUME_QUOTA_MAX = 3
+/** Trailing window (days) the quota is measured over. */
+export const RESUME_QUOTA_WINDOW_DAYS = 30
+/** Hours an approval stays downloadable before it expires. */
+export const RESUME_APPROVAL_WINDOW_HOURS = 72

--- a/src/tools/db/resume-download-requests/create-resume-download-request.ts
+++ b/src/tools/db/resume-download-requests/create-resume-download-request.ts
@@ -1,0 +1,63 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { RESUME_QUOTA_MAX, RESUME_QUOTA_WINDOW_DAYS } from './constants.js'
+import { CreateResumeDownloadRequestInputSchema } from './schemas.js'
+
+const name = 'create-resume-download-request'
+const config = {
+    title: 'Create Résumé Download Request',
+    description:
+        'Create a résumé-download request for a user. Enforces a per-user quota ' +
+        `(max ${RESUME_QUOTA_MAX} in the trailing ${RESUME_QUOTA_WINDOW_DAYS} days).`,
+    inputSchema: CreateResumeDownloadRequestInputSchema,
+}
+
+export function registerCreateResumeDownloadRequestTool(
+    server: McpServer,
+): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { userId, userEmail, reason } = args
+
+                // Server-side quota: reject if the user already has RESUME_QUOTA_MAX
+                // requests in the trailing window. The controller maps this to 429.
+                const windowStart = new Date(
+                    Date.now() - RESUME_QUOTA_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+                )
+                const recentCount = await prisma.resumeDownloadRequest.count({
+                    where: { userId, createdAt: { gte: windowStart } },
+                })
+                if (recentCount >= RESUME_QUOTA_MAX) {
+                    return createErrorResult(
+                        `Quota exceeded: at most ${RESUME_QUOTA_MAX} résumé-download requests per ${RESUME_QUOTA_WINDOW_DAYS} days`,
+                    )
+                }
+
+                const created = await prisma.resumeDownloadRequest.create({
+                    data: {
+                        userId,
+                        userEmail,
+                        reason: reason ?? null,
+                        status: 'pending',
+                    },
+                })
+
+                return createSuccessResult(created)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/resume-download-requests/deny-resume-download-request.ts
+++ b/src/tools/db/resume-download-requests/deny-resume-download-request.ts
@@ -1,0 +1,56 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { DenyResumeDownloadRequestInputSchema } from './schemas.js'
+
+const name = 'deny-resume-download-request'
+const config = {
+    title: 'Deny Résumé Download Request',
+    description: 'Deny a pending résumé-download request (admin).',
+    inputSchema: DenyResumeDownloadRequestInputSchema,
+}
+
+export function registerDenyResumeDownloadRequestTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { id, adminNote } = args
+                const existing = await prisma.resumeDownloadRequest.findUnique({
+                    where: { id },
+                })
+                if (!existing) {
+                    return createErrorResult(
+                        'Resume download request not found',
+                    )
+                }
+                if (existing.status !== 'pending') {
+                    return createErrorResult(
+                        `Cannot deny a request that is ${existing.status}`,
+                    )
+                }
+
+                const updated = await prisma.resumeDownloadRequest.update({
+                    where: { id },
+                    data: {
+                        status: 'denied',
+                        ...(adminNote !== undefined ? { adminNote } : {}),
+                    },
+                })
+
+                return createSuccessResult(updated)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/resume-download-requests/expiry.ts
+++ b/src/tools/db/resume-download-requests/expiry.ts
@@ -1,0 +1,23 @@
+// Lazy expiry: an `approved` request whose 72h window has elapsed is treated as
+// `expired` at read time. The service has no scheduler, so we never persist the
+// `expired` transition — reads derive it. Persisted status stays `approved` (or
+// `fulfilled`) so an admin can still see when/why it was granted.
+
+type ExpirableRequest = { status: string; expiresAt: Date | string | null }
+
+/** True when an approved request's download window has elapsed. */
+export function isExpired(
+    req: ExpirableRequest,
+    now: number = Date.now(),
+): boolean {
+    if (req.status !== 'approved' || !req.expiresAt) return false
+    return new Date(req.expiresAt).getTime() < now
+}
+
+/** Return the request with its effective (lazily-computed) status for display. */
+export function withEffectiveStatus<T extends ExpirableRequest>(
+    req: T,
+    now: number = Date.now(),
+): T {
+    return isExpired(req, now) ? { ...req, status: 'expired' } : req
+}

--- a/src/tools/db/resume-download-requests/fulfill-resume-download-request.ts
+++ b/src/tools/db/resume-download-requests/fulfill-resume-download-request.ts
@@ -1,0 +1,73 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { FulfillResumeDownloadRequestInputSchema } from './schemas.js'
+
+const name = 'fulfill-resume-download-request'
+const config = {
+    title: 'Fulfill Résumé Download Request',
+    description:
+        'Record a download against an approved request (owner only). Increments ' +
+        'downloadCount and flips status to fulfilled; allowed only within the ' +
+        'approval window.',
+    inputSchema: FulfillResumeDownloadRequestInputSchema,
+}
+
+export function registerFulfillResumeDownloadRequestTool(
+    server: McpServer,
+): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { id, userId } = args
+                const existing = await prisma.resumeDownloadRequest.findUnique({
+                    where: { id },
+                })
+                // Ownership mismatch is reported as not-found so a user can't probe
+                // for other users' request ids.
+                if (!existing || existing.userId !== userId) {
+                    return createErrorResult(
+                        'Resume download request not found',
+                    )
+                }
+
+                if (
+                    existing.status !== 'approved' &&
+                    existing.status !== 'fulfilled'
+                ) {
+                    return createErrorResult(
+                        'Request is not approved for download',
+                    )
+                }
+                if (
+                    !existing.expiresAt ||
+                    new Date(existing.expiresAt).getTime() < Date.now()
+                ) {
+                    return createErrorResult('Download window has expired')
+                }
+
+                const updated = await prisma.resumeDownloadRequest.update({
+                    where: { id },
+                    data: {
+                        status: 'fulfilled',
+                        downloadCount: { increment: 1 },
+                    },
+                })
+
+                return createSuccessResult(updated)
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/resume-download-requests/get-resume-download-request.ts
+++ b/src/tools/db/resume-download-requests/get-resume-download-request.ts
@@ -1,0 +1,43 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { withEffectiveStatus } from './expiry.js'
+import { GetResumeDownloadRequestInputSchema } from './schemas.js'
+
+const name = 'get-resume-download-request'
+const config = {
+    title: 'Get Résumé Download Request',
+    description: 'Get a résumé-download request by id (admin).',
+    inputSchema: GetResumeDownloadRequestInputSchema,
+}
+
+export function registerGetResumeDownloadRequestTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { id } = args
+                const request = await prisma.resumeDownloadRequest.findUnique({
+                    where: { id },
+                })
+                if (!request) {
+                    return createErrorResult(
+                        'Resume download request not found',
+                    )
+                }
+                return createSuccessResult(withEffectiveStatus(request))
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/resume-download-requests/index.ts
+++ b/src/tools/db/resume-download-requests/index.ts
@@ -1,0 +1,6 @@
+export { registerApproveResumeDownloadRequestTool } from './approve-resume-download-request.js'
+export { registerCreateResumeDownloadRequestTool } from './create-resume-download-request.js'
+export { registerDenyResumeDownloadRequestTool } from './deny-resume-download-request.js'
+export { registerFulfillResumeDownloadRequestTool } from './fulfill-resume-download-request.js'
+export { registerGetResumeDownloadRequestTool } from './get-resume-download-request.js'
+export { registerListResumeDownloadRequestsTool } from './list-resume-download-requests.js'

--- a/src/tools/db/resume-download-requests/list-resume-download-requests.ts
+++ b/src/tools/db/resume-download-requests/list-resume-download-requests.ts
@@ -1,0 +1,59 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { withEffectiveStatus } from './expiry.js'
+import { ListResumeDownloadRequestsInputSchema } from './schemas.js'
+
+const name = 'list-resume-download-requests'
+const config = {
+    title: 'List Résumé Download Requests',
+    description:
+        'List résumé-download requests (admin). Filter by stored status and/or user. ' +
+        'Output status reflects lazy expiry (an approved row past its window shows as expired).',
+    inputSchema: ListResumeDownloadRequestsInputSchema,
+}
+
+export function registerListResumeDownloadRequestsTool(
+    server: McpServer,
+): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const { status, userId, limit = 50, offset = 0 } = args
+
+                // Filter operates on the stored status; `all`/undefined = no filter.
+                const where: any = {}
+                if (status && status !== 'all') where.status = status
+                if (userId) where.userId = userId
+
+                const rows = await prisma.resumeDownloadRequest.findMany({
+                    where,
+                    take: limit,
+                    skip: offset,
+                    orderBy: { createdAt: 'desc' },
+                })
+
+                const requests = rows.map((r: any) => withEffectiveStatus(r))
+
+                return createSuccessResult({
+                    requests,
+                    total: requests.length,
+                    limit,
+                    offset,
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/resume-download-requests/schemas.ts
+++ b/src/tools/db/resume-download-requests/schemas.ts
@@ -1,0 +1,69 @@
+// Input schemas for résumé-download-request MCP tools (#139)
+import { z } from 'zod'
+
+/** Persisted statuses; `all` is a read-filter convenience meaning "no filter". */
+export const ResumeDownloadStatusEnum = z.enum([
+    'pending',
+    'approved',
+    'denied',
+    'fulfilled',
+    'expired',
+])
+export const ResumeDownloadReadStatusEnum = z.enum([
+    'pending',
+    'approved',
+    'denied',
+    'fulfilled',
+    'expired',
+    'all',
+])
+
+// `userId` / `userEmail` identify the requester. On the REST surface the
+// controller injects these from the caller's verified JWT (never the body); as
+// raw tool inputs they are explicit so the MCP surface stays a pure function.
+export const CreateResumeDownloadRequestInputSchema = {
+    userId: z
+        .string()
+        .describe('Requesting user id (Supabase auth UUID / JWT sub)'),
+    userEmail: z.string().describe('Requesting user email'),
+    reason: z
+        .string()
+        .optional()
+        .describe('Optional note from the user explaining the request'),
+}
+
+export const ListResumeDownloadRequestsInputSchema = {
+    status: ResumeDownloadReadStatusEnum.optional().describe(
+        'Filter by stored status (default: all)',
+    ),
+    userId: z.string().optional().describe('Filter to a single user'),
+    limit: z
+        .number()
+        .optional()
+        .describe('Maximum number of results (default 50)'),
+    offset: z
+        .number()
+        .optional()
+        .describe('Number of results to skip (default 0)'),
+}
+
+export const GetResumeDownloadRequestInputSchema = {
+    id: z.string().describe('Request id'),
+}
+
+export const ApproveResumeDownloadRequestInputSchema = {
+    id: z.string().describe('Request id to approve'),
+    adminNote: z.string().optional().describe('Optional internal admin note'),
+}
+
+export const DenyResumeDownloadRequestInputSchema = {
+    id: z.string().describe('Request id to deny'),
+    adminNote: z.string().optional().describe('Optional internal admin note'),
+}
+
+// `userId` scopes the fulfillment to the owner: the REST controller passes the
+// caller's JWT sub so a user can only fulfill their own approved request.
+export const FulfillResumeDownloadRequestInputSchema = {
+    id: z.string().describe('Request id to fulfill (record a download)'),
+    userId: z.string().describe('Owning user id; must match the request owner'),
+}

--- a/test/http/resume-download-requests-controller.test.ts
+++ b/test/http/resume-download-requests-controller.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the tool layer so we can assert the controller's identity-injection and
+// error-mapping logic in isolation (no DB, no JWKS).
+vi.mock('../../src/tools/local.js', () => ({ callTool: vi.fn() }))
+
+import { ResumeDownloadRequestsController } from '../../src/http/controllers/ResumeDownloadRequestsController'
+import { callTool } from '../../src/tools/local.js'
+
+const mockCallTool = callTool as unknown as ReturnType<typeof vi.fn>
+
+// expressAuthentication attaches the verified JWT to request.user.
+const reqAs = (user: any) => ({ headers: {}, user }) as any
+
+describe('ResumeDownloadRequestsController — create (#139)', () => {
+    beforeEach(() => {
+        mockCallTool.mockReset()
+        mockCallTool.mockResolvedValue({ id: 'r1', status: 'pending' })
+    })
+
+    it('injects userId/userEmail from the JWT, not the body', async () => {
+        await new ResumeDownloadRequestsController().createRequest(
+            reqAs({ sub: 'user-123', email: 'a@b.com' }),
+            { reason: 'applying' },
+        )
+        expect(mockCallTool).toHaveBeenCalledWith(
+            'create-resume-download-request',
+            { userId: 'user-123', userEmail: 'a@b.com', reason: 'applying' },
+        )
+    })
+
+    it('maps a quota error to 429', async () => {
+        mockCallTool.mockRejectedValueOnce(
+            new Error('Quota exceeded: at most 3 per 30 days'),
+        )
+        await expect(
+            new ResumeDownloadRequestsController().createRequest(
+                reqAs({ sub: 'user-123', email: 'a@b.com' }),
+                {},
+            ),
+        ).rejects.toMatchObject({ status: 429 })
+    })
+
+    it('401s when the token has no subject', async () => {
+        await expect(
+            new ResumeDownloadRequestsController().createRequest(
+                reqAs({ email: 'a@b.com' }),
+                {},
+            ),
+        ).rejects.toMatchObject({ status: 401 })
+    })
+
+    it('400s when the token has no email', async () => {
+        await expect(
+            new ResumeDownloadRequestsController().createRequest(
+                reqAs({ sub: 'user-123' }),
+                {},
+            ),
+        ).rejects.toMatchObject({ status: 400 })
+    })
+})
+
+describe('ResumeDownloadRequestsController — admin actions', () => {
+    beforeEach(() => {
+        mockCallTool.mockReset()
+    })
+
+    it('passes list filters through to the tool', async () => {
+        mockCallTool.mockResolvedValueOnce({
+            requests: [],
+            total: 0,
+            limit: 50,
+            offset: 0,
+        })
+        await new ResumeDownloadRequestsController().listRequests(
+            'pending',
+            'u1',
+            10,
+            5,
+        )
+        expect(mockCallTool).toHaveBeenCalledWith(
+            'list-resume-download-requests',
+            { status: 'pending', userId: 'u1', limit: 10, offset: 5 },
+        )
+    })
+
+    it('approve maps not-found to 404', async () => {
+        mockCallTool.mockRejectedValueOnce(
+            new Error('Resume download request not found'),
+        )
+        await expect(
+            new ResumeDownloadRequestsController().approveRequest('nope', {}),
+        ).rejects.toMatchObject({ status: 404 })
+    })
+
+    it('approve maps an invalid-state error to 409', async () => {
+        mockCallTool.mockRejectedValueOnce(
+            new Error('Cannot approve a request that is denied'),
+        )
+        await expect(
+            new ResumeDownloadRequestsController().approveRequest('r1', {}),
+        ).rejects.toMatchObject({ status: 409 })
+    })
+})
+
+describe('ResumeDownloadRequestsController — fulfill (owner)', () => {
+    beforeEach(() => {
+        mockCallTool.mockReset()
+    })
+
+    it('injects the caller id from the JWT and records the download', async () => {
+        mockCallTool.mockResolvedValueOnce({
+            id: 'r1',
+            status: 'fulfilled',
+            downloadCount: 1,
+        })
+        await new ResumeDownloadRequestsController().fulfillRequest(
+            reqAs({ sub: 'user-123', email: 'a@b.com' }),
+            'r1',
+        )
+        expect(mockCallTool).toHaveBeenCalledWith(
+            'fulfill-resume-download-request',
+            { id: 'r1', userId: 'user-123' },
+        )
+    })
+
+    it('maps an expired/not-approved error to 409', async () => {
+        mockCallTool.mockRejectedValueOnce(
+            new Error('Download window has expired'),
+        )
+        await expect(
+            new ResumeDownloadRequestsController().fulfillRequest(
+                reqAs({ sub: 'user-123', email: 'a@b.com' }),
+                'r1',
+            ),
+        ).rejects.toMatchObject({ status: 409 })
+    })
+})

--- a/test/tools/db/resume-download-requests/resume-download-requests-tools.test.ts
+++ b/test/tools/db/resume-download-requests/resume-download-requests-tools.test.ts
@@ -1,0 +1,253 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the shared prisma object's `resumeDownloadRequest` model so tool handlers
+// are deterministic without a database (mirrors the no-op stub contract).
+vi.mock('../../../../src/db/index', () => ({
+    prisma: {
+        resumeDownloadRequest: {
+            count: vi.fn(),
+            findMany: vi.fn(),
+            findUnique: vi.fn(),
+            create: vi.fn(),
+            update: vi.fn(),
+        },
+    },
+}))
+
+import { prisma } from '../../../../src/db/index.js'
+import { registerApproveResumeDownloadRequestTool } from '../../../../src/tools/db/resume-download-requests/approve-resume-download-request.js'
+import { registerCreateResumeDownloadRequestTool } from '../../../../src/tools/db/resume-download-requests/create-resume-download-request.js'
+import { registerDenyResumeDownloadRequestTool } from '../../../../src/tools/db/resume-download-requests/deny-resume-download-request.js'
+import { registerFulfillResumeDownloadRequestTool } from '../../../../src/tools/db/resume-download-requests/fulfill-resume-download-request.js'
+import { registerGetResumeDownloadRequestTool } from '../../../../src/tools/db/resume-download-requests/get-resume-download-request.js'
+import { registerListResumeDownloadRequestsTool } from '../../../../src/tools/db/resume-download-requests/list-resume-download-requests.js'
+
+const rdr = (prisma as any).resumeDownloadRequest as Record<
+    string,
+    ReturnType<typeof vi.fn>
+>
+
+const handlers = new Map<string, (args: any) => Promise<any>>()
+const fake: any = {
+    registerTool: (name: string, _cfg: any, handler: any) =>
+        handlers.set(name, handler),
+}
+
+const call = async (name: string, args: any) => {
+    const res = await handlers.get(name)!(args)
+    const text = res.content[0].text
+    let data: any
+    try {
+        data = JSON.parse(text)
+    } catch {
+        data = text // error results carry a plain "Error: ..." string
+    }
+    return { isError: !!res.isError, data }
+}
+
+const future = () => new Date(Date.now() + 60 * 60 * 1000)
+const past = () => new Date(Date.now() - 60 * 60 * 1000)
+
+beforeAll(() => {
+    registerCreateResumeDownloadRequestTool(fake)
+    registerListResumeDownloadRequestsTool(fake)
+    registerGetResumeDownloadRequestTool(fake)
+    registerApproveResumeDownloadRequestTool(fake)
+    registerDenyResumeDownloadRequestTool(fake)
+    registerFulfillResumeDownloadRequestTool(fake)
+})
+
+beforeEach(() => {
+    for (const fn of Object.values(rdr)) fn.mockReset()
+})
+
+describe('resume-download-request tools — create (quota)', () => {
+    it('creates a pending request when under quota', async () => {
+        rdr.count.mockResolvedValueOnce(2)
+        rdr.create.mockImplementation(async ({ data }: any) => ({
+            id: 'r1',
+            ...data,
+        }))
+        const { isError, data } = await call('create-resume-download-request', {
+            userId: 'u1',
+            userEmail: 'u1@example.com',
+            reason: 'applying',
+        })
+        expect(isError).toBe(false)
+        expect(data.status).toBe('pending')
+        expect(data.userId).toBe('u1')
+        // Quota counts this user's requests within a trailing window.
+        const where = rdr.count.mock.calls[0][0].where
+        expect(where.userId).toBe('u1')
+        expect(where.createdAt.gte).toBeInstanceOf(Date)
+    })
+
+    it('rejects with a quota error at the limit (3 in 30 days)', async () => {
+        rdr.count.mockResolvedValueOnce(3)
+        const { isError, data } = await call('create-resume-download-request', {
+            userId: 'u1',
+            userEmail: 'u1@example.com',
+        })
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/quota exceeded/i)
+        expect(rdr.create).not.toHaveBeenCalled()
+    })
+})
+
+describe('resume-download-request tools — list (lazy expiry)', () => {
+    it('filters by stored status and maps an expired-approved row on output', async () => {
+        rdr.findMany.mockResolvedValueOnce([
+            { id: 'a', status: 'approved', expiresAt: past() },
+            { id: 'b', status: 'pending', expiresAt: null },
+        ])
+        const { data } = await call('list-resume-download-requests', {
+            status: 'approved',
+        })
+        expect(rdr.findMany.mock.calls[0][0].where).toMatchObject({
+            status: 'approved',
+        })
+        expect(data.requests[0].status).toBe('expired') // approved + past window
+        expect(data.requests[1].status).toBe('pending')
+    })
+
+    it('applies no status filter for status=all', async () => {
+        rdr.findMany.mockResolvedValueOnce([])
+        await call('list-resume-download-requests', { status: 'all' })
+        expect(rdr.findMany.mock.calls[0][0].where.status).toBeUndefined()
+    })
+})
+
+describe('resume-download-request tools — get', () => {
+    it('404s a missing request', async () => {
+        rdr.findUnique.mockResolvedValueOnce(null)
+        const { isError, data } = await call('get-resume-download-request', {
+            id: 'nope',
+        })
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/not found/i)
+    })
+
+    it('reports an approved-but-expired request as expired', async () => {
+        rdr.findUnique.mockResolvedValueOnce({
+            id: 'x',
+            status: 'approved',
+            expiresAt: past(),
+        })
+        const { data } = await call('get-resume-download-request', { id: 'x' })
+        expect(data.status).toBe('expired')
+    })
+})
+
+describe('resume-download-request tools — approve/deny', () => {
+    it('approve sets approvedAt + a 72h window on a pending request', async () => {
+        rdr.findUnique.mockResolvedValueOnce({ id: 'r1', status: 'pending' })
+        rdr.update.mockImplementation(async ({ data }: any) => ({
+            id: 'r1',
+            ...data,
+        }))
+        const { data } = await call('approve-resume-download-request', {
+            id: 'r1',
+        })
+        expect(data.status).toBe('approved')
+        const window =
+            new Date(data.expiresAt).getTime() -
+            new Date(data.approvedAt).getTime()
+        expect(window).toBe(72 * 60 * 60 * 1000)
+    })
+
+    it('approve rejects a non-pending request', async () => {
+        rdr.findUnique.mockResolvedValueOnce({ id: 'r1', status: 'approved' })
+        const { isError, data } = await call(
+            'approve-resume-download-request',
+            { id: 'r1' },
+        )
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/cannot approve/i)
+        expect(rdr.update).not.toHaveBeenCalled()
+    })
+
+    it('deny marks a pending request denied', async () => {
+        rdr.findUnique.mockResolvedValueOnce({ id: 'r1', status: 'pending' })
+        rdr.update.mockImplementation(async ({ data }: any) => ({
+            id: 'r1',
+            ...data,
+        }))
+        const { data } = await call('deny-resume-download-request', {
+            id: 'r1',
+            adminNote: 'no',
+        })
+        expect(data.status).toBe('denied')
+        expect(data.adminNote).toBe('no')
+    })
+})
+
+describe('resume-download-request tools — fulfill (owner + window)', () => {
+    it('404s when the request belongs to another user', async () => {
+        rdr.findUnique.mockResolvedValueOnce({
+            id: 'r1',
+            userId: 'someone-else',
+            status: 'approved',
+            expiresAt: future(),
+        })
+        const { isError, data } = await call(
+            'fulfill-resume-download-request',
+            { id: 'r1', userId: 'u1' },
+        )
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/not found/i)
+        expect(rdr.update).not.toHaveBeenCalled()
+    })
+
+    it('rejects a request that is not approved', async () => {
+        rdr.findUnique.mockResolvedValueOnce({
+            id: 'r1',
+            userId: 'u1',
+            status: 'pending',
+            expiresAt: future(),
+        })
+        const { isError, data } = await call(
+            'fulfill-resume-download-request',
+            { id: 'r1', userId: 'u1' },
+        )
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/not approved/i)
+    })
+
+    it('rejects once the download window has expired', async () => {
+        rdr.findUnique.mockResolvedValueOnce({
+            id: 'r1',
+            userId: 'u1',
+            status: 'approved',
+            expiresAt: past(),
+        })
+        const { isError, data } = await call(
+            'fulfill-resume-download-request',
+            { id: 'r1', userId: 'u1' },
+        )
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/window has expired/i)
+    })
+
+    it('records a download: increments count and flips to fulfilled', async () => {
+        rdr.findUnique.mockResolvedValueOnce({
+            id: 'r1',
+            userId: 'u1',
+            status: 'approved',
+            expiresAt: future(),
+        })
+        rdr.update.mockImplementation(async ({ data }: any) => ({
+            id: 'r1',
+            userId: 'u1',
+            ...data,
+        }))
+        const { isError, data } = await call(
+            'fulfill-resume-download-request',
+            { id: 'r1', userId: 'u1' },
+        )
+        expect(isError).toBe(false)
+        expect(data.status).toBe('fulfilled')
+        const arg = rdr.update.mock.calls[0][0]
+        expect(arg.where).toEqual({ id: 'r1' })
+        expect(arg.data.downloadCount).toEqual({ increment: 1 })
+    })
+})

--- a/tools/bruno/ResumeDownloadRequests/ApproveRequest.bru
+++ b/tools/bruno/ResumeDownloadRequests/ApproveRequest.bru
@@ -1,0 +1,149 @@
+meta {
+  name: ApproveRequest
+  type: http
+  seq: 4
+  tags: [
+    ResumeDownloadRequests
+  ]
+}
+
+patch {
+  url: {{baseUrl}}/api/resumeDownloadRequests/:id/approve
+  body: json
+  auth: bearer
+}
+
+params:path {
+  id: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "adminNote": ""
+  }
+}
+
+docs {
+  Approve a pending request (admin). Sets approvedAt and a 72h window.
+}
+
+example {
+  name: 200 Response
+  description: Request approved
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/approve
+    method: PATCH
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "adminNote": ""
+      }
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": "",
+          "userId": "",
+          "userEmail": "",
+          "reason": "",
+          "status": "pending",
+          "adminNote": "",
+          "downloadCount": 0,
+          "createdAt": "",
+          "approvedAt": "",
+          "expiresAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Request not found
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/approve
+    method: PATCH
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "adminNote": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 409 Response
+  description: Request is not pending
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/approve
+    method: PATCH
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "adminNote": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 409
+      text: Conflict
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/ResumeDownloadRequests/CreateRequest.bru
+++ b/tools/bruno/ResumeDownloadRequests/CreateRequest.bru
@@ -1,0 +1,134 @@
+meta {
+  name: CreateRequest
+  type: http
+  seq: 1
+  tags: [
+    ResumeDownloadRequests
+  ]
+}
+
+post {
+  url: {{baseUrl}}/api/resumeDownloadRequests
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "reason": ""
+  }
+}
+
+docs {
+  Create a résumé-download request for the authenticated user.
+  Enforces a per-user quota (max 3 in the trailing 30 days) → 429.
+}
+
+example {
+  name: 201 Response
+  description: Request created
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests
+    method: POST
+    mode: json
+    body:json: {
+      {
+        "reason": ""
+      }
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 201
+      text: Created
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": "",
+          "userId": "",
+          "userEmail": "",
+          "reason": "",
+          "status": "pending",
+          "adminNote": "",
+          "downloadCount": 0,
+          "createdAt": "",
+          "approvedAt": "",
+          "expiresAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 401 Response
+  description: Unauthorized
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests
+    method: POST
+    mode: json
+    body:json: {
+      {
+        "reason": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 401
+      text: Unauthorized
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 429 Response
+  description: Quota exceeded
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests
+    method: POST
+    mode: json
+    body:json: {
+      {
+        "reason": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 429
+      text: Too Many Requests
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/ResumeDownloadRequests/DenyRequest.bru
+++ b/tools/bruno/ResumeDownloadRequests/DenyRequest.bru
@@ -1,0 +1,149 @@
+meta {
+  name: DenyRequest
+  type: http
+  seq: 5
+  tags: [
+    ResumeDownloadRequests
+  ]
+}
+
+patch {
+  url: {{baseUrl}}/api/resumeDownloadRequests/:id/deny
+  body: json
+  auth: bearer
+}
+
+params:path {
+  id: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "adminNote": ""
+  }
+}
+
+docs {
+  Deny a pending request (admin).
+}
+
+example {
+  name: 200 Response
+  description: Request denied
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/deny
+    method: PATCH
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "adminNote": ""
+      }
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": "",
+          "userId": "",
+          "userEmail": "",
+          "reason": "",
+          "status": "pending",
+          "adminNote": "",
+          "downloadCount": 0,
+          "createdAt": "",
+          "approvedAt": "",
+          "expiresAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Request not found
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/deny
+    method: PATCH
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "adminNote": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 409 Response
+  description: Request is not pending
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/deny
+    method: PATCH
+    mode: json
+    params:path: {
+      id: 
+    }
+  
+    body:json: {
+      {
+        "adminNote": ""
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 409
+      text: Conflict
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/ResumeDownloadRequests/FulfillRequest.bru
+++ b/tools/bruno/ResumeDownloadRequests/FulfillRequest.bru
@@ -1,0 +1,154 @@
+meta {
+  name: FulfillRequest
+  type: http
+  seq: 6
+  tags: [
+    ResumeDownloadRequests
+  ]
+}
+
+patch {
+  url: {{baseUrl}}/api/resumeDownloadRequests/:id/fulfill
+  body: none
+  auth: bearer
+}
+
+params:path {
+  id: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Record a download against the caller's own approved request. Increments
+  downloadCount and flips status to fulfilled; only valid within the window.
+}
+
+example {
+  name: 200 Response
+  description: Download recorded
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/fulfill
+    method: PATCH
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": "",
+          "userId": "",
+          "userEmail": "",
+          "reason": "",
+          "status": "pending",
+          "adminNote": "",
+          "downloadCount": 0,
+          "createdAt": "",
+          "approvedAt": "",
+          "expiresAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 401 Response
+  description: Unauthorized
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/fulfill
+    method: PATCH
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    status: {
+      code: 401
+      text: Unauthorized
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Request not found
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/fulfill
+    method: PATCH
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 409 Response
+  description: Request is not approved or the window has expired
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id/fulfill
+    method: PATCH
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    status: {
+      code: 409
+      text: Conflict
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/ResumeDownloadRequests/GetRequest.bru
+++ b/tools/bruno/ResumeDownloadRequests/GetRequest.bru
@@ -1,0 +1,97 @@
+meta {
+  name: GetRequest
+  type: http
+  seq: 3
+  tags: [
+    ResumeDownloadRequests
+  ]
+}
+
+get {
+  url: {{baseUrl}}/api/resumeDownloadRequests/:id
+  body: none
+  auth: bearer
+}
+
+params:path {
+  id: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  Get a résumé-download request by id (admin).
+}
+
+example {
+  name: 200 Response
+  description: Request retrieved
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id
+    method: GET
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "id": "",
+          "userId": "",
+          "userEmail": "",
+          "reason": "",
+          "status": "pending",
+          "adminNote": "",
+          "downloadCount": 0,
+          "createdAt": "",
+          "approvedAt": "",
+          "expiresAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Request not found
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests/:id
+    method: GET
+    mode: none
+    params:path: {
+      id: 
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/ResumeDownloadRequests/ListRequests.bru
+++ b/tools/bruno/ResumeDownloadRequests/ListRequests.bru
@@ -1,0 +1,82 @@
+meta {
+  name: ListRequests
+  type: http
+  seq: 2
+  tags: [
+    ResumeDownloadRequests
+  ]
+}
+
+get {
+  url: {{baseUrl}}/api/resumeDownloadRequests
+  body: none
+  auth: bearer
+}
+
+params:query {
+  ~status: 
+  ~userId: 
+  ~limit: 
+  ~offset: 
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+docs {
+  List résumé-download requests (admin).
+}
+
+example {
+  name: 200 Response
+  description: Requests retrieved
+  
+  request: {
+    url: {{baseUrl}}/api/resumeDownloadRequests
+    method: GET
+    mode: none
+    params:query: {
+      ~status: 
+      ~userId: 
+      ~limit: 
+      ~offset: 
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "requests": [
+            {
+              "id": "",
+              "userId": "",
+              "userEmail": "",
+              "reason": "",
+              "status": "pending",
+              "adminNote": "",
+              "downloadCount": 0,
+              "createdAt": "",
+              "approvedAt": "",
+              "expiresAt": ""
+            }
+          ],
+          "total": 0,
+          "limit": 0,
+          "offset": 0
+        }
+      '''
+    }
+  }
+}

--- a/tools/bruno/ResumeDownloadRequests/folder.bru
+++ b/tools/bruno/ResumeDownloadRequests/folder.bru
@@ -1,0 +1,7 @@
+meta {
+  name: ResumeDownloadRequests
+}
+
+auth {
+  mode: inherit
+}


### PR DESCRIPTION
Closes #139.

Backend for the gated résumé-download flow on bryandebaun.dev — a signed-in user requests the contact-bearing résumé, an admin approves/denies, and an approval grants a 72h download window. Mirrors the `Article` resource pattern (one tool implementation, two surfaces).

## What's included
- **Prisma** — `ResumeDownloadStatus` enum + `ResumeDownloadRequest` model (cuid id). Migration with owner-or-admin **RLS** mirroring the existing `AccessRequest` pattern (matched by the JWT email claim); defense-in-depth alongside app-layer authz.
- **MCP tools** (`src/tools/db/resume-download-requests/`) — `create` (server-side quota: **max 3 in the trailing 30 days**), `list`, `get`, `approve` (sets `approvedAt` + a 72h `expiresAt`), `deny`, `fulfill` (owner-only; records a download within the window). **Expiry is computed lazily at read time** — the service has no scheduler, so `expired` is never persisted.
- **REST** (`ResumeDownloadRequestsController.ts`) — `POST` (any authenticated user; `userId`/`userEmail` taken from the **verified JWT, never the body**) + admin `GET`/`approve`/`deny` + owner `fulfill`. Error mapping: quota → **429**, invalid-state transition → **409**, not-found → **404**.
- **DB-less stub** for the new model + a `count` stub method (the repo's stub-drift guard test enforces this).
- **Tests** — 13 tool + 9 controller unit tests. tsoa spec + Bruno collection regenerated.
- Incidental: adds an `env:pull` script (Doppler → `.env.local`).

## Verification
- `pnpm typecheck` exit 0 · `pnpm test` **322 passed / 5 env-gated skips / 0 failed** · migration syntax-checked via `sql:parse`.

## Notes / follow-ups
- **Migration not yet applied to a live DB locally** (local Docker Postgres pull was failing with transient registry errors). The **db-integration CI job applies it via `migrate deploy`** on this PR.
- **ADR-0007 assumption**: `fulfill` is owner-scoped (user JWT). If the website records downloads server-side via the gateway key instead, revisit that endpoint's security.
- **Cross-repo**: the issue's "generated client picked up by the website (`packages/mcp-client`)" is done in `bryandebaun.dev` after this merges — not in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)