### PR TITLE
fix(observability): warn at boot when optional integrations are unconfigured (#155)

### DIFF
--- a/docs/secrets-doppler.md
+++ b/docs/secrets-doppler.md
@@ -65,3 +65,38 @@ Moving secrets into Doppler is the natural moment to rotate the sensitive ones, 
 old plaintext has lived in `.env.local`: `MCP_API_KEY`, `INTERNAL_ADMIN_KEY`,
 `SUPABASE_SERVICE_ROLE_KEY`, `SESSION_JWT_SECRET`, `MAGIC_LINK_JWT_SECRET`,
 `SENDGRID_API_KEY`, `GITHUB_TOKEN`, and any Spotify/Odds keys.
+
+## Rotation & expiry
+
+Most secrets here never expire on their own — they change only when *we* rotate them.
+`GITHUB_TOKEN` is the exception, and the one that has already bitten us (#155): a
+classic PAT can carry an expiry date, and when it lapses the server keeps booting
+happily while every GitHub tool fails at call time.
+
+| Secret | Expires on its own? | Scopes / notes | On rotation |
+|---|---|---|---|
+| `GITHUB_TOKEN` | **Yes, if you set an expiry** — classic PATs default to 30 days in the GitHub UI | Needs **`repo`** (issue/label CRUD, and required for private repos such as `varsityclub-web`) and **`project`** (Projects v2 field/item tools). A `repo`-only token passes issue calls and fails Projects tools. | Set in Doppler `prd`, confirm it reaches Render, then verify with `list-labels` against a public **and** a private repo, plus one Projects v2 call. |
+| `MCP_API_KEY` | No | Gateway key for `/mcp` and DB-dependent `/api/*` | Update every MCP client (VS Code config, `bryandebaun.dev`) in the same change — rotating this alone locks them out. |
+| `SUPABASE_SERVICE_ROLE_KEY` | No | Service-role bypass identity | See `docs/runbooks/service-role-bypass.md`. |
+| `INTERNAL_ADMIN_KEY` | No | Second factor on the service-role path | Rotate alongside the service-role key. |
+| `SPOTIFY_REFRESH_TOKEN` | Revocable, not time-boxed | Invalidated if the Spotify app's secret is regenerated | Re-run the auth flow in `docs/runbooks/spotify.md`. |
+| `SENTRY_DSN`, `ODDS_API_KEY`, `SENDGRID_API_KEY` | No | Vendor-revocable only | Set in Doppler, redeploy. |
+
+**Prefer a PAT with no expiry for `GITHUB_TOKEN`**, or calendar the expiry date — there
+is no automated renewal here. Rotation is a two-step operation in both cases: set the
+value in the Doppler `prd` config, then confirm Render actually picked it up (a synced
+value still needs a deploy or restart to reach the running process).
+
+### Detecting a missing or lapsed secret
+
+Since #155 the server reports optional-integration state in two places, so a missing
+secret is visible without waiting for a tool call to fail:
+
+- **Boot logs** — one `capability disabled: <name> — <VAR> not set; <impact>` warning per
+  unconfigured integration (`src/capabilities.ts`, emitted from `src/index.ts`).
+- **`GET /healthz?deep=1`** — a `capabilities` map, e.g. `{ "github": false, … }`.
+
+Both are deliberately **non-fatal**: boot still succeeds and the probe still returns 200,
+because the server does plenty of useful work without any single integration. Note this
+only catches an *unset* variable — a token that is present but **expired or under-scoped**
+still looks configured, and surfaces as a 401/403 from the GitHub API at call time.

--- a/src/capabilities.ts
+++ b/src/capabilities.ts
@@ -1,0 +1,84 @@
+import { config } from './config.js'
+import { logger } from './logger.js'
+
+/**
+ * An optional integration whose absence *degrades* the server rather than
+ * breaking it. Every one of these is `optional()` in the zod env schema on
+ * purpose — this server does plenty of useful work without any single one of
+ * them, so a missing credential must never refuse boot (see issue #155).
+ *
+ * The cost of that choice is that a missing secret used to be invisible until
+ * somebody called a tool and got a runtime error with no corresponding startup
+ * signal. This module is the counterweight: warn loudly at boot, and report the
+ * state on the diagnostic health endpoint.
+ */
+export interface Capability {
+    /** Stable identifier; also the key used in the `/healthz?deep=1` payload. */
+    name: string
+    /** Whether the capability is configured, and therefore usable. */
+    enabled: boolean
+    /** The env var that enables it — named so the fix is obvious from the log. */
+    requires: string
+    /** What stops working while it is unconfigured. */
+    impact: string
+}
+
+/** Snapshot the configured/unconfigured state of every optional integration. */
+export function resolveCapabilities(): Capability[] {
+    return [
+        {
+            name: 'github',
+            enabled: Boolean(config.github.token),
+            requires: 'GITHUB_TOKEN',
+            impact: 'GitHub Issues and Projects v2 tools fail at call time',
+        },
+        {
+            name: 'database',
+            enabled: Boolean(config.database.url),
+            requires: 'DATABASE_URL',
+            impact: 'catalog reads return empty and writes throw (stub Prisma client)',
+        },
+        {
+            name: 'spotify',
+            enabled: config.spotify.enabled,
+            requires:
+                'SPOTIFY_CLIENT_ID + SPOTIFY_CLIENT_SECRET + SPOTIFY_REFRESH_TOKEN',
+            impact: 'Spotify playback and now-playing routes are disabled',
+        },
+        {
+            name: 'odds',
+            enabled: config.odds.enabled,
+            requires: 'ODDS_API_KEY',
+            impact: 'betting odds and event tools fail at call time',
+        },
+        {
+            name: 'sentry',
+            enabled: Boolean(config.sentry.dsn),
+            requires: 'SENTRY_DSN',
+            impact: 'errors are not reported anywhere except the log stream',
+        },
+    ]
+}
+
+/** `{ github: true, database: false, … }` — the shape served by health. */
+export function capabilitySummary(): Record<string, boolean> {
+    return Object.fromEntries(
+        resolveCapabilities().map((c) => [c.name, c.enabled]),
+    )
+}
+
+/**
+ * Log one warning per unconfigured capability at startup.
+ *
+ * Deliberately `warn`, not `error`: `logger.error` is bridged to Sentry, and a
+ * deployment that intentionally runs without (say) Spotify would otherwise page
+ * on every boot. The signal belongs in the boot logs, not the error tracker.
+ */
+export function logCapabilityWarnings(): void {
+    for (const c of resolveCapabilities()) {
+        if (c.enabled) continue
+        logger.warn(
+            `capability disabled: ${c.name} — ${c.requires} not set; ${c.impact}`,
+        )
+    }
+}

--- a/src/http/health-route.ts
+++ b/src/http/health-route.ts
@@ -1,4 +1,5 @@
 import type { Request, Response } from 'express'
+import { capabilitySummary } from '../capabilities.js'
 import { config } from '../config.js'
 import { initPrisma, prisma } from '../db/index.js'
 import { logger } from '../logger.js'
@@ -29,7 +30,8 @@ async function checkDatabase(): Promise<{
 export function registerHealthRoute(app: any): void {
     // Liveness probe — always returns 200 to indicate the process is alive.
     // `?deep=1` additionally exercises the DB (keep-alive for Render + Supabase,
-    // #119); the default form stays dependency-free for Render's own health check.
+    // #119) and reports optional-integration state (#155); the default form stays
+    // dependency-free and minimal for Render's own health check.
     app.get('/healthz', async (req: Request, res: Response) => {
         const base = {
             status: 'ok',
@@ -40,9 +42,15 @@ export function registerHealthRoute(app: any): void {
         const deep = req.query.deep === '1' || req.query.deep === 'true'
         if (!deep) return res.status(200).json(base)
 
+        // Unconfigured optional integrations are reported but never change the
+        // status code: the server is genuinely functional without them, and
+        // failing the probe here would take the whole service down over a
+        // missing GITHUB_TOKEN. This is a visibility signal, not a gate.
+        const capabilities = capabilitySummary()
+
         try {
             const db = await checkDatabase()
-            return res.status(200).json({ ...base, ...db })
+            return res.status(200).json({ ...base, ...db, capabilities })
         } catch (err) {
             // DB is configured but unreachable — surface a 503 so an external
             // monitor alerts on a genuine outage (a paused/restoring Supabase or
@@ -51,9 +59,12 @@ export function registerHealthRoute(app: any): void {
                 'deep /healthz DB check failed',
                 (err as any)?.message ?? err,
             )
-            return res
-                .status(503)
-                .json({ ...base, status: 'degraded', db: 'error' })
+            return res.status(503).json({
+                ...base,
+                status: 'degraded',
+                db: 'error',
+                capabilities,
+            })
         }
     })
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { logCapabilityWarnings } from './capabilities.js'
 // config.ts loads dotenv at module init — import it before anything else.
 import { config } from './config.js'
 import { logger } from './logger.js'
@@ -42,6 +43,11 @@ async function main(): Promise<void> {
     } catch (e) {
         logger.warn('startup diagnostic failed', e)
     }
+
+    // Surface unconfigured optional integrations in the boot logs. Without this
+    // a missing secret (e.g. GITHUB_TOKEN, #155) is invisible until a tool call
+    // fails at runtime with no corresponding startup signal.
+    logCapabilityWarnings()
 
     // Decide transport based on runtime environment.
     // Priority:

--- a/test/capabilities.test.ts
+++ b/test/capabilities.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/logger.js', () => ({
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}))
+
+import {
+    capabilitySummary,
+    logCapabilityWarnings,
+    resolveCapabilities,
+} from '../src/capabilities.js'
+import { config } from '../src/config.js'
+import { logger } from '../src/logger.js'
+
+const mockWarn = logger.warn as unknown as ReturnType<typeof vi.fn>
+
+const ORIGINAL = {
+    githubToken: config.github.token,
+    databaseUrl: config.database.url,
+    spotifyEnabled: config.spotify.enabled,
+    oddsEnabled: config.odds.enabled,
+    sentryDsn: config.sentry.dsn,
+}
+
+/** Configure every capability so tests can turn exactly one off. */
+function enableAll() {
+    ;(config as any).github.token = 'ghp_test'
+    ;(config as any).database.url = 'postgres://example'
+    ;(config as any).spotify.enabled = true
+    ;(config as any).odds.enabled = true
+    ;(config as any).sentry.dsn = 'https://key@sentry.example/1'
+}
+
+afterEach(() => {
+    ;(config as any).github.token = ORIGINAL.githubToken
+    ;(config as any).database.url = ORIGINAL.databaseUrl
+    ;(config as any).spotify.enabled = ORIGINAL.spotifyEnabled
+    ;(config as any).odds.enabled = ORIGINAL.oddsEnabled
+    ;(config as any).sentry.dsn = ORIGINAL.sentryDsn
+    mockWarn.mockReset()
+})
+
+describe('resolveCapabilities', () => {
+    it('reports github as disabled when GITHUB_TOKEN is unset (#155)', () => {
+        enableAll()
+        ;(config as any).github.token = undefined
+        const github = resolveCapabilities().find((c) => c.name === 'github')
+        expect(github).toMatchObject({
+            enabled: false,
+            requires: 'GITHUB_TOKEN',
+        })
+    })
+
+    it('reports github as enabled when GITHUB_TOKEN is set', () => {
+        enableAll()
+        const github = resolveCapabilities().find((c) => c.name === 'github')
+        expect(github?.enabled).toBe(true)
+    })
+
+    it('summarises every capability as a name -> boolean map', () => {
+        enableAll()
+        expect(capabilitySummary()).toEqual({
+            github: true,
+            database: true,
+            spotify: true,
+            odds: true,
+            sentry: true,
+        })
+    })
+})
+
+describe('logCapabilityWarnings', () => {
+    it('warns once for GITHUB_TOKEN, naming the var and the impact', () => {
+        enableAll()
+        ;(config as any).github.token = undefined
+
+        logCapabilityWarnings()
+
+        expect(mockWarn).toHaveBeenCalledTimes(1)
+        const [message] = mockWarn.mock.calls[0]
+        expect(message).toContain('GITHUB_TOKEN')
+        expect(message).toContain('github')
+        expect(message).toContain('fail at call time')
+    })
+
+    it('stays silent when everything is configured', () => {
+        enableAll()
+        logCapabilityWarnings()
+        expect(mockWarn).not.toHaveBeenCalled()
+    })
+
+    it('warns for each unconfigured capability independently', () => {
+        enableAll()
+        ;(config as any).github.token = undefined
+        ;(config as any).sentry.dsn = undefined
+
+        logCapabilityWarnings()
+
+        expect(mockWarn).toHaveBeenCalledTimes(2)
+    })
+
+    it('uses warn, never error — logger.error is bridged to Sentry', () => {
+        enableAll()
+        ;(config as any).github.token = undefined
+        logCapabilityWarnings()
+        expect(logger.error).not.toHaveBeenCalled()
+    })
+})

--- a/test/http/health-deep.test.ts
+++ b/test/http/health-deep.test.ts
@@ -76,3 +76,52 @@ describe('GET /healthz?deep=1 (#119 keep-alive deep check)', () => {
         expect(res.body).toMatchObject({ db: 'skipped' })
     })
 })
+
+describe('GET /healthz?deep=1 capability reporting (#155)', () => {
+    const ORIGINAL_GITHUB_TOKEN = config.github.token
+    const setGithubToken = (t: string | undefined) => {
+        ;(config as any).github.token = t
+    }
+
+    beforeEach(() => {
+        mockQueryRaw.mockReset()
+        mockInitPrisma.mockClear()
+        setDbUrl(undefined)
+    })
+    afterEach(() => {
+        setDbUrl(ORIGINAL_DB_URL)
+        setGithubToken(ORIGINAL_GITHUB_TOKEN)
+    })
+
+    it('reports github: false when GITHUB_TOKEN is unset', async () => {
+        setGithubToken(undefined)
+        const res = await request(makeApp()).get('/healthz?deep=1').expect(200)
+        expect(res.body.capabilities).toMatchObject({ github: false })
+    })
+
+    it('reports github: true when GITHUB_TOKEN is set', async () => {
+        setGithubToken('ghp_test')
+        const res = await request(makeApp()).get('/healthz?deep=1').expect(200)
+        expect(res.body.capabilities).toMatchObject({ github: true })
+    })
+
+    it('stays 200 with a missing capability — degraded is not unhealthy', async () => {
+        setGithubToken(undefined)
+        await request(makeApp()).get('/healthz?deep=1').expect(200)
+    })
+
+    it('still reports capabilities alongside a 503 DB failure', async () => {
+        setDbUrl('postgres://example')
+        setGithubToken(undefined)
+        mockQueryRaw.mockRejectedValueOnce(new Error('connection refused'))
+        const res = await request(makeApp()).get('/healthz?deep=1').expect(503)
+        expect(res.body).toMatchObject({ status: 'degraded', db: 'error' })
+        expect(res.body.capabilities).toMatchObject({ github: false })
+    })
+
+    it('keeps the shallow probe free of capability detail (Render gate stays minimal)', async () => {
+        setGithubToken(undefined)
+        const res = await request(makeApp()).get('/healthz').expect(200)
+        expect(res.body).not.toHaveProperty('capabilities')
+    })
+})


### PR DESCRIPTION
Closes the **code half** of #155. The ops half (setting `GITHUB_TOKEN` in the production Doppler config) is still outstanding and is called out below.

## Problem

`GITHUB_TOKEN` is unset in production, so every `mcp__bad-mcp__*` GitHub tool fails at call time. The server boots happily because `src/config.ts` declares the var `optional()` — which is the right call per the issue (the service has plenty of non-GitHub functionality, and refusing to boot over a missing optional capability would be a regression). The cost is that the gap was invisible until somebody called a tool, with no startup signal at all.

## Change

New `src/capabilities.ts` — a snapshot of every optional integration that *degrades* rather than breaks the server: `github`, `database`, `spotify`, `odds`, `sentry`. Each entry names the env var that enables it and the concrete impact of its absence.

Two consumers:

1. **Boot logs** (`src/index.ts`) — one warning per unconfigured capability:
   ```
   capability disabled: github — GITHUB_TOKEN not set; GitHub Issues and Projects v2 tools fail at call time
   ```
   Deliberately `warn`, not `error`. `logger.error` is bridged to Sentry, so an `error` here would page on every boot of a deployment that intentionally runs without (say) Spotify.

2. **`GET /healthz?deep=1`** — a `capabilities` map, e.g. `{ github: false, database: true, … }`.
   - Kept **off** the shallow `/healthz` so Render'''s deploy-gate payload stays minimal and dependency-free.
   - **Never changes the status code.** A missing capability must not fail the probe — taking the whole service down over an absent `GITHUB_TOKEN` would be strictly worse than the bug being fixed.

## Docs

Added a rotation/expiry section to `docs/secrets-doppler.md`. `GITHUB_TOKEN` is the one secret here that lapses on its own (classic PATs default to a 30-day expiry in the GitHub UI), and it needs **both** `repo` and `project` scopes — a `repo`-only token passes issue calls and fails every Projects v2 tool, which is an easy trap when re-minting.

## Limitation worth knowing

This catches an **unset** variable only. A token that is present but **expired or under-scoped** still reports `github: true` and fails with a 401/403 at call time. Catching that would need a live probe against the GitHub API on the health path, which I did not add — it puts an external dependency inside the readiness surface.

## Testing

- `test/capabilities.test.ts` (new, 7 tests) — per-capability resolution, the summary map, one-warning-per-gap, and an assertion that this path uses `warn` and never `error`.
- `test/http/health-deep.test.ts` (+5 tests) — `github: false`/`true` reporting, 200 preserved with a missing capability, capabilities still present alongside a 503 DB failure, and the shallow probe staying free of capability detail.
- Full suite: **350 passed, 5 skipped, 0 failed**.
- `pnpm run typecheck` clean; `biome check` clean on all touched files.

> [!NOTE]
> `pnpm run verify` fails on `main` today (21 pre-existing Biome format errors from #145/#147, in files unrelated to this change), and CI never runs `verify` — it runs `pnpm test` + `pnpm run build` only. I deliberately did **not** reformat those files here; that debt and the missing CI gate are ORR gap #5 and are being handled on the resiliency branch.

## Remaining for #155 (ops, not code)

- [ ] Mint a PAT with `repo` + `project` scopes
- [ ] Set `GITHUB_TOKEN` in the production Doppler config for `bad-mcp`; confirm it reaches Render
- [ ] Verify `list-labels` against a public **and** a private repo, plus one Projects v2 call and an issue create/update round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)