### PR TITLE
feat(auth): serve RFC 9728 Protected Resource Metadata for MCP spec conformance (#152)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,20 @@ OIDC_AUDIENCE=authenticated
 # Default below reproduces the historical hardcoded behaviour.
 # OIDC_ROLE_CLAIM_PATH=app_metadata.role,user_role
 
+# ── OAuth Protected Resource Metadata (RFC 9728, #152) ────────────────────────
+# Served at /.well-known/oauth-protected-resource[/mcp] so standards-based MCP
+# clients can discover how to authenticate. MCP_API_KEY keeps working alongside.
+
+# Public origin. Pin this in production — otherwise the advertised resource
+# identifier is derived from the (client-supplied) Host header.
+PUBLIC_BASE_URL=https://bad-mcp.onrender.com
+# Canonical resource identifier. Defaults to PUBLIC_BASE_URL + the request path.
+# OAUTH_RESOURCE_IDENTIFIER=https://bad-mcp.onrender.com/mcp
+# Comma-separated AS issuers. Defaults to OIDC_ISSUER (what we already verify).
+# OAUTH_AUTHORIZATION_SERVERS=https://your-tenant.logto.app/oidc
+# Comma-separated scopes to advertise.
+# OAUTH_SCOPES_SUPPORTED=mcp:read,mcp:write
+
 # ── Supabase ──────────────────────────────────────────────────────────────────
 # Supabase project URL — still the input OIDC discovery is derived from today.
 PUBLIC_SUPABASE_URL=https://your-project.supabase.co

--- a/docs/mcp-http.md
+++ b/docs/mcp-http.md
@@ -18,6 +18,68 @@ This document describes the new HTTP-based transports for the MCP server.
   - Used by SSE clients to send messages back to the server.
   - Must include header `X-MCP-Conn-Id: <connId>` and `Authorization: Bearer <MCP_API_KEY>` when auth is enabled.
 
+- GET /.well-known/oauth-protected-resource
+- GET /.well-known/oauth-protected-resource/mcp
+  - **Public** (deliberately un-gated — a document describing how to authenticate cannot sit behind the gate it describes).
+  - RFC 9728 Protected Resource Metadata. See below.
+
+## Authorization discovery (RFC 9728) — #152
+
+The June 2025 revision of the MCP authorization spec separates the **MCP server
+(resource server)** from the **authorization server** and requires the resource
+server to publish [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)
+metadata. That revision also removed the older fallback-default-endpoint
+mechanism, so this document is now the *only* way a standards-based MCP client
+can discover how to authenticate here.
+
+```console
+$ curl https://bad-mcp.onrender.com/.well-known/oauth-protected-resource/mcp
+{
+  "resource": "https://bad-mcp.onrender.com/mcp",
+  "bearer_methods_supported": ["header"],
+  "authorization_servers": ["https://<issuer>"]
+}
+```
+
+RFC 9728 §3.1 inserts the resource's path component after the well-known prefix,
+so the document for the `https://host/mcp` resource lives at
+`/.well-known/oauth-protected-resource/mcp`. The bare path is served too, for
+clients that have no path component to insert.
+
+On a 401 from a protected MCP endpoint the server points at that document via
+`WWW-Authenticate` (RFC 9728 §5.1):
+
+```
+WWW-Authenticate: Bearer error="invalid_token",
+  resource_metadata="https://bad-mcp.onrender.com/.well-known/oauth-protected-resource/mcp",
+  error_description="Missing or invalid credentials for the MCP resource"
+```
+
+### Configuration
+
+Every advertised value is configuration, never hardcoded — so the document
+follows whichever authorization server ADR 0001 Stage 2 lands on:
+
+| Var | Meaning | Default |
+|---|---|---|
+| `PUBLIC_BASE_URL` | Public origin of this deployment | Derived from `X-Forwarded-Proto`/`Host` |
+| `OAUTH_RESOURCE_IDENTIFIER` | Canonical resource identifier | Origin + request path |
+| `OAUTH_AUTHORIZATION_SERVERS` | Comma-separated AS issuers | `OIDC_ISSUER` |
+| `OAUTH_SCOPES_SUPPORTED` | Comma-separated scopes | omitted |
+
+**Pin `PUBLIC_BASE_URL` in production.** Without it the origin is derived from
+the `Host` header, which is client-supplied — harmless for a public document
+carrying no secret, but it means the advertised `resource` isn't guaranteed to
+match the audience real tokens are minted for.
+
+### This does not replace `MCP_API_KEY`
+
+The shared-secret gate is unchanged and still works both ways
+(`Authorization: Bearer <MCP_API_KEY>` and `X-Mcp-Api-Key`). This issue adds the
+conformant discovery path alongside it. Replacing `MCP_API_KEY` and the
+`service_role` bearer shortcut with real `client_credentials` grants is
+follow-on work tracked with the ADR 0001 Stage 2 spike.
+
 ## Example `mcp.json` snippet for HTTP servers
 
 ```

--- a/src/config.ts
+++ b/src/config.ts
@@ -143,6 +143,17 @@ const envSchema = z.object({
         .optional()
         .default('https://api.the-odds-api.com/v4'),
 
+    // ── OAuth Protected Resource Metadata (RFC 9728, #152) ────────────────
+    // Public origin of this deployment. Pin it in production so the advertised
+    // resource identifier is stable rather than derived from the Host header.
+    PUBLIC_BASE_URL: z.string().url().optional(),
+    // Canonical resource identifier. Defaults to the derived origin + /mcp.
+    OAUTH_RESOURCE_IDENTIFIER: z.string().url().optional(),
+    // Comma-separated authorization server issuers. Defaults to the OIDC issuer.
+    OAUTH_AUTHORIZATION_SERVERS: csvArray,
+    // Comma-separated scopes to advertise.
+    OAUTH_SCOPES_SUPPORTED: csvArray,
+
     // ── GitHub ────────────────────────────────────────────────────────────
     GITHUB_TOKEN: z.string().optional(),
 
@@ -337,6 +348,16 @@ export const config = {
         apiKey: env.ODDS_API_KEY,
         baseUrl: env.ODDS_API_BASE,
         enabled: Boolean(env.ODDS_API_KEY),
+    },
+
+    // RFC 9728 Protected Resource Metadata (#152). Every value is configuration
+    // so the advertised AS and resource identifier are never hardcoded — they
+    // follow whichever authorization server ADR 0001 Stage 2 lands on.
+    oauth: {
+        publicBaseUrl: env.PUBLIC_BASE_URL,
+        resourceIdentifier: env.OAUTH_RESOURCE_IDENTIFIER,
+        authorizationServers: env.OAUTH_AUTHORIZATION_SERVERS,
+        scopesSupported: env.OAUTH_SCOPES_SUPPORTED,
     },
 
     github: {

--- a/src/http/mcp-http.ts
+++ b/src/http/mcp-http.ts
@@ -3,6 +3,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { Application, Request, Response } from 'express'
 import { config } from '../config.js'
 import { logger } from '../logger.js'
+import { wwwAuthenticateValue } from './protected-resource-metadata.js'
 
 // Simple newline-delimited JSON HTTP stream transport
 export class HttpStreamTransport {
@@ -213,6 +214,27 @@ export class SseServerTransport {
     }
 }
 
+/**
+ * 401 with the RFC 9728 `resource_metadata` pointer (#152), so a standards-based
+ * MCP client can discover how to authenticate instead of seeing an opaque 401.
+ * Mirrors `mcpAuthMiddleware`; these handlers gate on `MCP_API_KEY` themselves.
+ */
+function rejectUnauthorized(req: Request, res: Response): void {
+    try {
+        res.set(
+            'WWW-Authenticate',
+            wwwAuthenticateValue(req, {
+                error: 'invalid_token',
+                description:
+                    'Missing or invalid credentials for the MCP resource',
+            }),
+        )
+    } catch {
+        /* header construction must never turn a 401 into a 500 */
+    }
+    res.status(401).json({ error: 'unauthorized' })
+}
+
 // Register endpoints on the Express app
 export function registerMcpHttp(app: Application): void {
     const base = '/mcp'
@@ -227,10 +249,12 @@ export function registerMcpHttp(app: Application): void {
             if (mcpKey) {
                 const auth = (req.headers.authorization || '').toString()
                 if (auth !== `Bearer ${mcpKey}`) {
-                    logger.error('mcp-http: POST /mcp auth failed', {
-                        got: auth,
+                    // Never log the presented credential (see mcp-auth.ts).
+                    logger.warn('mcp-http: POST /mcp auth failed', {
+                        path: req.path,
+                        ip: req.ip,
                     })
-                    res.status(401).json({ error: 'unauthorized' })
+                    rejectUnauthorized(req, res)
                     return
                 }
             }
@@ -282,10 +306,12 @@ export function registerMcpHttp(app: Application): void {
             if (mcpKey) {
                 const auth = (req.headers.authorization || '').toString()
                 if (auth !== `Bearer ${mcpKey}`) {
-                    logger.error('mcp-http: GET /mcp auth failed', {
-                        got: auth,
+                    // Never log the presented credential (see mcp-auth.ts).
+                    logger.warn('mcp-http: GET /mcp auth failed', {
+                        path: req.path,
+                        ip: req.ip,
                     })
-                    res.status(401).json({ error: 'unauthorized' })
+                    rejectUnauthorized(req, res)
                     return
                 }
             }
@@ -345,10 +371,12 @@ export function registerMcpHttp(app: Application): void {
             if (mcpKey) {
                 const auth = (req.headers.authorization || '').toString()
                 if (auth !== `Bearer ${mcpKey}`) {
-                    logger.error('mcp-http: POST /mcp/events auth failed', {
-                        got: auth,
+                    // Never log the presented credential (see mcp-auth.ts).
+                    logger.warn('mcp-http: POST /mcp/events auth failed', {
+                        path: req.path,
+                        ip: req.ip,
                     })
-                    res.status(401).json({ error: 'unauthorized' })
+                    rejectUnauthorized(req, res)
                     return
                 }
             }

--- a/src/http/middleware/mcp-auth.ts
+++ b/src/http/middleware/mcp-auth.ts
@@ -2,6 +2,25 @@ import type { NextFunction, Request, Response } from 'express'
 import { config } from '../../config.js'
 import { logger } from '../../logger.js'
 import { mcpAuthFailuresTotal } from '../metrics-route.js'
+import { wwwAuthenticateValue } from '../protected-resource-metadata.js'
+
+/**
+ * Reject with a 401 that tells a standards-based client where to look (#152).
+ *
+ * RFC 9728 §5.1: a protected resource signals its metadata location via the
+ * `resource_metadata` parameter on `WWW-Authenticate`. Without this a conformant
+ * MCP client sees an opaque 401 and has no way to discover how to authenticate.
+ */
+function unauthorized(req: Request, res: Response) {
+    res.set(
+        'WWW-Authenticate',
+        wwwAuthenticateValue(req, {
+            error: 'invalid_token',
+            description: 'Missing or invalid credentials for the MCP resource',
+        }),
+    )
+    return res.status(401).json({ error: 'Unauthorized' })
+}
 
 export function mcpAuthMiddleware(
     req: Request,
@@ -32,7 +51,7 @@ export function mcpAuthMiddleware(
         } catch {
             /* noop */
         }
-        return res.status(401).json({ error: 'Unauthorized' })
+        return unauthorized(req, res)
     } catch (err) {
         logger.error('mcp-auth: unexpected error', err)
         // Fail closed: treat as unauthorized
@@ -41,6 +60,13 @@ export function mcpAuthMiddleware(
         } catch {
             /* noop */
         }
-        return res.status(401).json({ error: 'Unauthorized' })
+        // `unauthorized()` builds a URL from request headers, so guard it here —
+        // this branch already means something unexpected happened, and a header
+        // failure must not escalate a 401 into an unhandled 500.
+        try {
+            return unauthorized(req, res)
+        } catch {
+            return res.status(401).json({ error: 'Unauthorized' })
+        }
     }
 }

--- a/src/http/protected-resource-metadata.ts
+++ b/src/http/protected-resource-metadata.ts
@@ -1,0 +1,137 @@
+import type { Application, Request, Response } from 'express'
+import { config } from '../config.js'
+
+/**
+ * RFC 9728 — OAuth 2.0 Protected Resource Metadata (#152).
+ *
+ * The June 2025 revision of the MCP authorization specification separates the
+ * **MCP server (resource server)** from the **authorization server**, and
+ * requires MCP servers to publish RFC 9728 metadata. That revision removed the
+ * previous fallback-default-endpoint mechanism, so PRM is now the only way a
+ * standards-based MCP client can discover how to authenticate here.
+ *
+ * This adds the conformant discovery path. It does **not** remove `MCP_API_KEY`:
+ * that shared-secret gate keeps working exactly as before, and replacing it (and
+ * the service-role bearer shortcut) with real `client_credentials` grants is
+ * follow-on work tracked with the ADR 0001 Stage 2 spike.
+ *
+ * @see https://datatracker.ietf.org/doc/html/rfc9728
+ * @see https://modelcontextprotocol.io/specification/draft/basic/authorization
+ */
+
+/** The RFC 9728 well-known path prefix. */
+const WELL_KNOWN = '/.well-known/oauth-protected-resource'
+
+/** The MCP endpoint this server exposes, relative to its origin. */
+const MCP_PATH = '/mcp'
+
+/**
+ * Best-effort origin for this deployment.
+ *
+ * `PUBLIC_BASE_URL` wins when set. Otherwise we fall back to the forwarded
+ * proto + Host header — convenient, but note the Host header is client-supplied,
+ * so a caller can influence the `resource` value it gets back. That is
+ * acceptable for a discovery document (it is public, carries no secret, and a
+ * client that lies to itself only breaks its own flow), but production should
+ * pin `PUBLIC_BASE_URL` so the advertised resource identifier is stable and
+ * matches the audience real tokens are minted for.
+ */
+function originFor(req: Request): string {
+    const configured = config.oauth.publicBaseUrl
+    if (configured) return configured.replace(/\/$/, '')
+
+    const proto =
+        (req.headers['x-forwarded-proto'] || '').toString().split(',')[0] ||
+        req.protocol ||
+        'https'
+    const host = (req.headers['x-forwarded-host'] || req.headers.host || '')
+        .toString()
+        .split(',')[0]
+    return `${proto}://${host}`
+}
+
+/** The canonical resource identifier this server advertises. */
+export function resourceIdentifier(req: Request, resourcePath = ''): string {
+    const configured = config.oauth.resourceIdentifier
+    if (configured) return configured.replace(/\/$/, '')
+    return `${originFor(req)}${resourcePath}`
+}
+
+/**
+ * Authorization servers to advertise.
+ *
+ * Configurable, defaulting to the OIDC issuer we already verify tokens against —
+ * so the document is meaningful today against Supabase and becomes correct for a
+ * different provider by changing env, not code. (Per #152's sequencing note, the
+ * value is only *finally* settled once ADR 0001 Stage 2 picks an AS.)
+ */
+function authorizationServers(): string[] {
+    if (config.oauth.authorizationServers.length > 0) {
+        return config.oauth.authorizationServers
+    }
+    const issuer = config.auth.oidc.issuer
+    return issuer ? [issuer] : []
+}
+
+/** Build the RFC 9728 metadata document for a given resource path. */
+export function buildMetadata(
+    req: Request,
+    resourcePath = '',
+): Record<string, unknown> {
+    const doc: Record<string, unknown> = {
+        // REQUIRED by RFC 9728 §2.
+        resource: resourceIdentifier(req, resourcePath),
+        // Advertised so audience-restricted tokens validate against this resource.
+        bearer_methods_supported: ['header'],
+    }
+
+    const servers = authorizationServers()
+    if (servers.length > 0) doc.authorization_servers = servers
+
+    if (config.oauth.scopesSupported.length > 0) {
+        doc.scopes_supported = config.oauth.scopesSupported
+    }
+
+    return doc
+}
+
+/**
+ * The `WWW-Authenticate` value to return alongside a 401/403 from a protected
+ * MCP endpoint, pointing the client at the metadata document (RFC 9728 §5.1).
+ */
+export function wwwAuthenticateValue(
+    req: Request,
+    opts: { error?: string; description?: string } = {},
+): string {
+    const metadataUrl = `${originFor(req)}${WELL_KNOWN}${MCP_PATH}`
+    const params = [`resource_metadata="${metadataUrl}"`]
+    if (opts.error) params.unshift(`error="${opts.error}"`)
+    if (opts.description) params.push(`error_description="${opts.description}"`)
+    return `Bearer ${params.join(', ')}`
+}
+
+/**
+ * Register the metadata endpoints.
+ *
+ * MUST be registered before any auth middleware — a discovery document behind
+ * the very gate it describes is useless. In hosted mode `createBasicApp()` runs
+ * before `registerDbDependentRoutes()` installs `mcpAuthMiddleware`, so calling
+ * this from there keeps it public.
+ */
+export function registerProtectedResourceMetadata(app: Application): void {
+    const send = (resourcePath: string) => (req: Request, res: Response) => {
+        // Public, cacheable, and explicitly not tied to a session.
+        res.set('Cache-Control', 'public, max-age=3600')
+        res.status(200).json(buildMetadata(req, resourcePath))
+    }
+
+    // RFC 9728 §3.1 inserts the resource's path component after the well-known
+    // prefix, so the document for `https://host/mcp` lives at
+    // `/.well-known/oauth-protected-resource/mcp`. Standards-based MCP clients
+    // request this form.
+    app.get(`${WELL_KNOWN}${MCP_PATH}`, send(MCP_PATH))
+
+    // The bare form, for the origin itself — what a client checks when it has no
+    // path component to insert.
+    app.get(WELL_KNOWN, send(''))
+}

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -11,6 +11,7 @@ import {
 } from './metrics-route.js'
 import { auditAdminCatalogMutations } from './middleware/audit.js'
 import { registerPlaybackRoute } from './playback-route.js'
+import { registerProtectedResourceMetadata } from './protected-resource-metadata.js'
 import { registerSwaggerRoute } from './swagger-route.js'
 import { RegisterRoutes } from './tsoa-routes.js'
 
@@ -52,6 +53,10 @@ export async function createHttpApp(): Promise<express.Application> {
     })
 
     registerHealthRoute(app)
+    // RFC 9728 discovery (#152). Registered here, before `mcpAuthMiddleware` is
+    // installed by `registerDbDependentRoutes`, so the document describing how to
+    // authenticate is not itself behind the gate it describes.
+    registerProtectedResourceMetadata(app)
     registerPlaybackRoute(app)
     registerMetricsRoute(app)
     // Book/author catalog routes are served by the TSOA controllers (RegisterRoutes below)
@@ -170,6 +175,10 @@ export function createBasicApp(): express.Application {
 
     // Minimal publicly safe routes (liveness, readiness, playback, metrics)
     registerHealthRoute(app)
+    // RFC 9728 discovery (#152). Registered here, before `mcpAuthMiddleware` is
+    // installed by `registerDbDependentRoutes`, so the document describing how to
+    // authenticate is not itself behind the gate it describes.
+    registerProtectedResourceMetadata(app)
     registerPlaybackRoute(app)
     registerMetricsRoute(app)
 

--- a/test/http/protected-resource-metadata.test.ts
+++ b/test/http/protected-resource-metadata.test.ts
@@ -1,0 +1,168 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { config } from '../../src/config.js'
+import { mcpAuthMiddleware } from '../../src/http/middleware/mcp-auth.js'
+import { registerProtectedResourceMetadata } from '../../src/http/protected-resource-metadata.js'
+
+const WELL_KNOWN = '/.well-known/oauth-protected-resource'
+
+const ORIGINAL = {
+    publicBaseUrl: config.oauth.publicBaseUrl,
+    resourceIdentifier: config.oauth.resourceIdentifier,
+    authorizationServers: config.oauth.authorizationServers,
+    scopesSupported: config.oauth.scopesSupported,
+    issuer: config.auth.oidc.issuer,
+    mcpApiKey: config.security.mcpApiKey,
+}
+
+const makeApp = () => {
+    const app = express()
+    registerProtectedResourceMetadata(app)
+    return app
+}
+
+beforeEach(() => {
+    ;(config as any).oauth.publicBaseUrl = 'https://bad-mcp.example.com'
+    ;(config as any).oauth.resourceIdentifier = undefined
+    ;(config as any).oauth.authorizationServers = []
+    ;(config as any).oauth.scopesSupported = []
+    ;(config as any).auth.oidc.issuer = 'https://issuer.example.com/auth/v1'
+})
+
+afterEach(() => {
+    ;(config as any).oauth.publicBaseUrl = ORIGINAL.publicBaseUrl
+    ;(config as any).oauth.resourceIdentifier = ORIGINAL.resourceIdentifier
+    ;(config as any).oauth.authorizationServers = ORIGINAL.authorizationServers
+    ;(config as any).oauth.scopesSupported = ORIGINAL.scopesSupported
+    ;(config as any).auth.oidc.issuer = ORIGINAL.issuer
+    ;(config as any).security.mcpApiKey = ORIGINAL.mcpApiKey
+})
+
+describe('RFC 9728 Protected Resource Metadata (#152)', () => {
+    it('serves a valid document at the bare well-known path', async () => {
+        const res = await request(makeApp()).get(WELL_KNOWN).expect(200)
+        // `resource` is the one REQUIRED member (RFC 9728 §2).
+        expect(res.body.resource).toBe('https://bad-mcp.example.com')
+        expect(res.body.bearer_methods_supported).toEqual(['header'])
+    })
+
+    // RFC 9728 §3.1 inserts the resource's path component after the well-known
+    // prefix — this is the form standards-based MCP clients actually request.
+    it('serves the path-inserted document for the /mcp resource', async () => {
+        const res = await request(makeApp())
+            .get(`${WELL_KNOWN}/mcp`)
+            .expect(200)
+        expect(res.body.resource).toBe('https://bad-mcp.example.com/mcp')
+    })
+
+    it('defaults authorization_servers to the OIDC issuer we already verify against', async () => {
+        const res = await request(makeApp()).get(`${WELL_KNOWN}/mcp`)
+        expect(res.body.authorization_servers).toEqual([
+            'https://issuer.example.com/auth/v1',
+        ])
+    })
+
+    it('takes the authorization server from config when set, not the issuer', async () => {
+        ;(config as any).oauth.authorizationServers = [
+            'https://tenant.logto.app/oidc',
+        ]
+        const res = await request(makeApp()).get(`${WELL_KNOWN}/mcp`)
+        expect(res.body.authorization_servers).toEqual([
+            'https://tenant.logto.app/oidc',
+        ])
+    })
+
+    it('takes the resource identifier from config when set', async () => {
+        ;(config as any).oauth.resourceIdentifier =
+            'https://api.example.com/mcp'
+        const res = await request(makeApp()).get(`${WELL_KNOWN}/mcp`)
+        expect(res.body.resource).toBe('https://api.example.com/mcp')
+    })
+
+    it('omits authorization_servers rather than emitting an empty array', async () => {
+        ;(config as any).auth.oidc.issuer = undefined
+        const res = await request(makeApp()).get(`${WELL_KNOWN}/mcp`)
+        expect(res.body).not.toHaveProperty('authorization_servers')
+    })
+
+    it('advertises scopes only when configured', async () => {
+        const before = await request(makeApp()).get(`${WELL_KNOWN}/mcp`)
+        expect(before.body).not.toHaveProperty('scopes_supported')
+
+        ;(config as any).oauth.scopesSupported = ['mcp:read', 'mcp:write']
+        const after = await request(makeApp()).get(`${WELL_KNOWN}/mcp`)
+        expect(after.body.scopes_supported).toEqual(['mcp:read', 'mcp:write'])
+    })
+
+    it('derives the origin from forwarded headers when no base URL is pinned', async () => {
+        ;(config as any).oauth.publicBaseUrl = undefined
+        const res = await request(makeApp())
+            .get(`${WELL_KNOWN}/mcp`)
+            .set('X-Forwarded-Proto', 'https')
+            .set('X-Forwarded-Host', 'derived.example.com')
+        expect(res.body.resource).toBe('https://derived.example.com/mcp')
+    })
+
+    it('is publicly reachable — the document must not sit behind the gate it describes', async () => {
+        ;(config as any).security.mcpApiKey = 'secret-key'
+        const app = express()
+        registerProtectedResourceMetadata(app)
+        app.use(mcpAuthMiddleware)
+        app.get('/protected', (_req, res) => res.json({ ok: true }))
+
+        await request(app).get(`${WELL_KNOWN}/mcp`).expect(200)
+        // Sanity check that the gate is genuinely active in this app.
+        await request(app).get('/protected').expect(401)
+    })
+})
+
+describe('WWW-Authenticate on MCP 401s (#152)', () => {
+    const gatedApp = () => {
+        ;(config as any).security.mcpApiKey = 'secret-key'
+        const app = express()
+        app.use(mcpAuthMiddleware)
+        app.get('/mcp', (_req, res) => res.json({ ok: true }))
+        return app
+    }
+
+    it('returns 401 carrying a resource_metadata pointer', async () => {
+        const res = await request(gatedApp()).get('/mcp').expect(401)
+        const header = res.headers['www-authenticate']
+        expect(header).toContain('Bearer')
+        expect(header).toContain(
+            `resource_metadata="https://bad-mcp.example.com${WELL_KNOWN}/mcp"`,
+        )
+    })
+
+    it('includes a machine-readable error code', async () => {
+        const res = await request(gatedApp()).get('/mcp').expect(401)
+        expect(res.headers['www-authenticate']).toContain(
+            'error="invalid_token"',
+        )
+    })
+
+    it('still lets a valid MCP_API_KEY through unchanged', async () => {
+        const res = await request(gatedApp())
+            .get('/mcp')
+            .set('Authorization', 'Bearer secret-key')
+            .expect(200)
+        expect(res.body).toEqual({ ok: true })
+        expect(res.headers['www-authenticate']).toBeUndefined()
+    })
+
+    it('still accepts the X-Mcp-Api-Key second-factor form unchanged', async () => {
+        await request(gatedApp())
+            .get('/mcp')
+            .set('X-Mcp-Api-Key', 'secret-key')
+            .expect(200)
+    })
+
+    it('stays a no-op when MCP_API_KEY is unset', async () => {
+        ;(config as any).security.mcpApiKey = undefined
+        const app = express()
+        app.use(mcpAuthMiddleware)
+        app.get('/mcp', (_req, res) => res.json({ ok: true }))
+        await request(app).get('/mcp').expect(200)
+    })
+})


### PR DESCRIPTION
Closes #152.

> [!IMPORTANT]
> **Stacked on #157** (`fix/auth-subject-identity-151-150`), because this reads `config.auth.oidc.issuer` — the provider-neutral shape introduced there. Merge #157 first; GitHub will retarget this to `main` automatically. The diff below is this branch's own commit only.

## What and why

The June 2025 revision of the MCP authorization spec separates the **MCP server (resource server)** from the **authorization server** and requires resource servers to publish [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) metadata. That revision also *removed* the older fallback-default-endpoint mechanism — so PRM is now the only way a standards-based MCP client can discover how to authenticate here. Today we offer a shared secret (`MCP_API_KEY`), which is neither conformant nor discoverable.

### Endpoints

| Path | Serves |
|---|---|
| `/.well-known/oauth-protected-resource/mcp` | The `https://host/mcp` resource — RFC 9728 §3.1 inserts the path component after the well-known prefix, and this is the form conformant MCP clients request |
| `/.well-known/oauth-protected-resource` | The bare origin, for clients with no path component to insert |

Both are **public by construction**. They're registered in `createBasicApp()`, which runs before `registerDbDependentRoutes()` installs `mcpAuthMiddleware` — a document describing how to authenticate must not sit behind the gate it describes. There's a test asserting exactly that, in an app where the gate is proven active.

### `WWW-Authenticate` on 401

```
WWW-Authenticate: Bearer error="invalid_token",
  resource_metadata="https://bad-mcp.onrender.com/.well-known/oauth-protected-resource/mcp",
  error_description="Missing or invalid credentials for the MCP resource"
```

Applied in `mcpAuthMiddleware` and in the three self-gating handlers in `mcp-http.ts` (`POST /mcp`, `GET /mcp`, `POST /mcp/events`). Header construction is wrapped so it can never escalate a 401 into a 500.

### Configuration, not hardcoding

| Var | Meaning | Default |
|---|---|---|
| `PUBLIC_BASE_URL` | Public origin | Derived from `X-Forwarded-Proto`/`Host` |
| `OAUTH_RESOURCE_IDENTIFIER` | Canonical resource id | Origin + request path |
| `OAUTH_AUTHORIZATION_SERVERS` | Comma-separated AS issuers | `OIDC_ISSUER` |
| `OAUTH_SCOPES_SUPPORTED` | Comma-separated scopes | omitted |

Defaulting `authorization_servers` to the issuer we *already verify tokens against* means the document is meaningful today against Supabase and becomes correct for a different provider by changing env — which is the sequencing note in the issue: the AS value is only finally settled once ADR 0001 Stage 2 picks one.

> [!NOTE]
> **Pin `PUBLIC_BASE_URL` in production.** Otherwise the origin comes from the `Host` header, which is client-supplied. That's harmless for a public document carrying no secret — a client that lies to itself only breaks its own flow — but the advertised `resource` then isn't guaranteed to match the audience real tokens are minted for. Documented inline and in `docs/mcp-http.md`.

## `MCP_API_KEY` is untouched

Still works both ways (`Authorization: Bearer <key>` and `X-Mcp-Api-Key`), still a no-op when unset. This adds the conformant path alongside; it does not remove the existing one. Three tests pin that. Replacing the shared secret and the `service_role` bearer shortcut with real `client_credentials` grants remains follow-on work with the Stage 2 spike.

---

## 🔒 Also fixes a credential leak

Found while editing these handlers — not in the issue, but I wasn't going to modify the adjacent line and leave it:

```ts
logger.error('mcp-http: POST /mcp auth failed', { got: auth })   // ← the presented bearer token
```

All three `mcp-http.ts` auth-failure paths logged the credential the caller presented, verbatim. `mcp-auth.ts` is explicitly careful not to do this ("never log the presented credential value") — these handlers predate or missed that.

It's worse than a noisy log: `logger.error` is bridged to Sentry, and `src/sentry.ts` scrubs by **key name** (`authorization|cookie|token|secret|password|api-key|jwt|dsn`). The key here is `got`, which matches none of them — so every failed auth attempt shipped the presented key to Sentry in the clear. Anyone probing `/mcp` with a guessed or stolen token would have deposited it there.

Now logs `path` + `ip` at `warn`, matching `mcp-auth.ts`.

## Testing

Full suite: **358 passed, 5 skipped, 0 failed.** `pnpm run typecheck` clean, `biome check` clean on touched files.

`test/http/protected-resource-metadata.test.ts` — 14 new tests covering document shape at both paths, config precedence over the issuer default, omitting empty members rather than emitting `[]`, forwarded-header origin derivation, public reachability past an active gate, and the `WWW-Authenticate`/`MCP_API_KEY` behaviour.

**Verified live**, not only via supertest — built and ran the server on :8899:

```console
$ curl localhost:8899/.well-known/oauth-protected-resource/mcp
{"resource":"https://bad-mcp.example.com/mcp","bearer_methods_supported":["header"],
 "authorization_servers":["https://<issuer>"]}

$ curl -X POST localhost:8899/mcp            # unauthenticated
401
WWW-Authenticate: Bearer error="invalid_token", resource_metadata="https://bad-mcp.example.com/.well-known/oauth-protected-resource/mcp", ...

$ curl -X POST localhost:8899/mcp -H 'Authorization: Bearer <MCP_API_KEY>' -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
200  → real tools/list response
```

### One AC not fully met

> - [ ] Verified against at least one standards-based MCP client.

I verified the **protocol-level behaviour** such a client consumes (both documents, the header, and that the existing key path is unbroken), but I don't have a conformant OAuth-discovery MCP client wired up here to drive the full flow — and the flow can't complete end-to-end anyway until there's an authorization server that will actually issue an audience-restricted token for this resource, which is ADR 0001 Stage 2. Worth doing as a explicit check once the Logto spike (#153) lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
