### PR TITLE
feat(resume): DB-backed singleton résumé content resource (#147)

### DIFF
--- a/prisma/migrations/20260703140000_add_resume_content/migration.sql
+++ b/prisma/migrations/20260703140000_add_resume_content/migration.sql
@@ -1,0 +1,29 @@
+-- Add Resume singleton content resource: DB-backed résumé, ADR-0007 Phase 3 (#147).
+-- Exactly one row (id = 1). `basics.privateContact` is stripped from public reads
+-- at the application layer (resume tools / ResumeController); RLS below is
+-- coarse-grained defense-in-depth (public read of the row, admin-only writes).
+
+-- CreateTable
+CREATE TABLE "Resume" (
+    "id" INTEGER NOT NULL DEFAULT 1,
+    "document" JSONB NOT NULL,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Resume_pkey" PRIMARY KEY ("id"),
+    -- Singleton: only row id = 1 may ever exist.
+    CONSTRAINT "Resume_singleton" CHECK ("id" = 1)
+);
+
+-- Row-Level Security: anyone may read the single row (the app strips private
+-- contact fields before returning them publicly); only admins may write.
+ALTER TABLE "Resume" ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Resume_public_select" ON "Resume";
+CREATE POLICY "Resume_public_select" ON "Resume" FOR SELECT USING (true);
+
+DROP POLICY IF EXISTS "Resume_admin_all" ON "Resume";
+CREATE POLICY "Resume_admin_all" ON "Resume" FOR ALL USING (
+  current_setting('request.jwt.claims.role', true) = 'admin'
+) WITH CHECK (
+  current_setting('request.jwt.claims.role', true) = 'admin'
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -202,6 +202,16 @@ model ResumeDownloadRequest {
   @@index([userId, createdAt]) // supports the 3-per-trailing-30-days quota count
 }
 
+// DB-backed résumé, ADR-0007 Phase 3 (#147). A SINGLETON: exactly one row (id = 1,
+// enforced by a CHECK constraint in the migration). `document` holds the JSON Resume
+// structure as jsonb. `basics.privateContact` (email/phone) is stripped from public
+// reads at the application layer — see the resume tools / ResumeController.
+model Resume {
+  id        Int      @id @default(1)
+  document  Json
+  updatedAt DateTime @updatedAt
+}
+
 // Personal sports-betting tracker. Core purpose: compare bets made on intuition
 // vs. with AI assistance, graded on closing-line value (CLV) + ROI. See #127/#128.
 // Private data — admin-only at the RLS layer.

--- a/prisma/seed-data/resume.ts
+++ b/prisma/seed-data/resume.ts
@@ -1,0 +1,19 @@
+// Placeholder skeleton for the singleton résumé (#147). The real content lives in
+// bryandebaun.dev's resume.json and is migrated in via PUT /api/resume (or the
+// admin editor). Seeding only ensures the singleton row exists; it never
+// overwrites an edited résumé (upsert uses `update: {}`).
+export const resumeSkeleton = {
+    basics: {
+        name: '',
+        label: '',
+        url: '',
+        summary: '',
+        location: {},
+        profiles: [],
+        privateContact: { email: '', phone: '' },
+    },
+    work: [],
+    education: [],
+    skills: [],
+    projects: [],
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,8 +1,11 @@
 import { pathToFileURL } from 'node:url'
 import pkg from '@prisma/client'
+
 const { PrismaClient } = pkg as any
+
 import { PrismaPg } from '@prisma/adapter-pg'
 import { cptsdArticle } from './seed-data/cptsd.js'
+import { resumeSkeleton } from './seed-data/resume.js'
 
 // Lazily construct the real client so importing this module (e.g. from tests
 // that inject a mock `db`) has no side effects and doesn't require DATABASE_URL.
@@ -44,6 +47,22 @@ async function ensureCanonicalContent(db: any) {
             err,
         )
     }
+
+    try {
+        // Ensure the singleton résumé row exists. `update: {}` so re-seeding never
+        // clobbers an edited résumé; real content arrives via PUT /api/resume.
+        await db.resume.upsert({
+            where: { id: 1 },
+            update: {},
+            create: { id: 1, document: resumeSkeleton },
+        })
+        console.log('Ensured singleton résumé row (id=1)')
+    } catch (err) {
+        console.error(
+            'Failed to ensure résumé singleton (is the Resume table migrated?):',
+            err,
+        )
+    }
 }
 
 export async function runSeed(prismaClient?: any) {
@@ -55,7 +74,9 @@ export async function runSeed(prismaClient?: any) {
     // Quick presence check to avoid re-seeding bulk sample data on every cold
     // start. Bryan's admin profile is the canonical marker.
     try {
-        const existingAdmin = await db.profile.findUnique({ where: { email: 'brn.dbn@gmail.com' } })
+        const existingAdmin = await db.profile.findUnique({
+            where: { email: 'brn.dbn@gmail.com' },
+        })
         if (existingAdmin) {
             console.log('DB already seeded; skipping sample data.')
             return
@@ -75,8 +96,8 @@ export async function runSeed(prismaClient?: any) {
     if (!adminSupabaseUuid) {
         console.warn(
             'ADMIN_SUPABASE_UUID not set — using a random UUID for the admin Profile. ' +
-            'JWT admin auth will not match the Supabase user until this is set and any ' +
-            'existing prod row is reconciled (see issue #90).'
+                'JWT admin auth will not match the Supabase user until this is set and any ' +
+                'existing prod row is reconciled (see issue #90).',
         )
     }
     const bryanUuid = adminSupabaseUuid ?? crypto.randomUUID()
@@ -317,7 +338,7 @@ export async function runSeed(prismaClient?: any) {
         books: { book1, book2, book3 },
         movies: { movie1, movie2, movie3 },
         games: { game1, game2, game3 },
-        contentCreators: { cc1, cc2, cc3 }
+        contentCreators: { cc1, cc2, cc3 },
     })
 
     // Reset sequences to ensure they're ahead of any manually-inserted IDs (fixes CI test flakes with duplicate key violations)
@@ -332,7 +353,9 @@ export async function runSeed(prismaClient?: any) {
 
     for (const { table, sequence } of sequenceResets) {
         try {
-            await db.$executeRawUnsafe(`SELECT setval('"${sequence}"', (SELECT COALESCE(MAX(id), 1) FROM "${table}"))`)
+            await db.$executeRawUnsafe(
+                `SELECT setval('"${sequence}"', (SELECT COALESCE(MAX(id), 1) FROM "${table}"))`,
+            )
             console.log(`${table} sequence reset successfully`)
         } catch (err) {
             console.error(`Failed to reset ${table} sequence:`, err)
@@ -355,9 +378,7 @@ async function main() {
 // Only run when executed directly (`node dist/seed.js` / `prisma db seed`),
 // not when imported (e.g. by tests) — importing must have no side effects.
 const isMain =
-    !!process.argv[1] &&
-    import.meta.url === pathToFileURL(process.argv[1]).href
+    !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href
 if (isMain) {
     main()
 }
-

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -29,6 +29,7 @@ const MODEL_NAMES = [
     'videoGame',
     'contentCreator',
     'article',
+    'resume',
     'resumeDownloadRequest',
     'bet',
     'rating',

--- a/src/http/controllers/ResumeController.ts
+++ b/src/http/controllers/ResumeController.ts
@@ -1,0 +1,112 @@
+import {
+    Body,
+    Controller,
+    Get,
+    Put,
+    Response,
+    Route,
+    Security,
+    SuccessResponse,
+    Tags,
+} from 'tsoa'
+import { callTool } from '../../tools/local.js'
+import { httpError, isNotFound, isValidationError } from './_http-errors.js'
+
+/** JSON Resume private contact fields — never returned by the public GET. */
+export interface ResumePrivateContact {
+    email?: string
+    phone?: string
+    [key: string]: unknown
+}
+
+export interface ResumeBasics {
+    name: string
+    label?: string
+    url?: string
+    summary?: string
+    privateContact?: ResumePrivateContact
+    [key: string]: unknown
+}
+
+/** The JSON Resume document. Open-ended (index signatures) — JSON Resume is extensible. */
+export interface ResumeDocument {
+    basics: ResumeBasics
+    work?: unknown[]
+    education?: unknown[]
+    skills?: unknown[]
+    projects?: unknown[]
+    [key: string]: unknown
+}
+
+export interface ResumeResponse {
+    document: ResumeDocument
+    updatedAt: string
+}
+
+/**
+ * DB-backed singleton résumé (ADR-0007 Phase 3, #147).
+ *
+ * - `GET /api/resume` (API-key) returns the document with `basics.privateContact`
+ *   **stripped** — safe to render on the public page.
+ * - `GET /api/resume/full` (API-key or admin JWT) returns the full document
+ *   including private contact, for the gated render and the PDF generator.
+ * - `PUT /api/resume` (admin JWT) replaces the whole document.
+ */
+@Route('api/resume')
+@Tags('Resume')
+export class ResumeController extends Controller {
+    /** Public résumé — private contact fields removed. */
+    @Get()
+    @Security('api_key')
+    @SuccessResponse('200', 'Résumé retrieved')
+    @Response('404', 'Résumé not found')
+    public async getResume(): Promise<ResumeResponse> {
+        try {
+            const result = await callTool('get-resume', {
+                includePrivate: false,
+            })
+            return result as ResumeResponse
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Résumé not found')
+            throw err
+        }
+    }
+
+    /**
+     * Full résumé including private contact. Server-to-server (API-key) or admin.
+     */
+    @Get('full')
+    @Security('api_key')
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Full résumé retrieved')
+    @Response('404', 'Résumé not found')
+    public async getResumeFull(): Promise<ResumeResponse> {
+        try {
+            const result = await callTool('get-resume', {
+                includePrivate: true,
+            })
+            return result as ResumeResponse
+        } catch (err: any) {
+            if (isNotFound(err)) throw httpError(404, 'Résumé not found')
+            throw err
+        }
+    }
+
+    /** Replace the singleton résumé document (admin only). */
+    @Put()
+    @Security('jwt', ['admin'])
+    @SuccessResponse('200', 'Résumé updated')
+    @Response('400', 'Invalid résumé document')
+    @Response('401', 'Unauthorized')
+    public async putResume(
+        @Body() body: ResumeDocument,
+    ): Promise<ResumeResponse> {
+        try {
+            const result = await callTool('update-resume', { document: body })
+            return result as ResumeResponse
+        } catch (err: any) {
+            if (isValidationError(err)) throw httpError(400, err.message)
+            throw err
+        }
+    }
+}

--- a/src/http/controllers/_http-errors.ts
+++ b/src/http/controllers/_http-errors.ts
@@ -44,6 +44,11 @@ export function isInvalidState(err: any): boolean {
     )
 }
 
+/** True when a tool error indicates invalid input / a failed shape validation (→ 400). */
+export function isValidationError(err: any): boolean {
+    return typeof err?.message === 'string' && /^invalid /i.test(err.message)
+}
+
 /** True when a tool error indicates a time-limited window has elapsed (→ 410). */
 export function isExpiredWindow(err: any): boolean {
     return (

--- a/src/tools/db/index.ts
+++ b/src/tools/db/index.ts
@@ -52,6 +52,11 @@ import {
     registerListMoviesTool,
     registerUpdateMovieTool,
 } from './movies/index.js'
+// Résumé content (singleton) tools (#147)
+import {
+    registerGetResumeTool,
+    registerUpdateResumeTool,
+} from './resume/index.js'
 // Résumé-download-request tools (#139)
 import {
     registerApproveResumeDownloadRequestTool,
@@ -124,6 +129,10 @@ export function registerDbTools(server: McpServer): void {
     registerApproveResumeDownloadRequestTool(server)
     registerDenyResumeDownloadRequestTool(server)
     registerRecordResumeDownloadTool(server)
+
+    // Résumé content (singleton) tools (#147)
+    registerGetResumeTool(server)
+    registerUpdateResumeTool(server)
 
     // Bet tools (sports-betting tracker)
     registerCreateBetTool(server)

--- a/src/tools/db/resume/get-resume.ts
+++ b/src/tools/db/resume/get-resume.ts
@@ -1,0 +1,52 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { GetResumeInputSchema } from './schemas.js'
+import { stripPrivateContact } from './strip.js'
+
+const name = 'get-resume'
+const config = {
+    title: 'Get Résumé',
+    description:
+        'Get the singleton résumé document. Public reads omit basics.privateContact; ' +
+        'pass includePrivate=true (admin / server-to-server) to include it.',
+    inputSchema: GetResumeInputSchema,
+}
+
+// The résumé is a singleton stored at a fixed id.
+const RESUME_ID = 1
+
+export function registerGetResumeTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                const includePrivate = args?.includePrivate === true
+                const row = await prisma.resume.findUnique({
+                    where: { id: RESUME_ID },
+                })
+                if (!row) return createErrorResult('Resume not found')
+
+                const document = includePrivate
+                    ? row.document
+                    : stripPrivateContact(row.document)
+
+                return createSuccessResult({
+                    document,
+                    updatedAt: row.updatedAt,
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/src/tools/db/resume/index.ts
+++ b/src/tools/db/resume/index.ts
@@ -1,0 +1,2 @@
+export { registerGetResumeTool } from './get-resume.js'
+export { registerUpdateResumeTool } from './update-resume.js'

--- a/src/tools/db/resume/schemas.ts
+++ b/src/tools/db/resume/schemas.ts
@@ -1,0 +1,51 @@
+// Input + document schemas for the résumé content resource (#147).
+import { z } from 'zod'
+
+// Lenient, top-level JSON Resume validation (the issue asks to "validate the
+// top-level shape"). Inner entries stay open (`passthrough` / `z.any()`) because
+// JSON Resume is extensible and the site may add fields over time.
+export const PrivateContactSchema = z
+    .object({
+        email: z.string().optional(),
+        phone: z.string().optional(),
+    })
+    .passthrough()
+
+export const ResumeBasicsSchema = z
+    .object({
+        name: z.string(),
+        label: z.string().optional(),
+        url: z.string().optional(),
+        summary: z.string().optional(),
+        location: z.any().optional(),
+        profiles: z.array(z.any()).optional(),
+        privateContact: PrivateContactSchema.optional(),
+    })
+    .passthrough()
+
+export const ResumeDocumentSchema = z
+    .object({
+        basics: ResumeBasicsSchema,
+        work: z.array(z.any()).optional(),
+        education: z.array(z.any()).optional(),
+        skills: z.array(z.any()).optional(),
+        projects: z.array(z.any()).optional(),
+    })
+    .passthrough()
+
+export type ResumeDocument = z.infer<typeof ResumeDocumentSchema>
+
+export const GetResumeInputSchema = {
+    includePrivate: z
+        .boolean()
+        .optional()
+        .describe(
+            'Include basics.privateContact (email/phone). Default false — public reads are stripped.',
+        ),
+}
+
+export const UpdateResumeInputSchema = {
+    document: ResumeDocumentSchema.describe(
+        'The full JSON Resume document to store (replaces the singleton).',
+    ),
+}

--- a/src/tools/db/resume/strip.ts
+++ b/src/tools/db/resume/strip.ts
@@ -1,0 +1,21 @@
+// Remove basics.privateContact (email/phone) from a résumé document for public
+// reads. This app-layer stripping is the guarantee ADR-0007 relies on: a public
+// response must never carry the private contact fields (#147).
+
+/** Return a deep copy of the document with `basics.privateContact` removed. */
+export function stripPrivateContact(document: unknown): unknown {
+    // Deep clone so we never mutate the stored row; the document is plain JSON.
+    const clone =
+        typeof document === 'object' && document !== null
+            ? JSON.parse(JSON.stringify(document))
+            : document
+    if (
+        clone &&
+        typeof clone === 'object' &&
+        clone.basics &&
+        typeof clone.basics === 'object'
+    ) {
+        delete clone.basics.privateContact
+    }
+    return clone
+}

--- a/src/tools/db/resume/update-resume.ts
+++ b/src/tools/db/resume/update-resume.ts
@@ -1,0 +1,62 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js'
+import { prisma } from '../../../db/index.js'
+import {
+    createErrorResult,
+    createSuccessResult,
+} from '../../github-issues/results.js'
+import { registerTool } from '../../registration.js'
+import { ResumeDocumentSchema, UpdateResumeInputSchema } from './schemas.js'
+
+const name = 'update-resume'
+const config = {
+    title: 'Update Résumé',
+    description:
+        'Replace the singleton résumé document (admin). Validates the top-level ' +
+        'JSON Resume shape (basics + work/education/skills/projects).',
+    inputSchema: UpdateResumeInputSchema,
+}
+
+const RESUME_ID = 1
+
+export function registerUpdateResumeTool(server: McpServer): void {
+    registerTool(
+        server,
+        name,
+        config,
+        async (args: any): Promise<CallToolResult> => {
+            try {
+                // Validate here so both surfaces (MCP + REST via callTool) enforce
+                // the shape — the REST facade doesn't re-run the Zod input schema.
+                const parsed = ResumeDocumentSchema.safeParse(args?.document)
+                if (!parsed.success) {
+                    const detail = parsed.error.issues
+                        .map(
+                            (i) =>
+                                `${i.path.join('.') || '(root)'}: ${i.message}`,
+                        )
+                        .join('; ')
+                    return createErrorResult(
+                        `Invalid resume document: ${detail}`,
+                    )
+                }
+                const document = parsed.data
+
+                const row = await prisma.resume.upsert({
+                    where: { id: RESUME_ID },
+                    update: { document },
+                    create: { id: RESUME_ID, document },
+                })
+
+                return createSuccessResult({
+                    document: row.document,
+                    updatedAt: row.updatedAt,
+                })
+            } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error)
+                return createErrorResult(message)
+            }
+        },
+    )
+}

--- a/test/http/resume-controller.test.ts
+++ b/test/http/resume-controller.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the tool layer so we can assert the controller's delegation and error
+// mapping in isolation (no DB, no JWKS).
+vi.mock('../../src/tools/local.js', () => ({ callTool: vi.fn() }))
+
+import { ResumeController } from '../../src/http/controllers/ResumeController'
+import { callTool } from '../../src/tools/local.js'
+
+const mockCallTool = callTool as unknown as ReturnType<typeof vi.fn>
+
+describe('ResumeController (#147)', () => {
+    beforeEach(() => {
+        mockCallTool.mockReset()
+        mockCallTool.mockResolvedValue({
+            document: { basics: { name: 'B' } },
+            updatedAt: '2026-07-03T00:00:00Z',
+        })
+    })
+
+    it('public GET requests the stripped document', async () => {
+        await new ResumeController().getResume()
+        expect(mockCallTool).toHaveBeenCalledWith('get-resume', {
+            includePrivate: false,
+        })
+    })
+
+    it('full GET requests the document including private contact', async () => {
+        await new ResumeController().getResumeFull()
+        expect(mockCallTool).toHaveBeenCalledWith('get-resume', {
+            includePrivate: true,
+        })
+    })
+
+    it('GET maps not-found to 404', async () => {
+        mockCallTool.mockRejectedValueOnce(new Error('Resume not found'))
+        await expect(new ResumeController().getResume()).rejects.toMatchObject({
+            status: 404,
+        })
+    })
+
+    it('PUT delegates the body to update-resume', async () => {
+        const body: any = {
+            basics: { name: 'Bryan' },
+            work: [],
+        }
+        await new ResumeController().putResume(body)
+        expect(mockCallTool).toHaveBeenCalledWith('update-resume', {
+            document: body,
+        })
+    })
+
+    it('PUT maps a validation error to 400', async () => {
+        mockCallTool.mockRejectedValueOnce(
+            new Error('Invalid resume document: basics.name: Required'),
+        )
+        await expect(
+            new ResumeController().putResume({ basics: {} } as any),
+        ).rejects.toMatchObject({ status: 400 })
+    })
+})

--- a/test/tools/db/resume/resume-tools.test.ts
+++ b/test/tools/db/resume/resume-tools.test.ts
@@ -1,0 +1,137 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Mock the shared prisma object's `resume` model so tool handlers are
+// deterministic without a database (mirrors the no-op stub contract).
+vi.mock('../../../../src/db/index', () => ({
+    prisma: {
+        resume: {
+            findUnique: vi.fn(),
+            upsert: vi.fn(),
+        },
+    },
+}))
+
+import { prisma } from '../../../../src/db/index.js'
+import { registerGetResumeTool } from '../../../../src/tools/db/resume/get-resume.js'
+import { registerUpdateResumeTool } from '../../../../src/tools/db/resume/update-resume.js'
+
+const resume = (prisma as any).resume as Record<
+    string,
+    ReturnType<typeof vi.fn>
+>
+
+const handlers = new Map<string, (args: any) => Promise<any>>()
+const fake: any = {
+    registerTool: (name: string, _cfg: any, handler: any) =>
+        handlers.set(name, handler),
+}
+
+const call = async (name: string, args: any) => {
+    const res = await handlers.get(name)!(args)
+    const text = res.content[0].text
+    let data: any
+    try {
+        data = JSON.parse(text)
+    } catch {
+        data = text
+    }
+    return { isError: !!res.isError, data }
+}
+
+const withPrivate = () => ({
+    document: {
+        basics: {
+            name: 'Bryan',
+            summary: 'Engineer',
+            privateContact: { email: 'me@example.com', phone: '555-1234' },
+        },
+        work: [],
+    },
+    updatedAt: new Date('2026-07-03T00:00:00Z'),
+})
+
+beforeAll(() => {
+    registerGetResumeTool(fake)
+    registerUpdateResumeTool(fake)
+})
+
+beforeEach(() => {
+    for (const fn of Object.values(resume)) fn.mockReset()
+})
+
+describe('resume tools — get-resume (private-contact stripping #147)', () => {
+    it('404s when the singleton row does not exist', async () => {
+        resume.findUnique.mockResolvedValueOnce(null)
+        const { isError, data } = await call('get-resume', {})
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/not found/i)
+    })
+
+    it('strips basics.privateContact on a public read (default)', async () => {
+        resume.findUnique.mockResolvedValueOnce(withPrivate())
+        const { isError, data } = await call('get-resume', {})
+        expect(isError).toBe(false)
+        expect(data.document.basics.name).toBe('Bryan') // other fields preserved
+        expect(data.document.basics.privateContact).toBeUndefined()
+    })
+
+    it('does not mutate the stored row while stripping', async () => {
+        const row = withPrivate()
+        resume.findUnique.mockResolvedValueOnce(row)
+        await call('get-resume', {})
+        // The source document still has its private contact (deep-cloned before strip).
+        expect(row.document.basics.privateContact).toEqual({
+            email: 'me@example.com',
+            phone: '555-1234',
+        })
+    })
+
+    it('includes privateContact when includePrivate=true', async () => {
+        resume.findUnique.mockResolvedValueOnce(withPrivate())
+        const { data } = await call('get-resume', { includePrivate: true })
+        expect(data.document.basics.privateContact).toEqual({
+            email: 'me@example.com',
+            phone: '555-1234',
+        })
+    })
+})
+
+describe('resume tools — update-resume (upsert + validation)', () => {
+    it('upserts the singleton (id=1) with a valid document', async () => {
+        resume.upsert.mockImplementation(async ({ create, update }: any) => ({
+            id: 1,
+            document: update?.document ?? create?.document,
+            updatedAt: new Date(),
+        }))
+        const doc = {
+            basics: { name: 'Bryan' },
+            work: [],
+            education: [],
+            skills: [],
+            projects: [],
+        }
+        const { isError, data } = await call('update-resume', { document: doc })
+        expect(isError).toBe(false)
+        expect(data.document.basics.name).toBe('Bryan')
+        const arg = resume.upsert.mock.calls[0][0]
+        expect(arg.where).toEqual({ id: 1 })
+        expect(arg.create.id).toBe(1)
+    })
+
+    it('rejects a document missing basics.name (top-level shape)', async () => {
+        const { isError, data } = await call('update-resume', {
+            document: { basics: {}, work: [] },
+        })
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/invalid resume document/i)
+        expect(resume.upsert).not.toHaveBeenCalled()
+    })
+
+    it('rejects a document with a non-array work section', async () => {
+        const { isError, data } = await call('update-resume', {
+            document: { basics: { name: 'B' }, work: 'nope' },
+        })
+        expect(isError).toBe(true)
+        expect(String(data)).toMatch(/invalid resume document/i)
+    })
+})

--- a/tools/bruno/Resume/GetResume.bru
+++ b/tools/bruno/Resume/GetResume.bru
@@ -1,0 +1,106 @@
+meta {
+  name: GetResume
+  type: http
+  seq: 1
+  tags: [
+    Resume
+  ]
+}
+
+get {
+  url: {{baseUrl}}/api/resume
+  body: none
+  auth: apikey
+}
+
+headers {
+  X-Mcp-Api-Key: {{apiKey}}
+}
+
+auth:apikey {
+  key: X-Mcp-Api-Key
+  value: {{apiKey}}
+  placement: header
+}
+
+docs {
+  Public résumé — private contact fields removed.
+}
+
+example {
+  name: 200 Response
+  description: Résumé retrieved
+  
+  request: {
+    url: {{baseUrl}}/api/resume
+    method: GET
+    mode: none
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "document": {
+            "basics": {
+              "name": "",
+              "label": "",
+              "url": "",
+              "summary": "",
+              "privateContact": {
+                "email": "",
+                "phone": ""
+              }
+            },
+            "work": [],
+            "education": [],
+            "skills": [],
+            "projects": []
+          },
+          "updatedAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Résumé not found
+  
+  request: {
+    url: {{baseUrl}}/api/resume
+    method: GET
+    mode: none
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Resume/GetResumeFull.bru
+++ b/tools/bruno/Resume/GetResumeFull.bru
@@ -1,0 +1,106 @@
+meta {
+  name: GetResumeFull
+  type: http
+  seq: 3
+  tags: [
+    Resume
+  ]
+}
+
+get {
+  url: {{baseUrl}}/api/resume/full
+  body: none
+  auth: apikey
+}
+
+headers {
+  X-Mcp-Api-Key: {{apiKey}}
+}
+
+auth:apikey {
+  key: X-Mcp-Api-Key
+  value: {{apiKey}}
+  placement: header
+}
+
+docs {
+  Full résumé including private contact. Server-to-server (API-key) or admin.
+}
+
+example {
+  name: 200 Response
+  description: Full résumé retrieved
+  
+  request: {
+    url: {{baseUrl}}/api/resume/full
+    method: GET
+    mode: none
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "document": {
+            "basics": {
+              "name": "",
+              "label": "",
+              "url": "",
+              "summary": "",
+              "privateContact": {
+                "email": "",
+                "phone": ""
+              }
+            },
+            "work": [],
+            "education": [],
+            "skills": [],
+            "projects": []
+          },
+          "updatedAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 404 Response
+  description: Résumé not found
+  
+  request: {
+    url: {{baseUrl}}/api/resume/full
+    method: GET
+    mode: none
+    headers: {
+      X-Mcp-Api-Key: {{apiKey}}
+    }
+  }
+  
+  response: {
+    status: {
+      code: 404
+      text: Not Found
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Resume/PutResume.bru
+++ b/tools/bruno/Resume/PutResume.bru
@@ -1,0 +1,192 @@
+meta {
+  name: PutResume
+  type: http
+  seq: 2
+  tags: [
+    Resume
+  ]
+}
+
+put {
+  url: {{baseUrl}}/api/resume
+  body: json
+  auth: bearer
+}
+
+auth:bearer {
+  token: {{token}}
+}
+
+body:json {
+  {
+    "basics": {
+      "name": "",
+      "label": "",
+      "url": "",
+      "summary": "",
+      "privateContact": {
+        "email": "",
+        "phone": ""
+      }
+    },
+    "work": [],
+    "education": [],
+    "skills": [],
+    "projects": []
+  }
+}
+
+docs {
+  Replace the singleton résumé document (admin only).
+}
+
+example {
+  name: 200 Response
+  description: Résumé updated
+  
+  request: {
+    url: {{baseUrl}}/api/resume
+    method: PUT
+    mode: json
+    body:json: {
+      {
+        "basics": {
+          "name": "",
+          "label": "",
+          "url": "",
+          "summary": "",
+          "privateContact": {
+            "email": "",
+            "phone": ""
+          }
+        },
+        "work": [],
+        "education": [],
+        "skills": [],
+        "projects": []
+      }
+    }
+  }
+  
+  response: {
+    headers: {
+      Content-Type: application/json
+    }
+  
+    status: {
+      code: 200
+      text: OK
+    }
+  
+    body: {
+      type: json
+      content: '''
+        {
+          "document": {
+            "basics": {
+              "name": "",
+              "label": "",
+              "url": "",
+              "summary": "",
+              "privateContact": {
+                "email": "",
+                "phone": ""
+              }
+            },
+            "work": [],
+            "education": [],
+            "skills": [],
+            "projects": []
+          },
+          "updatedAt": ""
+        }
+      '''
+    }
+  }
+}
+
+example {
+  name: 400 Response
+  description: Invalid résumé document
+  
+  request: {
+    url: {{baseUrl}}/api/resume
+    method: PUT
+    mode: json
+    body:json: {
+      {
+        "basics": {
+          "name": "",
+          "label": "",
+          "url": "",
+          "summary": "",
+          "privateContact": {
+            "email": "",
+            "phone": ""
+          }
+        },
+        "work": [],
+        "education": [],
+        "skills": [],
+        "projects": []
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 400
+      text: Bad Request
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}
+
+example {
+  name: 401 Response
+  description: Unauthorized
+  
+  request: {
+    url: {{baseUrl}}/api/resume
+    method: PUT
+    mode: json
+    body:json: {
+      {
+        "basics": {
+          "name": "",
+          "label": "",
+          "url": "",
+          "summary": "",
+          "privateContact": {
+            "email": "",
+            "phone": ""
+          }
+        },
+        "work": [],
+        "education": [],
+        "skills": [],
+        "projects": []
+      }
+    }
+  }
+  
+  response: {
+    status: {
+      code: 401
+      text: Unauthorized
+    }
+  
+    body: {
+      type: text
+      content: '''
+  
+      '''
+    }
+  }
+}

--- a/tools/bruno/Resume/folder.bru
+++ b/tools/bruno/Resume/folder.bru
@@ -1,0 +1,7 @@
+meta {
+  name: Resume
+}
+
+auth {
+  mode: inherit
+}


### PR DESCRIPTION
Closes #147.

ADR-0007 Phase 3: the editable résumé moves from the site's file-backed `resume.json` to a **DB singleton**, so it can be edited live from the admin instead of by committing a file.

## What's included
- **Prisma** — `Resume` singleton model (`id Int @default(1)`, `document` jsonb, `updatedAt`). Migration **hard-enforces one row** via `CHECK (id = 1)` and adds RLS (public `SELECT`, admin-only writes).
- **The key decision — split private contact by auth**:
  - `GET /api/resume` — API-key → document with **`basics.privateContact` stripped** (safe for the public page).
  - `GET /api/resume/full` — API-key **or** admin-JWT → **full** document incl. private contact (gated render + PDF).
  - `PUT /api/resume` — admin-JWT → replace the whole document.
- **Tools** (one impl, two surfaces): `get-resume` (`includePrivate` gate) and `update-resume` (validates the top-level JSON Resume shape via Zod, upserts `id=1`). A `stripPrivateContact` helper **deep-clones**, so the stored row is never mutated and the strip is total.
- **Validation**: lenient top-level (basics required + `name`; `work/education/skills/projects` arrays; `privateContact` = `{email?, phone?}`), passthrough on inner fields since JSON Resume is extensible. Invalid → **400**.
- **Seed**: idempotent skeleton singleton (`update: {}` never clobbers an edited résumé). Regenerated tsoa spec + Bruno; added a `resume` DB-less stub.

## Verification
- **Live Postgres**: migration applies; the singleton CHECK **rejects a second row**; both RLS policies present; seed creates `id=1`.
- `pnpm typecheck` exit 0 · `pnpm test` **338 passed / 5 env-gated skips / 0 failed**. Tests prove the public read **omits `privateContact`** and doesn't mutate the source, full read includes it, and PUT validates + round-trips.

## Notes / follow-ups
- **Seed is a placeholder skeleton** — `resume.json` lives in `bryandebaun.dev`, so the real content is imported via `PUT /api/resume` or the admin editor (cross-repo).
- **Frontend follow-up (bryandebaun.dev #117)**: admin editor mirroring `ArticleEditor`; `/resume` + `/resume/full` read from the API; retire `resume.json`.
- **RLS caveat**: the table's RLS allows public `SELECT` of the whole row; `privateContact` protection is **app-layer** (the strip), which is the guarantee the acceptance test asserts. RLS can't sub-field-strip jsonb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)