### PR TITLE
docs(agents): drop reference to the retired copilot-agents repo

### DIFF
--- a/.github/agents/README.md
+++ b/.github/agents/README.md
@@ -7,5 +7,5 @@ The active agent definitions for this repo are **Claude Code subagents** in
 The previous GitHub Copilot `*.agent.md` personas are kept for reference in
 [`archive/`](archive/) and are **deprecated** — do not edit them.
 
-Canonical agent definitions are maintained in the `copilot-agents` repo and installed
-per-repo / at the user level (`~/.claude/agents/`).
+The cross-project `debaun-*` agents live at the user level (`~/.claude/agents/`). The former
+`copilot-agents` source repo was retired and archived on 2026-07-21.


### PR DESCRIPTION
## Summary

One-line docs fix: `.github/agents/README.md` pointed at the `copilot-agents` repo as the canonical source for agent definitions. That repo was [archived](https://github.com/bryan-debaun/copilot-agents) on 2026-07-21 now that work has consolidated on Claude Code.

## Changes

Replaces the stale pointer with where the cross-project `debaun-*` agents actually live — `~/.claude/agents/`, version-controlled in the [`workspace`](https://github.com/bryan-debaun/workspace) meta-repo.

This repo's own `.claude/agents/` subagents (`mcp-server-coder`, `-reviewer`, `-support`, `-tester`) are unaffected.

## Notes for reviewers

Docs-only, no code paths touched. Companion PRs cover `workspace` and `Pillow`.
