### PR TITLE
fix(auth): treat the token subject as opaque; make OIDC config provider-neutral (#151, #150)

### DIFF
--- a/.claude/agents/mcp-server-support.md
+++ b/.claude/agents/mcp-server-support.md
@@ -89,7 +89,7 @@ Use the Grep/Glob tools (not raw Select-String) to locate where an env var, rout
 
 | Scenario | What to check |
 |----------|---------------|
-| Auth issue | `src/auth/jwt.ts`, `src/http/middleware/mcp-auth.ts`, `SUPABASE_JWKS_URL` |
+| Auth issue | `src/auth/jwt.ts`, `src/http/middleware/mcp-auth.ts`, `OIDC_JWKS_URL` |
 | Magic-link broken | `src/auth/magic-link.ts`, `src/http/controllers/MagicLinkController.ts`, `MAGIC_LINK_JWT_SECRET` |
 | MCP tool not found | `src/tools/index.ts` (registration), `src/server.ts`, tool schema `description` field |
 | Route returns 404 | `src/http/server.ts` (registration order), `registerDbDependentRoutes()` timing |

--- a/.env.example
+++ b/.env.example
@@ -17,12 +17,28 @@ SHOW_INVITE_TOKEN=0                    # '1' to include invite token in admin re
 # ── Database ──────────────────────────────────────────────────────────────────
 DATABASE_URL=postgresql://postgres:postgres@localhost:5432/mcp_dev
 
-# ── Auth / Supabase ───────────────────────────────────────────────────────────
-SUPABASE_JWKS_URL=https://your-project.supabase.co/.well-known/jwks.json
-# If SUPABASE_JWKS_URL is unset, derived from PUBLIC_SUPABASE_URL
+# ── Auth / OIDC ───────────────────────────────────────────────────────────────
+# Provider-neutral (#150). Verification is standard OIDC discovery + JWKS, so
+# pointing at a different identity provider is an env change, not a code change.
+# The legacy SUPABASE_JWKS_URL / SUPABASE_ISS / SUPABASE_AUD spellings are still
+# accepted (new name wins; a boot warning fires while only the legacy one is set).
+
+# Escape hatch: pin JWKS + issuer explicitly and skip discovery. Both must be set.
+OIDC_JWKS_URL=https://your-project.supabase.co/auth/v1/.well-known/jwks.json
+OIDC_ISSUER=https://your-project.supabase.co/auth/v1
+OIDC_AUDIENCE=authenticated
+
+# Where discovery runs when the two above are unset. Falls back to
+# PUBLIC_SUPABASE_URL + /auth/v1 (GoTrue's base) if this is unset.
+# OIDC_DISCOVERY_BASE=https://your-tenant.logto.app/oidc
+
+# Comma-separated dotted claim paths searched in order for an application role.
+# Default below reproduces the historical hardcoded behaviour.
+# OIDC_ROLE_CLAIM_PATH=app_metadata.role,user_role
+
+# ── Supabase ──────────────────────────────────────────────────────────────────
+# Supabase project URL — still the input OIDC discovery is derived from today.
 PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-SUPABASE_ISS=https://your-project.supabase.co   # Preferred over PUBLIC_SUPABASE_URL
-SUPABASE_AUD=authenticated
 SUPABASE_SERVICE_ROLE_KEY=changeme     # Preferred alias (SUPABASE_SECRET_KEY also accepted)
 SUPABASE_ANON_KEY=changeme             # Public/anon key (PUBLIC_SUPABASE_PUBLISHABLE_KEY also accepted)
 

--- a/docs/operational-readiness-review.md
+++ b/docs/operational-readiness-review.md
@@ -115,8 +115,8 @@ GitHub automation callers      ─┘                                  ├→ Gi
 |---|---|---|
 | `DATABASE_URL` | Postgres connection (Prisma) | All DB features (stub fallback if absent) |
 | `MCP_API_KEY` | MCP gateway key (Bearer or `X-Mcp-Api-Key`) | Gating MCP + DB-dependent REST routes |
-| `SUPABASE_JWKS_URL` / `PUBLIC_SUPABASE_URL` | JWT verification (JWKS) | Admin REST auth |
-| `SUPABASE_ISS`, `SUPABASE_AUD` | JWT `iss`/`aud` validation | Admin REST auth |
+| `OIDC_JWKS_URL` / `PUBLIC_SUPABASE_URL` | JWT verification (JWKS) | Admin REST auth |
+| `OIDC_ISSUER`, `OIDC_AUDIENCE` | JWT `iss`/`aud` validation | Admin REST auth |
 | `SUPABASE_SERVICE_ROLE_KEY` (or `SUPABASE_SECRET_KEY`) | Service-role bypass identity | Server-to-server admin |
 | `INTERNAL_ADMIN_KEY`, `ADMIN_IP_ALLOWLIST` | Harden service-role bypass | Service-role admin path |
 | `GITHUB_TOKEN` | Octokit (Issues/Projects) | GitHub tools |

--- a/docs/runbooks/admin-user-management.md
+++ b/docs/runbooks/admin-user-management.md
@@ -15,7 +15,7 @@ Overview
 Supabase Auth account cleanup (recommended manual steps)
 
 - Deleting a user locally does NOT remove the Supabase Auth account. To remove Supabase Auth account:
-  1. Use Supabase Admin API: `DELETE ${SUPABASE_ISS}/auth/v1/admin/users/:uid` using the service role key.
+  1. Use Supabase Admin API: `DELETE ${PUBLIC_SUPABASE_URL}/auth/v1/admin/users/:uid` using the service role key. (This is the project **root** URL — the previous `${SUPABASE_ISS}` form double-appended `/auth/v1`, since the issuer already ends in it.)
   2. Verify any webhooks or third-party integrations are cleaned up.
   3. If you need to coordinate downstream cleanup (ratings, invites, etc.), follow the project-specific procedures described in the data retention policy.
 

--- a/docs/runbooks/deploy-render.md
+++ b/docs/runbooks/deploy-render.md
@@ -23,22 +23,35 @@ Set these in Render Dashboard > Environment > Environment Variables (secure):
 - `MCP_API_KEY` (optional; for protected control endpoints used by internal tools)
 - `NODE_ENV=production`
 
-Supabase / Auth-related (required for admin & JWT validation):
+Auth / OIDC (required for admin & JWT validation):
 
 - `DATABASE_URL` (Postgres connection string used by Prisma)
+- `OIDC_JWKS_URL` (JWKS endpoint used to validate access tokens)
+- `OIDC_ISSUER` (expected JWT `iss`)
+- `OIDC_AUDIENCE` (expected JWT `aud` / client id)
+- `OIDC_DISCOVERY_BASE` (optional — where discovery runs when the two above are unset; defaults to `PUBLIC_SUPABASE_URL` + `/auth/v1`)
+- `OIDC_ROLE_CLAIM_PATH` (optional — comma-separated dotted claim paths searched for an app role; defaults to `app_metadata.role,user_role`)
+
+Supabase-specific (project access, not token verification):
+
+- `PUBLIC_SUPABASE_URL` (project URL; discovery is derived from this when `OIDC_DISCOVERY_BASE` is unset)
 - `SUPABASE_SECRET_KEY` (preferred server/service role key) — fallback: `SUPABASE_SERVICE_ROLE_KEY`
-- `PUBLIC_SUPABASE_URL` (preferred issuer / public URL) — fallback: `SUPABASE_ISS`
-- `SUPABASE_JWKS_URL` (JWKS endpoint used to validate Supabase-issued JWTs)
-- `SUPABASE_AUD` (expected JWT audience / client id)
 - `PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred publishable/anon key) — fallback: `SUPABASE_ANON_KEY`
+
+> **Renaming the auth vars (#150).** The legacy `SUPABASE_JWKS_URL` / `SUPABASE_ISS` /
+> `SUPABASE_AUD` spellings are still accepted, and the new `OIDC_*` name wins when both
+> are present. To rename without an auth outage: **set the `OIDC_*` vars alongside the
+> existing ones, deploy, confirm auth still works, then delete the legacy vars in a
+> second deploy.** While only a legacy name is set the server logs a warning at boot
+> naming the exact rename, so the leftovers are easy to find.
 
 Add these to the Render service environment and to GitHub Actions secrets (for CI jobs that run DB migrations and integration tests). For local development, use `.env` files and the local Postgres from `docker-compose.yml` with seeded data.
 
 JWT middleware and test fixtures
 
-- The codebase provides a JWT middleware that validates Supabase-issued JWTs using the JWKS endpoint and verifies `iss` and `aud` claims.
+- The codebase provides a JWT middleware that validates issuer-signed access tokens using the JWKS endpoint and verifies `iss` and `aud` claims. Resolution is standard OIDC discovery first, with the explicit env pins as an escape hatch — nothing in the verification path is provider-specific.
 - For tests, we generate an ephemeral RSA key pair and stub the JWKS endpoint so tests can sign and validate tokens without network access.
-- Ensure `SUPABASE_JWKS_URL`, `SUPABASE_AUD`, and `SUPABASE_ISS` are set for CI so the middleware tests run in the DB Integration job or unit tests.
+- Ensure `OIDC_JWKS_URL`, `OIDC_AUDIENCE`, and `OIDC_ISSUER` are set for CI so the middleware tests run in the DB Integration job or unit tests.
 
 Build & Start
 -------------
@@ -135,8 +148,8 @@ Secrets & Token Management
 
 Supabase JWT / JWKS configuration
 
-- Store Supabase-related secrets in Render: `SUPABASE_JWKS_URL`, `SUPABASE_AUD`, `PUBLIC_SUPABASE_URL` (or `SUPABASE_ISS`), `SUPABASE_SECRET_KEY` (or `SUPABASE_SERVICE_ROLE_KEY`), and `DATABASE_URL`.
-- Configure the JWT middleware to validate tokens using the JWKS endpoint (`SUPABASE_JWKS_URL`) and by verifying `aud` and `iss` claims against `SUPABASE_AUD` and `SUPABASE_ISS`.
+- Store auth + Supabase secrets in Render: `OIDC_JWKS_URL`, `OIDC_AUDIENCE`, `OIDC_ISSUER` (or `PUBLIC_SUPABASE_URL` to derive them), `SUPABASE_SECRET_KEY` (or `SUPABASE_SERVICE_ROLE_KEY`), and `DATABASE_URL`.
+- Configure the JWT middleware to validate tokens using the JWKS endpoint (`OIDC_JWKS_URL`) and by verifying `aud` and `iss` claims against `OIDC_AUDIENCE` and `OIDC_ISSUER`.
 - For local development and tests, include a mock JWKS JSON file (e.g., `test/fixtures/mock-jwks.json`) and helper utilities to generate test tokens signed with a test key (do **not** commit private keys). Tests should exercise authorized vs unauthorized flows using these fixtures.
 - The `SUPABASE_SERVICE_ROLE_KEY` is highly sensitive (server-only). Use it for admin CLI operations or server-to-server calls only; never expose it in client code or logs. When rotating the service role key: update Render secrets, update CI secrets, and redeploy; verify any long-lived sessions/tokens are revoked as part of rotation.
 - Add the required GitHub Actions secrets (for example, `DATABASE_URL` and `SUPABASE_SERVICE_ROLE_KEY`) so CI jobs can run migrations and integration tests against ephemeral test databases.

--- a/infra/supabase/README.md
+++ b/infra/supabase/README.md
@@ -32,7 +32,7 @@ Getting started
 
    - `database_url` -> `DATABASE_URL`
    - `service_role_key` -> `SUPABASE_SECRET_KEY` (preferred) — legacy `SUPABASE_SERVICE_ROLE_KEY` still accepted
-   - `jwks_url` -> `SUPABASE_JWKS_URL`
+   - `jwks_url` -> `OIDC_JWKS_URL`
    - `project_public_url` -> `PUBLIC_SUPABASE_URL`
    - `anon_key` -> `PUBLIC_SUPABASE_PUBLISHABLE_KEY` (preferred) — legacy `SUPABASE_ANON_KEY` still accepted
 

--- a/infra/supabase/outputs.tf
+++ b/infra/supabase/outputs.tf
@@ -11,6 +11,6 @@ output "service_role_key" {
 }
 
 output "jwks_url" {
-  description = "JWKS endpoint for Supabase JWT validation (SUPABASE_JWKS_URL)"
+  description = "JWKS endpoint for access-token validation (OIDC_JWKS_URL)"
   value       = "https://<your-project>.supabase.co/.well-known/jwks.json"
 }

--- a/prisma/migrations/20260731120000_profile_issuer_external_id/migration.sql
+++ b/prisma/migrations/20260731120000_profile_issuer_external_id/migration.sql
@@ -1,0 +1,33 @@
+-- Issue #151: stop overloading Profile.id as the identity-provider subject.
+--
+-- `Profile.id` has been doing double duty as the Supabase Auth user.id, and the
+-- auth lookup gated on a UUID-shaped regex before it would even try the id
+-- match. Any issuer that mints non-UUID subjects (Logto uses short alphanumeric
+-- ids) fell through that gate silently and resolved to no profile — which
+-- `resolveAppRole` reports as `isAdmin: false`, quietly downgrading an admin
+-- instead of failing loudly.
+--
+-- Identity moves to an explicit (issuer, external_id) pair so a subject is
+-- attributable to the issuer that minted it, and so two issuers can coexist
+-- during a migration.
+
+ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS "issuer" TEXT;
+ALTER TABLE "Profile" ADD COLUMN IF NOT EXISTS "external_id" TEXT;
+
+-- Backfill. Every pre-existing row's `id` IS the subject the previous code
+-- matched on, so copying it into `external_id` preserves resolution exactly.
+--
+-- `issuer` is deliberately left NULL rather than hardcoded to the current
+-- Supabase issuer URL: this migration runs against dev, CI, and production
+-- databases that point at different Supabase projects, and stamping one
+-- project's issuer would mis-attribute rows in the others. The application
+-- treats a NULL issuer as "pre-migration, not yet attributed" and still matches
+-- it on external_id alone, so the backfill is complete without downtime.
+UPDATE "Profile" SET "external_id" = "id" WHERE "external_id" IS NULL;
+
+CREATE INDEX IF NOT EXISTS "Profile_external_id_idx" ON "Profile"("external_id");
+
+-- One profile per identity per issuer. Postgres treats NULLs as distinct under a
+-- unique index, so this constrains attributed identities without blocking
+-- profiles that have no linked identity yet (seeded or admin-created rows).
+CREATE UNIQUE INDEX IF NOT EXISTS "Profile_issuer_external_id_key" ON "Profile"("issuer", "external_id");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -54,13 +54,29 @@ enum BetMarket {
 
 // Minimal profile linked to Supabase Auth user
 model Profile {
-  id        String   @id // UUID from Supabase Auth user.id
+  // Local surrogate key. Historically this doubled as the Supabase Auth user.id,
+  // which coupled identity to one provider's id format — see issue #151.
+  id String @id
+
+  // The identity that owns this profile, attributed to the issuer that minted it.
+  // `externalId` is an OPAQUE string: Supabase mints UUIDs, Logto mints short
+  // alphanumeric ids, and nothing may assume a shape. Both are nullable so a
+  // profile can exist before anyone has signed in as it (seeded/admin-created),
+  // and so pre-migration rows can carry `externalId` with `issuer` still unknown.
+  issuer     String? @map("issuer")
+  externalId String? @map("external_id")
+
   email     String   @unique
   name      String?
   isAdmin   Boolean  @default(false) @map("is_admin")
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  // One profile per identity per issuer. Postgres treats NULLs as distinct, so
+  // this constrains attributed identities without blocking profiles that have
+  // no linked identity yet.
+  @@unique([issuer, externalId])
+  @@index([externalId])
   @@index([isAdmin])
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -88,28 +88,35 @@ export async function runSeed(prismaClient?: any) {
 
     console.log('Seeding DB...')
 
-    // Generate UUIDs for profiles (matching Supabase Auth format)
+    // Generate surrogate ids for profiles.
     const crypto = await import('crypto')
-    // Bryan's Profile.id MUST equal his Supabase Auth user.id for JWT admin auth
-    // to resolve him as admin (see issue #90). Supply it via ADMIN_SUPABASE_UUID.
-    const adminSupabaseUuid = process.env.ADMIN_SUPABASE_UUID
-    if (!adminSupabaseUuid) {
+    // The identity-provider subject for Bryan's admin profile. Since #151 this
+    // lands in `Profile.externalId` rather than being forced onto `Profile.id`,
+    // so the surrogate key and the provider subject are no longer the same
+    // value and reconciling them is a column update rather than a re-key (#90).
+    const adminExternalId = process.env.ADMIN_SUPABASE_UUID
+    if (!adminExternalId) {
         console.warn(
-            'ADMIN_SUPABASE_UUID not set — using a random UUID for the admin Profile. ' +
-                'JWT admin auth will not match the Supabase user until this is set and any ' +
-                'existing prod row is reconciled (see issue #90).',
+            'ADMIN_SUPABASE_UUID not set — seeding the admin Profile without an ' +
+                'externalId. JWT admin auth will fall back to the email claim until ' +
+                'this is set (see issues #90 and #151).',
         )
     }
-    const bryanUuid = adminSupabaseUuid ?? crypto.randomUUID()
+    const bryanUuid = crypto.randomUUID()
     const adminUuid = crypto.randomUUID()
 
-    // Create Bryan's admin profile
-    // NOTE: In production, this ID should match the Supabase Auth user.id
+    // Create Bryan's admin profile. `issuer` is left NULL — the seed does not
+    // know which issuer will mint the token, and the auth path matches a
+    // NULL-issuer row on externalId alone.
     const bryanAdmin = await db.profile.upsert({
         where: { email: 'brn.dbn@gmail.com' },
-        update: { isAdmin: true },
+        update: {
+            isAdmin: true,
+            ...(adminExternalId ? { externalId: adminExternalId } : {}),
+        },
         create: {
             id: bryanUuid,
+            externalId: adminExternalId ?? null,
             email: 'brn.dbn@gmail.com',
             name: 'Bryan DeBaun',
             isAdmin: true,

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -1,16 +1,23 @@
 import { NextFunction, Request, Response } from 'express'
 import { createRemoteJWKSet, type JWTPayload, jwtVerify } from 'jose'
-import { config } from '../config.js'
+import { config, legacyAuthEnvNames } from '../config.js'
 import { prisma } from '../db/index.js'
+import { authSubjectUnresolvedTotal } from '../http/metrics-route.js'
 import { logger } from '../logger.js'
 
-if (!config.auth.supabaseJwksUrl) {
+if (!config.auth.oidc.jwksUrl) {
     logger.warn(
-        'SUPABASE_JWKS_URL not set; JWT middleware will not validate tokens',
+        'OIDC_JWKS_URL not set; JWT middleware will not validate tokens',
     )
 }
 
-/** Resolved Supabase JWT verification parameters. */
+if (legacyAuthEnvNames.length > 0) {
+    logger.warn(
+        `auth config uses legacy Supabase-prefixed env names (#150); rename in the deployment env: ${legacyAuthEnvNames.join(', ')}`,
+    )
+}
+
+/** Resolved OIDC access-token verification parameters. */
 interface AuthVerifyConfig {
     jwksUrl: string
     issuer: string
@@ -39,31 +46,32 @@ function getJwks(url: string) {
 
 /**
  * Resolve the JWKS URL + issuer to verify against, in priority order:
- *   1. Explicit env overrides (SUPABASE_JWKS_URL + SUPABASE_ISS) — operator escape hatch.
- *   2. OpenID discovery (`<supabase>/auth/v1/.well-known/openid-configuration`) — the
- *      authoritative source for `jwks_uri`/`issuer`, so we track Supabase path changes
- *      automatically rather than hardcoding them.
- *   3. Values derived from PUBLIC_SUPABASE_URL under `/auth/v1` — used if discovery is
- *      unreachable.
+ *   1. Explicit env overrides (OIDC_JWKS_URL + OIDC_ISSUER) — operator escape hatch.
+ *   2. OIDC discovery (`<base>/.well-known/openid-configuration`) — the authoritative
+ *      source for `jwks_uri`/`issuer`, so we track provider path changes automatically
+ *      rather than hardcoding them. This is the primary path and the reason no
+ *      `IIdentityProvider` abstraction is warranted: discovery already *is* the
+ *      vendor-neutral interface.
+ *   3. Values derived from the discovery base — used if discovery is unreachable.
  */
 async function resolveAuthConfig(): Promise<AuthVerifyConfig> {
-    const audience = config.auth.supabaseAud
-    if (!audience) throw new Error('SUPABASE_AUD must be set')
+    const audience = config.auth.oidc.audience
+    if (!audience) throw new Error('OIDC_AUDIENCE must be set')
 
     if (
-        config.auth.supabaseJwksUrlFromEnv &&
-        config.auth.supabaseIssFromEnv &&
-        config.auth.supabaseJwksUrl &&
-        config.auth.supabaseIss
+        config.auth.oidc.jwksUrlFromEnv &&
+        config.auth.oidc.issuerFromEnv &&
+        config.auth.oidc.jwksUrl &&
+        config.auth.oidc.issuer
     ) {
         return {
-            jwksUrl: config.auth.supabaseJwksUrl,
-            issuer: config.auth.supabaseIss,
+            jwksUrl: config.auth.oidc.jwksUrl,
+            issuer: config.auth.oidc.issuer,
             audience,
         }
     }
 
-    const base = config.auth.supabaseAuthBase
+    const base = config.auth.oidc.discoveryBase
     if (base) {
         try {
             const res = await fetch(`${base}/.well-known/openid-configuration`)
@@ -80,30 +88,30 @@ async function resolveAuthConfig(): Promise<AuthVerifyConfig> {
                     }
                 }
                 logger.warn(
-                    'OpenID discovery doc missing jwks_uri/issuer; using derived config',
+                    'OIDC discovery doc missing jwks_uri/issuer; using derived config',
                 )
             } else {
                 logger.warn(
-                    `OpenID discovery returned ${res.status}; using derived config`,
+                    `OIDC discovery returned ${res.status}; using derived config`,
                 )
             }
         } catch (err: any) {
             logger.warn(
-                'OpenID discovery fetch failed; using derived config',
+                'OIDC discovery fetch failed; using derived config',
                 err?.message ?? err,
             )
         }
     }
 
-    if (config.auth.supabaseJwksUrl && config.auth.supabaseIss) {
+    if (config.auth.oidc.jwksUrl && config.auth.oidc.issuer) {
         return {
-            jwksUrl: config.auth.supabaseJwksUrl,
-            issuer: config.auth.supabaseIss,
+            jwksUrl: config.auth.oidc.jwksUrl,
+            issuer: config.auth.oidc.issuer,
             audience,
         }
     }
     throw new Error(
-        'Supabase auth not configured: set PUBLIC_SUPABASE_URL or SUPABASE_JWKS_URL/SUPABASE_ISS',
+        'OIDC auth not configured: set OIDC_DISCOVERY_BASE (or PUBLIC_SUPABASE_URL) or OIDC_JWKS_URL/OIDC_ISSUER',
     )
 }
 
@@ -118,7 +126,7 @@ function getAuthConfig(): Promise<AuthVerifyConfig> {
     return _authConfigPromise
 }
 
-export async function verifySupabaseJwt(token: string): Promise<JWTPayload> {
+export async function verifyAccessToken(token: string): Promise<JWTPayload> {
     const { jwksUrl, issuer, audience } = await getAuthConfig()
     const { payload } = await jwtVerify(token, getJwks(jwksUrl), {
         issuer,
@@ -127,34 +135,74 @@ export async function verifySupabaseJwt(token: string): Promise<JWTPayload> {
     return payload
 }
 
-/**
- * Resolve an application role baked into the token, if present.
- *
- * NOTE: Supabase always sets a top-level `role` claim, but it is the Postgres
- * role (`anon` | `authenticated` | `service_role`) — NOT an application role.
- * We deliberately ignore that claim and look for an app-level role under
- * `app_metadata.role` (admin-controlled, the standard Supabase RBAC location)
- * or a custom top-level `user_role` claim emitted by a custom access-token hook.
- */
-function roleFromToken(payload: any): string | undefined {
-    const appRole = payload?.app_metadata?.role ?? payload?.user_role
-    return typeof appRole === 'string' && appRole.length > 0
-        ? appRole
-        : undefined
+/** Read a dotted claim path (`app_metadata.role`) out of a token payload. */
+function readClaimPath(payload: any, path: string): unknown {
+    return path
+        .split('.')
+        .reduce<any>(
+            (acc, key) => (acc == null ? undefined : acc[key]),
+            payload,
+        )
 }
 
 /**
- * Look up the local Profile for a Supabase user. `Profile.id` IS the Supabase
- * Auth `user.id` (UUID), so match on `id` first; fall back to `email` (from the
- * JWT) so admin auth still works when a stored Profile.id has not yet been
- * reconciled with the Supabase UUID. See issue #90.
+ * Resolve an application role baked into the token, if present.
+ *
+ * Which claims to consult is configuration (`OIDC_ROLE_CLAIM_PATH`), defaulting
+ * to `app_metadata.role` then `user_role` — the previous hardcoded behaviour.
+ *
+ * NOTE: Supabase always sets a top-level `role` claim, but it is the Postgres
+ * role (`anon` | `authenticated` | `service_role`) — NOT an application role, so
+ * it is deliberately absent from the default paths.
  */
-async function findLocalProfileBySub(sub: string, email?: string) {
-    const s = sub ? String(sub) : ''
-    if (s && /^[0-9a-fA-F-]{36}$/.test(s)) {
-        const byId = await prisma.profile.findUnique({ where: { id: s } })
-        if (byId) return byId
+function roleFromToken(payload: any): string | undefined {
+    for (const path of config.auth.oidc.roleClaimPaths) {
+        const value = readClaimPath(payload, path)
+        if (typeof value === 'string' && value.length > 0) return value
     }
+    return undefined
+}
+
+/**
+ * Look up the local Profile for an authenticated subject.
+ *
+ * The subject is treated as an **opaque string** (#151). It used to be gated on
+ * a UUID-shaped regex because `Profile.id` doubled as the Supabase Auth user id;
+ * any issuer minting non-UUID subjects (Logto uses short alphanumeric ids) fell
+ * straight through that gate to the email fallback or to no profile at all —
+ * and `resolveAppRole` reports `isAdmin: false` when no profile is found, so an
+ * admin was silently downgraded rather than erroring loudly.
+ *
+ * Identity now lives in an explicit `(issuer, externalId)` pair, so a subject is
+ * attributable to the issuer that minted it and two issuers can coexist during a
+ * migration. Resolution order:
+ *
+ *   1. A row explicitly attributed to this token's issuer.
+ *   2. A pre-migration row (`issuer` NULL, `externalId` backfilled from `id`).
+ *   3. Email from the JWT — retained per #90, but no longer load-bearing.
+ */
+async function findLocalProfileBySub(
+    sub: string,
+    issuer?: string,
+    email?: string,
+) {
+    const s = sub ? String(sub) : ''
+
+    if (s) {
+        // One round trip for both candidates; prefer the issuer-attributed row
+        // so a legacy unattributed row can't shadow a migrated one.
+        const candidates = await prisma.profile.findMany({
+            where: {
+                externalId: s,
+                OR: [{ issuer: issuer ?? null }, { issuer: null }],
+            },
+        })
+        const attributed = candidates.find((p: any) => p.issuer === issuer)
+        if (attributed) return attributed
+        const legacy = candidates.find((p: any) => p.issuer === null)
+        if (legacy) return legacy
+    }
+
     const emailToTry = s.includes('@') ? s : email
     if (emailToTry)
         return prisma.profile.findUnique({ where: { email: emailToTry } })
@@ -165,13 +213,21 @@ export interface ResolvedAuthz {
     role: string
     isAdmin: boolean
     localUserId?: unknown
+    /**
+     * True when the token verified but no local Profile could be matched to its
+     * subject. Distinguishes "we know who this is, they are not an admin" from
+     * "we could not identify this user at all" — the two used to be
+     * indistinguishable, which is what made the #151 downgrade silent.
+     */
+    unresolvedSubject?: boolean
 }
 
 /**
  * Hybrid authorization resolution: prefer an app role baked into the token
  * (stateless, no DB hit — the standard/scalable path); otherwise fall back to
- * the local Profile (by id, then email). Pure — returns the resolution so both
- * the Express middleware and the TSOA authentication handler can share it.
+ * the local Profile (by issuer+subject, then email). Pure — returns the
+ * resolution so both the Express middleware and the TSOA authentication handler
+ * can share it.
  */
 export async function resolveAppRole(payload: any): Promise<ResolvedAuthz> {
     const tokenRole = roleFromToken(payload)
@@ -183,8 +239,11 @@ export async function resolveAppRole(payload: any): Promise<ResolvedAuthz> {
         }
     }
 
+    const sub = payload?.sub ? String(payload.sub) : ''
+    const issuer = typeof payload?.iss === 'string' ? payload.iss : undefined
     const profile = await findLocalProfileBySub(
-        payload?.sub ? String(payload.sub) : '',
+        sub,
+        issuer,
         typeof payload?.email === 'string' ? payload.email : undefined,
     )
     if (profile) {
@@ -195,11 +254,27 @@ export async function resolveAppRole(payload: any): Promise<ResolvedAuthz> {
         }
     }
 
-    // No app role and no local profile: preserve the token's (Postgres) role
-    // claim so non-admin authenticated users still pass non-admin guards.
+    // No app role and no local profile. This still fails closed on admin, but it
+    // is now loud: a valid token whose subject we cannot map to a profile is an
+    // identity problem, not an authorization answer, and it should never again
+    // look the same as an ordinary non-admin user in the logs.
+    try {
+        authSubjectUnresolvedTotal.inc()
+    } catch {
+        /* metrics must never break auth */
+    }
+    logger.warn('auth: token verified but no local profile resolved', {
+        sub,
+        issuer,
+        hasEmailClaim: typeof payload?.email === 'string',
+    })
+
+    // Preserve the token's (Postgres) role claim so non-admin authenticated
+    // users still pass non-admin guards.
     return {
         role: typeof payload?.role === 'string' ? payload.role : 'user',
         isAdmin: false,
+        unresolvedSubject: true,
     }
 }
 
@@ -218,7 +293,7 @@ export async function jwtMiddleware(
 ) {
     try {
         const auth = req.headers.authorization
-        const serviceRoleKey = config.auth.supabaseServiceRoleKey
+        const serviceRoleKey = config.auth.serviceRoleKey
 
         if (auth) {
             // If Authorization header exists it must be a Bearer token
@@ -238,7 +313,7 @@ export async function jwtMiddleware(
             }
 
             const token = auth.slice('Bearer '.length)
-            const payload = await verifySupabaseJwt(token)
+            const payload = await verifyAccessToken(token)
 
             // attach a minimal user object (from token)
             ;(<any>req).user = Object.assign({ sub: payload.sub }, payload)
@@ -256,8 +331,8 @@ export async function jwtMiddleware(
             return next()
         }
 
-        // No Authorization header — a Supabase JWT bearer token is the only
-        // accepted credential (custom session-cookie auth was removed).
+        // No Authorization header — an OIDC bearer token is the only accepted
+        // credential (custom session-cookie auth was removed).
         return res.status(401).json({ error: 'Missing token' })
     } catch (err: any) {
         logger.warn('JWT validation failed', err?.message ?? err)

--- a/src/auth/optional-admin.ts
+++ b/src/auth/optional-admin.ts
@@ -1,8 +1,8 @@
 import type { Request } from 'express'
-import { resolveAppRole, verifySupabaseJwt } from './jwt.js'
+import { resolveAppRole, verifyAccessToken } from './jwt.js'
 
 /**
- * Best-effort check of whether a request carries a valid **admin** Supabase JWT.
+ * Best-effort check of whether a request carries a valid **admin** access token.
  *
  * Used by endpoints gated by the MCP gateway key (`@Security('api_key')`) that
  * want to *additionally* unlock admin-only views (e.g. draft articles) when an
@@ -16,7 +16,7 @@ export async function requestIsAdmin(req: Request): Promise<boolean> {
     const auth = req.headers.authorization
     if (!auth || !auth.startsWith('Bearer ')) return false
     try {
-        const payload = await verifySupabaseJwt(auth.slice('Bearer '.length))
+        const payload = await verifyAccessToken(auth.slice('Bearer '.length))
         const { isAdmin } = await resolveAppRole(payload)
         return isAdmin
     } catch {

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,13 +96,32 @@ const envSchema = z.object({
     // ── Database ──────────────────────────────────────────────────────────
     DATABASE_URL: z.string().url().optional(),
 
-    // ── Auth / Supabase ───────────────────────────────────────────────────
-    // JWKS URL: prefer explicit; derive from PUBLIC_SUPABASE_URL as fallback
+    // ── Auth / OIDC ───────────────────────────────────────────────────────
+    // Provider-neutral names (#150). The mechanism was always vendor-agnostic —
+    // OIDC discovery + JWKS + standard claims — only the naming was Supabase's.
+    // The legacy `SUPABASE_*` spellings are still accepted so the Render env can
+    // be renamed across a deploy boundary without an auth outage; the new name
+    // wins, and a warning fires while only the legacy one is set.
+    OIDC_JWKS_URL: z.string().url().optional(),
+    OIDC_ISSUER: z.string().optional(),
+    OIDC_AUDIENCE: z.string().optional(),
+    // Where to run OIDC discovery. Explicit, provider-neutral form; falls back to
+    // `PUBLIC_SUPABASE_URL + /auth/v1` (GoTrue's base) when unset.
+    OIDC_DISCOVERY_BASE: z.string().url().optional(),
+    // Comma-separated dotted claim paths searched in order for an application
+    // role. Default reproduces the previous hardcoded behaviour exactly.
+    OIDC_ROLE_CLAIM_PATH: z.string().optional(),
+
+    // Legacy aliases — retained for one deploy, then droppable (#150).
     SUPABASE_JWKS_URL: z.string().url().optional(),
-    PUBLIC_SUPABASE_URL: z.string().url().optional(),
     SUPABASE_ISS: z.string().optional(),
     SUPABASE_AUD: z.string().optional(),
-    // Service role key — accept either alias
+
+    // Supabase project URL — still the input we derive discovery from today, and
+    // genuinely Supabase's own name for it, so it keeps its spelling.
+    PUBLIC_SUPABASE_URL: z.string().url().optional(),
+    // Service role key — accept either alias. Not part of token verification;
+    // this is the bearer shortcut #152 tracks replacing with client_credentials.
     SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
     SUPABASE_SECRET_KEY: z.string().optional(),
     // Anon / publishable key — accept either alias
@@ -170,22 +189,62 @@ const env = result.data
 // Derived / normalized values
 // ---------------------------------------------------------------------------
 
+// ── OIDC (#150) ────────────────────────────────────────────────────────────
+// Each setting accepts the provider-neutral name first and the legacy
+// Supabase-prefixed name second, so both can coexist for one deploy.
+const oidcJwksUrlFromEnv = env.OIDC_JWKS_URL ?? env.SUPABASE_JWKS_URL
+const oidcIssuerFromEnv = env.OIDC_ISSUER ?? env.SUPABASE_ISS
+const oidcAudienceFromEnv = env.OIDC_AUDIENCE ?? env.SUPABASE_AUD
+
+/** Legacy env names still in use — reported at boot so the rename can finish. */
+export const legacyAuthEnvNames: string[] = [
+    env.OIDC_JWKS_URL === undefined && env.SUPABASE_JWKS_URL !== undefined
+        ? 'SUPABASE_JWKS_URL → OIDC_JWKS_URL'
+        : undefined,
+    env.OIDC_ISSUER === undefined && env.SUPABASE_ISS !== undefined
+        ? 'SUPABASE_ISS → OIDC_ISSUER'
+        : undefined,
+    env.OIDC_AUDIENCE === undefined && env.SUPABASE_AUD !== undefined
+        ? 'SUPABASE_AUD → OIDC_AUDIENCE'
+        : undefined,
+].filter((v): v is string => v !== undefined)
+
 // Supabase's GoTrue auth service lives under `/auth/v1`, so both the issuer and
 // the JWKS endpoint are derived from `PUBLIC_SUPABASE_URL + /auth/v1` — NOT the
 // project root. (The token's `iss` is `https://<ref>.supabase.co/auth/v1` and the
 // JWKS lives at `<iss>/.well-known/jwks.json`; deriving from the bare root yields
 // a 404 JWKS and an issuer mismatch — both surface as opaque 401s.)
-const supabaseAuthBase: string | undefined = env.PUBLIC_SUPABASE_URL
-    ? `${env.PUBLIC_SUPABASE_URL.replace(/\/$/, '')}/auth/v1`
-    : undefined
+// `OIDC_DISCOVERY_BASE` overrides this for any non-Supabase issuer.
+const oidcDiscoveryBase: string | undefined =
+    env.OIDC_DISCOVERY_BASE ??
+    (env.PUBLIC_SUPABASE_URL
+        ? `${env.PUBLIC_SUPABASE_URL.replace(/\/$/, '')}/auth/v1`
+        : undefined)
 
-/** Resolved JWKS URL: explicit var wins; derived from `<supabase>/auth/v1` otherwise. */
-const supabaseJwksUrl: string | undefined =
-    env.SUPABASE_JWKS_URL ??
-    (supabaseAuthBase ? `${supabaseAuthBase}/.well-known/jwks.json` : undefined)
+/** Resolved JWKS URL: explicit var wins; derived from the discovery base otherwise. */
+const oidcJwksUrl: string | undefined =
+    oidcJwksUrlFromEnv ??
+    (oidcDiscoveryBase
+        ? `${oidcDiscoveryBase}/.well-known/jwks.json`
+        : undefined)
 
-/** Resolved issuer: explicit SUPABASE_ISS wins; fallback to `<supabase>/auth/v1`. */
-const supabaseIss: string | undefined = env.SUPABASE_ISS ?? supabaseAuthBase
+/** Resolved issuer: explicit var wins; fallback to the discovery base. */
+const oidcIssuer: string | undefined = oidcIssuerFromEnv ?? oidcDiscoveryBase
+
+/**
+ * Dotted claim paths searched in order for an application role.
+ *
+ * The default reproduces the previous hardcoded behaviour: `app_metadata.role`
+ * (admin-controlled, the standard Supabase RBAC location) then a top-level
+ * `user_role` claim from a custom access-token hook. A different provider can
+ * point this at, say, `scope` or a namespaced claim without a code change.
+ */
+const oidcRoleClaimPaths: string[] = (
+    env.OIDC_ROLE_CLAIM_PATH ?? 'app_metadata.role,user_role'
+)
+    .split(',')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0)
 
 /** Service role key: prefer the canonical name; accept legacy alias. */
 const supabaseServiceRoleKey: string | undefined =
@@ -239,22 +298,30 @@ export const config = {
     },
 
     auth: {
-        // Derived (or explicit) JWKS URL / issuer — used as the fallback when
-        // OpenID discovery is unavailable. The `*FromEnv` flags let the auth layer
-        // know whether the operator pinned these explicitly (in which case they win
-        // over discovery).
-        supabaseJwksUrl,
-        supabaseIss,
-        supabaseJwksUrlFromEnv: Boolean(env.SUPABASE_JWKS_URL),
-        supabaseIssFromEnv: Boolean(env.SUPABASE_ISS),
-        // `<project>/auth/v1` — the GoTrue base; OpenID discovery and the derived
-        // JWKS/issuer all hang off this.
-        supabaseAuthBase,
-        // Supabase access tokens carry `aud: 'authenticated'` by default; allow an
-        // explicit override but don't require operators to set it.
-        supabaseAud: env.SUPABASE_AUD ?? 'authenticated',
-        supabaseServiceRoleKey,
-        supabaseAnonKey,
+        // Provider-neutral OIDC verification parameters (#150). Nothing in here
+        // is Supabase-specific: OIDC discovery + JWKS + standard claims already
+        // *is* the vendor-agnostic interface, so pointing at a different issuer
+        // is an env change rather than a code change.
+        oidc: {
+            // Derived (or explicit) JWKS URL / issuer — the fallback when OIDC
+            // discovery is unavailable. The `*FromEnv` flags tell the auth layer
+            // whether the operator pinned these explicitly (in which case they
+            // win over discovery).
+            jwksUrl: oidcJwksUrl,
+            issuer: oidcIssuer,
+            jwksUrlFromEnv: Boolean(oidcJwksUrlFromEnv),
+            issuerFromEnv: Boolean(oidcIssuerFromEnv),
+            // Base for `/.well-known/openid-configuration`.
+            discoveryBase: oidcDiscoveryBase,
+            // Supabase access tokens carry `aud: 'authenticated'` by default;
+            // allow an explicit override but don't require operators to set it.
+            audience: oidcAudienceFromEnv ?? 'authenticated',
+            roleClaimPaths: oidcRoleClaimPaths,
+        },
+        // Not part of token verification — the shared-secret bearer shortcut that
+        // #152 tracks replacing with a real client_credentials grant.
+        serviceRoleKey: supabaseServiceRoleKey,
+        anonKey: supabaseAnonKey,
     },
 
     spotify: {

--- a/src/http/authentication.ts
+++ b/src/http/authentication.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express'
-import { resolveAppRole, verifySupabaseJwt } from '../auth/jwt.js'
+import { resolveAppRole, verifyAccessToken } from '../auth/jwt.js'
 import { config } from '../config.js'
 
 /** Build an error carrying an HTTP status so the global handler emits a clean 4xx. */
@@ -50,17 +50,17 @@ export async function expressAuthentication(
 
         let decoded
         try {
-            decoded = await verifySupabaseJwt(token)
+            decoded = await verifyAccessToken(token)
         } catch {
-            // verifySupabaseJwt logs the underlying cause (bad signature, JWKS
+            // verifyAccessToken logs the underlying cause (bad signature, JWKS
             // fetch, expired, etc.). Surface a clean 401 instead of letting a jose
             // throw fall through to the generic 'internal error' handler (#117).
             throw authError('Invalid or expired token', 401)
         }
 
         // Resolve the application role the same way as the Express middleware:
-        // a token-baked app role (app_metadata.role) wins, otherwise the local
-        // Profile (by id, then email). The Supabase top-level `role` claim is
+        // a token-baked app role wins, otherwise the local Profile (by
+        // issuer+subject, then email). The Supabase top-level `role` claim is
         // the Postgres role ('authenticated') — NOT an app role — so checking it
         // directly (the previous behavior) always failed admin scope checks.
         const { role, isAdmin } = await resolveAppRole(decoded)

--- a/src/http/metrics-route.ts
+++ b/src/http/metrics-route.ts
@@ -63,6 +63,19 @@ export const mcpAuthFailuresTotal = new Counter({
     help: 'Total number of MCP API auth failures',
 })
 
+/**
+ * Tokens that verified but whose subject matched no local Profile (#151).
+ *
+ * Deliberately separate from `mcp_auth_failures_total`: this is not an auth
+ * failure — the request proceeds as a non-admin. It is the signal that an
+ * identity mapping is broken, which is exactly the condition that used to
+ * silently downgrade an admin with no distinguishable trace.
+ */
+export const authSubjectUnresolvedTotal = new Counter({
+    name: 'auth_subject_unresolved_total',
+    help: 'Verified tokens whose subject could not be mapped to a local Profile',
+})
+
 // Book aggregate metrics
 export const bookAggregateUpdateFailuresTotal = new Counter({
     name: 'book_aggregate_update_failures_total',

--- a/test/auth/jwt.test.ts
+++ b/test/auth/jwt.test.ts
@@ -1,4 +1,4 @@
-import express from 'express'
+﻿import express from 'express'
 import { exportJWK, generateKeyPair, SignJWT } from 'jose'
 import request from 'supertest'
 import {
@@ -13,7 +13,7 @@ import {
 import {
     __resetAuthCaches,
     jwtMiddleware,
-    verifySupabaseJwt,
+    verifyAccessToken,
 } from '../../src/auth/jwt'
 import { requireAdmin } from '../../src/auth/requireAdmin'
 import { config } from '../../src/config.js'
@@ -36,13 +36,13 @@ let origInternalAdminKey: string | undefined
 
 beforeAll(async () => {
     // Save originals
-    origJwksUrl = config.auth.supabaseJwksUrl
-    origIss = config.auth.supabaseIss
-    origAud = config.auth.supabaseAud
-    origSvcKey = config.auth.supabaseServiceRoleKey
-    origAnonKey = config.auth.supabaseAnonKey
-    origJwksFromEnv = config.auth.supabaseJwksUrlFromEnv
-    origIssFromEnv = config.auth.supabaseIssFromEnv
+    origJwksUrl = config.auth.oidc.jwksUrl
+    origIss = config.auth.oidc.issuer
+    origAud = config.auth.oidc.audience
+    origSvcKey = config.auth.serviceRoleKey
+    origAnonKey = config.auth.anonKey
+    origJwksFromEnv = config.auth.oidc.jwksUrlFromEnv
+    origIssFromEnv = config.auth.oidc.issuerFromEnv
     origAdminIpAllowlist = config.security.adminIpAllowlist
     origInternalAdminKey = config.security.internalAdminKey
 
@@ -67,21 +67,21 @@ beforeAll(async () => {
     // Set config values used by middleware (replaces process.env.* reads). Pin the
     // JWKS/issuer as explicit env overrides so verification uses them directly
     // (discovery is exercised separately below).
-    config.auth.supabaseJwksUrl = jwksUrl
-    config.auth.supabaseIss = issuer
-    config.auth.supabaseAud = audience
-    config.auth.supabaseJwksUrlFromEnv = true
-    config.auth.supabaseIssFromEnv = true
+    config.auth.oidc.jwksUrl = jwksUrl
+    config.auth.oidc.issuer = issuer
+    config.auth.oidc.audience = audience
+    config.auth.oidc.jwksUrlFromEnv = true
+    config.auth.oidc.issuerFromEnv = true
 })
 
 afterAll(() => {
-    config.auth.supabaseJwksUrl = origJwksUrl
-    config.auth.supabaseIss = origIss
-    config.auth.supabaseAud = origAud
-    config.auth.supabaseServiceRoleKey = origSvcKey
-    config.auth.supabaseAnonKey = origAnonKey
-    config.auth.supabaseJwksUrlFromEnv = origJwksFromEnv
-    config.auth.supabaseIssFromEnv = origIssFromEnv
+    config.auth.oidc.jwksUrl = origJwksUrl
+    config.auth.oidc.issuer = origIss
+    config.auth.oidc.audience = origAud
+    config.auth.serviceRoleKey = origSvcKey
+    config.auth.anonKey = origAnonKey
+    config.auth.oidc.jwksUrlFromEnv = origJwksFromEnv
+    config.auth.oidc.issuerFromEnv = origIssFromEnv
     config.security.adminIpAllowlist = origAdminIpAllowlist
     config.security.internalAdminKey = origInternalAdminKey
     __resetAuthCaches()
@@ -90,12 +90,12 @@ afterAll(() => {
 
 afterEach(() => {
     // Restore per-test mutations between tests
-    config.auth.supabaseServiceRoleKey = origSvcKey
-    config.auth.supabaseAnonKey = origAnonKey
-    config.auth.supabaseJwksUrl = jwksUrl
-    config.auth.supabaseIss = issuer
-    config.auth.supabaseJwksUrlFromEnv = true
-    config.auth.supabaseIssFromEnv = true
+    config.auth.serviceRoleKey = origSvcKey
+    config.auth.anonKey = origAnonKey
+    config.auth.oidc.jwksUrl = jwksUrl
+    config.auth.oidc.issuer = issuer
+    config.auth.oidc.jwksUrlFromEnv = true
+    config.auth.oidc.issuerFromEnv = true
     config.security.adminIpAllowlist = origAdminIpAllowlist
     config.security.internalAdminKey = origInternalAdminKey
     // Clear memoized auth config + JWKS so the next test re-resolves from config.
@@ -138,7 +138,7 @@ describe('JWT middleware', () => {
         expect(res.status).toBe(401)
     })
 
-    it('verifySupabaseJwt fails for expired token', async () => {
+    it('verifyAccessToken fails for expired token', async () => {
         const token = await new SignJWT({ role: 'authenticated' })
             .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
             .setIssuer(issuer)
@@ -151,7 +151,7 @@ describe('JWT middleware', () => {
         // wait to expire
         await new Promise((r) => setTimeout(r, 1100))
 
-        await expect(verifySupabaseJwt(token)).rejects.toThrow()
+        await expect(verifyAccessToken(token)).rejects.toThrow()
     })
 
     it('resolves jwks_uri and issuer from the OpenID discovery document when not pinned via env', async () => {
@@ -160,7 +160,7 @@ describe('JWT middleware', () => {
         const discoIssuer = discoBase
 
         const prevFetch = (global as any).fetch
-        const prevAuthBase = config.auth.supabaseAuthBase
+        const prevAuthBase = config.auth.oidc.discoveryBase
         vi.stubGlobal('fetch', async (url: string) => {
             const u = url.toString()
             if (u === `${discoBase}/.well-known/openid-configuration`) {
@@ -184,9 +184,9 @@ describe('JWT middleware', () => {
         })
 
         // Force the discovery path: no explicit env pin, drive off the auth base.
-        config.auth.supabaseJwksUrlFromEnv = false
-        config.auth.supabaseIssFromEnv = false
-        config.auth.supabaseAuthBase = discoBase
+        config.auth.oidc.jwksUrlFromEnv = false
+        config.auth.oidc.issuerFromEnv = false
+        config.auth.oidc.discoveryBase = discoBase
         __resetAuthCaches()
 
         const token = await new SignJWT({ role: 'authenticated' })
@@ -198,18 +198,18 @@ describe('JWT middleware', () => {
             .setExpirationTime('2h')
             .sign(privateKey as any)
 
-        const payload = await verifySupabaseJwt(token)
+        const payload = await verifyAccessToken(token)
         expect(String((payload as any).sub)).toBe('user-disco')
 
         // restore (afterEach also re-pins env + resets caches)
         ;(global as any).fetch = prevFetch
-        config.auth.supabaseAuthBase = prevAuthBase
+        config.auth.oidc.discoveryBase = prevAuthBase
     })
 
     it('rejects service role key when not allowed by header or IP allowlist', async () => {
         const app = express()
         const serviceKey = 'super-secret-service-key'
-        config.auth.supabaseServiceRoleKey = serviceKey
+        config.auth.serviceRoleKey = serviceKey
         app.get('/whoami', jwtMiddleware, (req, res) =>
             res.json({ user: (req as any).user }),
         )
@@ -228,7 +228,7 @@ describe('JWT middleware', () => {
     it('allows service key when ip is allowlisted and header present and writes audit log + metric', async () => {
         const app = express()
         const serviceKey = 'super-secret-service-key'
-        config.auth.supabaseServiceRoleKey = serviceKey
+        config.auth.serviceRoleKey = serviceKey
 
         // Mock prisma.auditLog.create and metric
         const p = (await import('../../src/db/index.js')) as any
@@ -261,79 +261,192 @@ describe('JWT middleware', () => {
         expect(incSpy).toHaveBeenCalled()
     })
 
-    // --- Issue #90: JWT admin auth resolution -------------------------------
+    // --- Issues #90 / #151: JWT admin auth resolution -----------------------
 
-    it('grants admin by matching a UUID sub to a local admin Profile by id (issue #90)', async () => {
-        const supabaseSub = '00b72aac-2286-48e5-955a-c8012cceb9c5'
-        const token = await new SignJWT({
-            role: 'authenticated',
-            email: 'brn.dbn@gmail.com',
-        })
+    /** Sign a token for `sub` against the pinned test issuer/audience. */
+    const signFor = async (sub: string, claims: Record<string, unknown> = {}) =>
+        new SignJWT({ role: 'authenticated', ...claims })
             .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
             .setIssuer(issuer)
             .setAudience(audience)
-            .setSubject(supabaseSub)
+            .setSubject(sub)
             .setIssuedAt()
             .setExpirationTime('2h')
             .sign(privateKey as any)
 
-        const p = (await import('../../src/db/index.js')) as any
-        const findUnique = vi.fn().mockResolvedValue({
-            id: supabaseSub,
-            email: 'brn.dbn@gmail.com',
-            isAdmin: true,
-        })
-        p.prisma.profile = { findUnique }
-
+    /** Tiny app exposing an admin-gated route through the real middleware. */
+    const adminApp = () => {
         const app = express()
         app.get('/admin', jwtMiddleware, requireAdmin, (_req, res) =>
             res.json({ ok: true }),
         )
+        return app
+    }
 
-        const res = await request(app)
+    it('grants admin by matching a UUID sub to a local admin Profile (issue #90)', async () => {
+        const sub = '00b72aac-2286-48e5-955a-c8012cceb9c5'
+        const token = await signFor(sub, { email: 'brn.dbn@gmail.com' })
+
+        const p = (await import('../../src/db/index.js')) as any
+        const findMany = vi.fn().mockResolvedValue([
+            {
+                id: 'local-surrogate-id',
+                issuer: null,
+                externalId: sub,
+                email: 'brn.dbn@gmail.com',
+                isAdmin: true,
+            },
+        ])
+        p.prisma.profile = { findMany, findUnique: vi.fn() }
+
+        const res = await request(adminApp())
             .get('/admin')
             .set('Authorization', `Bearer ${token}`)
         expect(res.status).toBe(200)
-        // Regression guard: lookup must be by `id`, not the nonexistent `external_id`
-        expect(findUnique).toHaveBeenCalledWith({ where: { id: supabaseSub } })
+        // Identity is matched on externalId scoped to the minting issuer, with a
+        // NULL-issuer (pre-migration) row still accepted.
+        expect(findMany).toHaveBeenCalledWith({
+            where: {
+                externalId: sub,
+                OR: [{ issuer }, { issuer: null }],
+            },
+        })
     })
 
-    it('falls back to email lookup when the UUID id lookup misses (issue #90)', async () => {
-        const supabaseSub = '11111111-2222-3333-4444-555555555555'
-        const email = 'brn.dbn@gmail.com'
-        const token = await new SignJWT({ role: 'authenticated', email })
-            .setProtectedHeader({ alg: 'RS256', kid: publicJwk.kid })
-            .setIssuer(issuer)
-            .setAudience(audience)
-            .setSubject(supabaseSub)
-            .setIssuedAt()
-            .setExpirationTime('2h')
-            .sign(privateKey as any)
+    // The #151 bug in one test: this subject is not UUID-shaped, so the old
+    // regex-gated lookup skipped the DB entirely and reported isAdmin: false.
+    it('grants admin for a NON-UUID subject with an admin profile (issue #151)', async () => {
+        const logtoStyleSub = 'x7k2p9qm4n'
+        const token = await signFor(logtoStyleSub)
 
         const p = (await import('../../src/db/index.js')) as any
-        const findUnique = vi
-            .fn()
-            .mockResolvedValueOnce(null) // id miss (stored Profile.id not yet reconciled)
-            .mockResolvedValueOnce({
-                id: 'stored-random-uuid',
-                email,
+        const findMany = vi.fn().mockResolvedValue([
+            {
+                id: 'local-surrogate-id',
+                issuer,
+                externalId: logtoStyleSub,
+                email: 'brn.dbn@gmail.com',
                 isAdmin: true,
-            }) // email hit
-        p.prisma.profile = { findUnique }
+            },
+        ])
+        p.prisma.profile = { findMany, findUnique: vi.fn() }
 
-        const app = express()
-        app.get('/admin', jwtMiddleware, requireAdmin, (_req, res) =>
-            res.json({ ok: true }),
-        )
-
-        const res = await request(app)
+        const res = await request(adminApp())
             .get('/admin')
             .set('Authorization', `Bearer ${token}`)
         expect(res.status).toBe(200)
-        expect(findUnique).toHaveBeenNthCalledWith(1, {
-            where: { id: supabaseSub },
+        expect(findMany).toHaveBeenCalled()
+    })
+
+    it('prefers the issuer-attributed row over a legacy NULL-issuer row (issue #151)', async () => {
+        const sub = 'shared-subject-value'
+        const token = await signFor(sub)
+
+        const p = (await import('../../src/db/index.js')) as any
+        // Returned in the "wrong" order on purpose: selection must not depend on
+        // the order Postgres happens to hand rows back in.
+        const findMany = vi.fn().mockResolvedValue([
+            { id: 'legacy', issuer: null, externalId: sub, isAdmin: false },
+            { id: 'migrated', issuer, externalId: sub, isAdmin: true },
+        ])
+        p.prisma.profile = { findMany, findUnique: vi.fn() }
+
+        const res = await request(adminApp())
+            .get('/admin')
+            .set('Authorization', `Bearer ${token}`)
+        expect(res.status).toBe(200)
+    })
+
+    it('falls back to email lookup when the subject lookup misses (issue #90)', async () => {
+        const sub = '11111111-2222-3333-4444-555555555555'
+        const email = 'brn.dbn@gmail.com'
+        const token = await signFor(sub, { email })
+
+        const p = (await import('../../src/db/index.js')) as any
+        const findMany = vi.fn().mockResolvedValue([]) // no identity row yet
+        const findUnique = vi.fn().mockResolvedValue({
+            id: 'stored-random-uuid',
+            email,
+            isAdmin: true,
         })
-        expect(findUnique).toHaveBeenNthCalledWith(2, { where: { email } })
+        p.prisma.profile = { findMany, findUnique }
+
+        const res = await request(adminApp())
+            .get('/admin')
+            .set('Authorization', `Bearer ${token}`)
+        expect(res.status).toBe(200)
+        expect(findUnique).toHaveBeenCalledWith({ where: { email } })
+    })
+
+    it('counts and logs an unresolvable subject distinctly from a resolved non-admin (issue #151)', async () => {
+        const { resolveAppRole } = await import('../../src/auth/jwt.js')
+        const m = (await import('../../src/http/metrics-route.js')) as any
+        const { logger } = (await import('../../src/logger.js')) as any
+        const p = (await import('../../src/db/index.js')) as any
+
+        const incSpy = vi
+            .spyOn(m.authSubjectUnresolvedTotal, 'inc')
+            .mockImplementation(() => {})
+        const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {})
+
+        // 1. Resolved, but not an admin — an ordinary answer. Silent.
+        p.prisma.profile = {
+            findMany: vi
+                .fn()
+                .mockResolvedValue([
+                    { id: 'p1', issuer, externalId: 'known', isAdmin: false },
+                ]),
+            findUnique: vi.fn(),
+        }
+        const resolved = await resolveAppRole({ sub: 'known', iss: issuer })
+        expect(resolved).toMatchObject({ isAdmin: false, role: 'user' })
+        expect(resolved.unresolvedSubject).toBeUndefined()
+        expect(incSpy).not.toHaveBeenCalled()
+
+        // 2. Nothing matched — an identity problem, not an authorization answer.
+        p.prisma.profile = {
+            findMany: vi.fn().mockResolvedValue([]),
+            findUnique: vi.fn().mockResolvedValue(null),
+        }
+        const unresolved = await resolveAppRole({
+            sub: 'ghost',
+            iss: issuer,
+            role: 'authenticated',
+        })
+        expect(unresolved).toMatchObject({
+            isAdmin: false,
+            unresolvedSubject: true,
+        })
+        expect(incSpy).toHaveBeenCalledTimes(1)
+        expect(warnSpy).toHaveBeenCalledWith(
+            'auth: token verified but no local profile resolved',
+            expect.objectContaining({ sub: 'ghost', issuer }),
+        )
+
+        incSpy.mockRestore()
+        warnSpy.mockRestore()
+    })
+
+    it('reads the app role from a configured custom claim path (#150)', async () => {
+        const { resolveAppRole } = await import('../../src/auth/jwt.js')
+        const orig = config.auth.oidc.roleClaimPaths
+        const p = (await import('../../src/db/index.js')) as any
+        const findMany = vi.fn()
+        p.prisma.profile = { findMany, findUnique: vi.fn() }
+
+        try {
+            config.auth.oidc.roleClaimPaths = ['realm_access.app_role']
+            const resolved = await resolveAppRole({
+                sub: 'user-x',
+                realm_access: { app_role: 'admin' },
+                // The default paths are present but must be ignored now.
+                app_metadata: { role: 'user' },
+            })
+            expect(resolved).toMatchObject({ role: 'admin', isAdmin: true })
+            expect(findMany).not.toHaveBeenCalled() // still stateless
+        } finally {
+            config.auth.oidc.roleClaimPaths = orig
+        }
     })
 
     it('grants admin from app_metadata.role in the token without any DB lookup (hybrid)', async () => {

--- a/test/config/config.test.ts
+++ b/test/config/config.test.ts
@@ -83,42 +83,73 @@ describe('config module', () => {
             expect(config.spotify.enabled).toBe(expected)
         })
 
-        it('auth.supabaseIss is a string when set', () => {
-            if (config.auth.supabaseIss !== undefined) {
-                expect(typeof config.auth.supabaseIss).toBe('string')
-                expect(config.auth.supabaseIss.length).toBeGreaterThan(0)
+        it('auth.oidc.issuer is a string when set', () => {
+            if (config.auth.oidc.issuer !== undefined) {
+                expect(typeof config.auth.oidc.issuer).toBe('string')
+                expect(config.auth.oidc.issuer.length).toBeGreaterThan(0)
             }
         })
 
-        it('auth.supabaseJwksUrl is derived under /auth/v1 from PUBLIC_SUPABASE_URL when SUPABASE_JWKS_URL absent', () => {
+        it('auth.oidc.jwksUrl is derived under /auth/v1 from PUBLIC_SUPABASE_URL when no explicit JWKS URL is set', () => {
             if (
+                !process.env.OIDC_JWKS_URL &&
                 !process.env.SUPABASE_JWKS_URL &&
+                !process.env.OIDC_DISCOVERY_BASE &&
                 process.env.PUBLIC_SUPABASE_URL
             ) {
                 // Supabase serves JWKS under the GoTrue path, not the project root.
-                expect(config.auth.supabaseJwksUrl).toContain(
+                expect(config.auth.oidc.jwksUrl).toContain(
                     '/auth/v1/.well-known/jwks.json',
                 )
             }
         })
 
-        it('auth.supabaseIss is derived under /auth/v1 from PUBLIC_SUPABASE_URL when SUPABASE_ISS absent', () => {
-            if (!process.env.SUPABASE_ISS && process.env.PUBLIC_SUPABASE_URL) {
+        it('auth.oidc.issuer is derived under /auth/v1 from PUBLIC_SUPABASE_URL when no explicit issuer is set', () => {
+            if (
+                !process.env.OIDC_ISSUER &&
+                !process.env.SUPABASE_ISS &&
+                !process.env.OIDC_DISCOVERY_BASE &&
+                process.env.PUBLIC_SUPABASE_URL
+            ) {
                 // Token `iss` is `https://<ref>.supabase.co/auth/v1`, not the bare root.
-                expect(config.auth.supabaseIss).toMatch(/\/auth\/v1$/)
+                expect(config.auth.oidc.issuer).toMatch(/\/auth\/v1$/)
             }
         })
 
-        it('auth.supabaseAud defaults to "authenticated" when SUPABASE_AUD is unset', () => {
-            if (!process.env.SUPABASE_AUD) {
-                expect(config.auth.supabaseAud).toBe('authenticated')
+        it('auth.oidc.audience defaults to "authenticated" when unset', () => {
+            if (!process.env.OIDC_AUDIENCE && !process.env.SUPABASE_AUD) {
+                expect(config.auth.oidc.audience).toBe('authenticated')
             }
         })
 
-        it('auth.supabaseServiceRoleKey normalizes SUPABASE_SERVICE_ROLE_KEY and SUPABASE_SECRET_KEY aliases', () => {
-            if (config.auth.supabaseServiceRoleKey !== undefined) {
-                expect(typeof config.auth.supabaseServiceRoleKey).toBe('string')
+        it('auth.serviceRoleKey normalizes SUPABASE_SERVICE_ROLE_KEY and SUPABASE_SECRET_KEY aliases', () => {
+            if (config.auth.serviceRoleKey !== undefined) {
+                expect(typeof config.auth.serviceRoleKey).toBe('string')
             }
+        })
+
+        // --- #150: provider-neutral OIDC config ----------------------------
+
+        it('auth.oidc.roleClaimPaths defaults to the historical hardcoded paths', () => {
+            if (!process.env.OIDC_ROLE_CLAIM_PATH) {
+                expect(config.auth.oidc.roleClaimPaths).toEqual([
+                    'app_metadata.role',
+                    'user_role',
+                ])
+            }
+        })
+
+        it('exposes no supabase-prefixed identifier on config.auth (#150 acceptance)', () => {
+            const walk = (obj: any, path = 'auth'): string[] =>
+                Object.entries(obj).flatMap(([key, value]) => [
+                    ...(/supabase/i.test(key) ? [`${path}.${key}`] : []),
+                    ...(value &&
+                    typeof value === 'object' &&
+                    !Array.isArray(value)
+                        ? walk(value, `${path}.${key}`)
+                        : []),
+                ])
+            expect(walk(config.auth)).toEqual([])
         })
     })
 })

--- a/test/http/authentication.test.ts
+++ b/test/http/authentication.test.ts
@@ -1,9 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+﻿import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Mock the auth module so we can drive verification/role-resolution outcomes
 // without real JWKS/JWTs. authentication.ts imports these named exports.
 vi.mock('../../src/auth/jwt.js', () => ({
-    verifySupabaseJwt: vi.fn(),
+    verifyAccessToken: vi.fn(),
     resolveAppRole: vi.fn(),
 }))
 
@@ -13,11 +13,11 @@ vi.mock('../../src/config.js', () => ({
     config: { security: { mcpApiKey: undefined as string | undefined } },
 }))
 
-import { resolveAppRole, verifySupabaseJwt } from '../../src/auth/jwt.js'
+import { resolveAppRole, verifyAccessToken } from '../../src/auth/jwt.js'
 import { config } from '../../src/config.js'
 import { expressAuthentication } from '../../src/http/authentication'
 
-const mockVerify = verifySupabaseJwt as unknown as ReturnType<typeof vi.fn>
+const mockVerify = verifyAccessToken as unknown as ReturnType<typeof vi.fn>
 const mockResolve = resolveAppRole as unknown as ReturnType<typeof vi.fn>
 
 const setMcpKey = (key: string | undefined) => {
@@ -29,7 +29,7 @@ const reqWith = (authorization?: string) =>
 
 const reqWithHeaders = (headers: Record<string, string>) => ({ headers }) as any
 
-describe('expressAuthentication (#117 — clean 401/403 instead of "internal error")', () => {
+describe('expressAuthentication (#117 â€” clean 401/403 instead of "internal error")', () => {
     beforeEach(() => {
         mockVerify.mockReset()
         mockResolve.mockReset()
@@ -86,12 +86,12 @@ describe('expressAuthentication (#117 — clean 401/403 instead of "internal err
     })
 })
 
-describe('expressAuthentication api_key (#117 — spec matches deployment for reads)', () => {
+describe('expressAuthentication api_key (#117 â€” spec matches deployment for reads)', () => {
     beforeEach(() => {
         setMcpKey(undefined)
     })
 
-    it('passes through (open) when MCP_API_KEY is unset — keeps CI / no-DB green', async () => {
+    it('passes through (open) when MCP_API_KEY is unset â€” keeps CI / no-DB green', async () => {
         await expect(
             expressAuthentication(reqWith(), 'api_key'),
         ).resolves.toBeUndefined()


### PR DESCRIPTION
Closes #151. Closes #150.

Landed together because both substantially rewrite `src/auth/jwt.ts` — doing #151 first would have meant writing new code under `SUPABASE_*` names and renaming it a commit later. #151 itself says "do that one first or together".

---

## #151 — the actual bug

`findLocalProfileBySub()` gated the profile lookup behind a UUID-shaped regex, because `Profile.id` doubled as the Supabase Auth user id:

```ts
if (s && /^[0-9a-fA-F-]{36}$/.test(s)) {
    const byId = await prisma.profile.findUnique({ where: { id: s } })
```

Any issuer minting non-UUID subjects (Logto uses short alphanumeric ids) never enters that branch.

**Why it's a defect and not just cleanliness:** it fails in the wrong direction. `resolveAppRole()` returns `isAdmin: false` when no profile is found, so an admin whose subject stopped matching the regex was *quietly downgraded* — and nothing in the logs distinguished "this user is not an admin" from "we could not identify this user at all". Same outcome, same silence, completely different cause.

### What changed

- **The subject is opaque.** Regex gone.
- **Identity moves off `Profile.id`** onto an explicit `(issuer, externalId)` pair, so a subject is attributable to the issuer that minted it — which is also what makes a dual-issuer transition period possible.
- **Resolution order:** issuer-attributed row → pre-migration NULL-issuer row → email fallback (#90, retained but no longer load-bearing). One `findMany` covers both subject cases in a single round trip; the winner is picked explicitly in code so the order Postgres happens to return rows in can't decide who is admin.
- **`auth_subject_unresolved_total`** + a distinct `warn` log. Kept separate from `mcp_auth_failures_total` on purpose: this is *not* an auth failure — the request proceeds as a non-admin. It is the signal that an identity mapping is broken. `ResolvedAuthz.unresolvedSubject` carries the same fact in-process.

### The migration

Backfills `external_id = id` — every existing row's `id` **is** the subject the old code matched on, so resolution is preserved exactly.

`issuer` is deliberately left **NULL** rather than stamped with the current Supabase issuer URL. The migration runs against dev, CI, and production databases that point at *different* Supabase projects; hardcoding one project's issuer would mis-attribute rows in the others. The app treats a NULL issuer as "not yet attributed" and still matches it on `external_id` alone, so the backfill is complete and needs no downtime or follow-up step.

> [!WARNING]
> **The migration is parse-validated, not apply-validated.** `scripts/find-sql-error.ts` parses all 5 statements cleanly, but I could not execute it: Docker's daemon isn't running locally, and I wasn't going to point a migration at the real database without asking.
>
> This is worth flagging beyond this PR — **CI runs `prisma db push`, not `prisma migrate deploy`** (`.github/workflows/ci-deploy-render.yml:63`). No automated job ever executes migration SQL, so *every* migration's first real execution is against production during the Render build. I'm treating that as a resiliency finding and will raise it with the audit work.

### Seed

`ADMIN_SUPABASE_UUID` now lands in `externalId` instead of being forced onto `Profile.id`. That also dissolves the #90 friction: reconciling the admin identity becomes a column update rather than a re-key of the primary key.

---

## #150 — provider-neutral OIDC config

`src/auth/jwt.ts` was already a standards-compliant OAuth resource server — OIDC discovery for `jwks_uri`/`issuer`, then `jose`'s `createRemoteJWKSet` + `jwtVerify` with issuer/audience checks. The *mechanism* was never Supabase-specific; only the naming and configuration were.

| Before | After |
|---|---|
| `SUPABASE_JWKS_URL` | `OIDC_JWKS_URL` |
| `SUPABASE_ISS` | `OIDC_ISSUER` |
| `SUPABASE_AUD` | `OIDC_AUDIENCE` |
| *(derived from `PUBLIC_SUPABASE_URL` only)* | `OIDC_DISCOVERY_BASE` (new; still falls back to the derivation) |
| *(hardcoded `app_metadata.role ?? user_role`)* | `OIDC_ROLE_CLAIM_PATH` |
| `config.auth.supabase*` | `config.auth.oidc.*` |
| `verifySupabaseJwt()` | `verifyAccessToken()` |

**No behavioural change.** `OIDC_ROLE_CLAIM_PATH` defaults to `app_metadata.role,user_role`, reproducing the previous hardcoded lookup exactly.

### Renaming Render without an auth outage

Both spellings are accepted; the `OIDC_*` name wins. While only a legacy name is set, the server logs at boot:

```
auth config uses legacy Supabase-prefixed env names (#150); rename in the deployment env: SUPABASE_ISS → OIDC_ISSUER
```

So the rollout is: add the `OIDC_*` vars alongside the existing ones → deploy → confirm auth works → delete the legacy vars in a second deploy. The warning tells you exactly what's left. Documented in `docs/runbooks/deploy-render.md`.

### Explicitly not done

Per ADR 0001, **no `IIdentityProvider` abstraction.** OIDC discovery + JWKS + standard claims already *is* the vendor-agnostic interface; wrapping it would re-abstract something already abstract. `verifyAccessToken` and `resolveAppRole` stay plain functions reading injected config.

---

## Scope notes

- `PUBLIC_SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`, and `SUPABASE_ANON_KEY` **keep their env names** — the first is genuinely Supabase's name for the project URL, and the latter two are project access rather than token verification (the service-role bearer shortcut is #152's follow-on work). They are exposed as `config.auth.serviceRoleKey` / `config.auth.anonKey`, so the AC "no `supabase` identifier remains in `config.auth`" holds — and there's a test asserting it by walking the object.
- `scripts/create-supabase-user-for-local.ts` and `scripts/migrate-supabase-users.ts` still read `process.env.SUPABASE_ISS` directly as a fallback. They keep working (it remains a valid var) and they're Supabase-admin tooling outside the verification path, so I left them. Worth noting that usage was already dubious — the issuer ends in `/auth/v1`, so those scripts were building `…/auth/v1/auth/v1/…` on that fallback path. I fixed the same latent bug where it appeared in `docs/runbooks/admin-user-management.md`.

## Testing

Full suite: **344 passed, 5 skipped, 0 failed.** `pnpm run typecheck` clean, `biome check` clean on all touched files.

New/changed coverage in `test/auth/jwt.test.ts`:
- **`grants admin for a NON-UUID subject`** — the #151 bug in one test; fails on `main`.
- `prefers the issuer-attributed row over a legacy NULL-issuer row` — returns rows in the "wrong" order deliberately.
- `counts and logs an unresolvable subject distinctly from a resolved non-admin` — asserts the resolved-non-admin case stays silent and the unresolvable case increments the counter and emits the warn. This is the AC that the two are no longer indistinguishable.
- `reads the app role from a configured custom claim path (#150)` — including that it stays stateless (no DB hit).
- Rewrote the two #90 tests onto the new lookup.

In `test/config/config.test.ts`: role-claim-path default, and an acceptance test that walks `config.auth` recursively asserting no key matches `/supabase/i`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
