### PR TITLE
feat(security): make RLS an actual control (ORR gap #7)

### DIFF
--- a/docs/operational-readiness-review.md
+++ b/docs/operational-readiness-review.md
@@ -295,9 +295,18 @@ GitHub automation callers      ─┘                                  ├→ Gi
 
   This is not necessarily the wrong design: authorization is enforced in the application layer (OIDC JWT → `resolveAppRole` → `requireAdmin`, plus the MCP gateway key), and for a single-user service that is a defensible place for it to live. The single-user simplification that removed the policies was a deliberate decision. **What was wrong was the belief that a second layer existed.** An inert control you trust is worse than one you know you don't have.
 
-  Pinned by `test/integration/rls-enforcement.test.ts` (gated on `RUN_DB_INTEGRATION`), which asserts the real posture and fails loudly if it ever changes — so the next person to enable RLS finds out whether it actually applies instead of assuming.
+  **Resolved 2026-08-01 — RLS is now a real control.** Built, merged, and inert until a credential cutover ([`docs/runbooks/rls-cutover.md`](runbooks/rls-cutover.md)):
 
-  **Open decision (not taken here):** either commit to making RLS real — a non-owner role without `BYPASSRLS`, `FORCE ROW LEVEL SECURITY`, policies restored on the catalog tables, and `request.jwt.claims.*` propagated per session — or drop the four remaining policy sets so nothing implies protection that isn't there. Today's half-state is the worst of both.
+  - **`20260801120000_enforce_rls`** creates `mcp_app` — a non-owner, `NOBYPASSRLS` role with data privileges but **no DDL** — and sets `ENABLE` + **`FORCE ROW LEVEL SECURITY`** with a uniform policy pair on every table: `USING (true)` for SELECT, `role = 'admin'` for writes. FORCE is deliberate: without it, ownership alone silently reopens everything, which is how this became inert the first time.
+  - **`src/db/with-request-claims.ts`** wraps write operations in a transaction that `set_config`s `request.jwt.claims.*` first. `is_local => true` scopes the setting to that transaction so it cannot bleed across a pooled connection — load-bearing on Supabase's transaction pooler.
+  - **Reads are not wrapped.** Catalog reads are public and are the hot path (`/api/books` p50 307ms, already DB-round-trip bound); carrying identity on them would cost two extra round-trips per page load for no security gain. Writes are where an authorization bug costs something.
+  - Identity is established by whichever gate resolves it — `jwtMiddleware`, TSOA's `expressAuthentication`, `mcpAuthMiddleware`, and a wrapper around MCP tool handlers in `createServer()`. The MCP gateway key and service-role path map to admin claims, preserving today's behaviour exactly; what changes is that a **user JWT can no longer write without genuinely resolving to admin.**
+
+  Why the migration alone couldn't do it: `postgres` owns every table *and* carries `BYPASSRLS`. No `ALTER TABLE` overrides that — enforcement requires connecting as a different role, i.e. a credential rotation. Hence a runbook rather than a deploy.
+
+  `test/integration/rls-enforcement.test.ts` now asserts enforcement rather than pinning inertness, and connects **as `mcp_app`** — testing as the owner would pass vacuously, which is precisely the trap the original setup fell into.
+
+  > **One footgun, found by the spike and pinned by a test.** Prisma operations are lazy, so `runWithDbContext(ctx, () => db.x.create(…))` without an inner `await` executes *after* the scope exits and loses its claims. It fails closed, but silently.
 - **Secrets:** see §4 — env-only, scrubbed from Sentry, not logged.
 - **Error responses:** global handler returns generic `internal error` in production (no stack/message leakage).
 - **Admin debug endpoints:** hard-blocked in production regardless of `ADMIN_DEBUG_ENABLED` (verified `index.ts`).
@@ -394,7 +403,7 @@ These are **informal, best-effort targets for a solo project** — *not* contrac
 
 | Topic | Decision needed |
 |---|---|
-| **RLS** (§9) | Either make it real (non-owner role, `FORCE`, restored policies, per-session claims) or drop the four remaining policy sets. The current half-state implies protection that does not exist. For a single-user app with app-layer authz, **dropping them is the honest cheaper option** — but that is a call, not a cleanup. |
+| **RLS** (§9) | **Decided: make it real.** Built and merged, currently inert pending a credential cutover — see [`docs/runbooks/rls-cutover.md`](runbooks/rls-cutover.md). |
 | **Deploy gating** (§3) | The workflow now gates deploys, but it only takes effect once Auto-Deploy is turned **off** in the Render dashboard and `RENDER_DEPLOY_HOOK_URL` is set. Until then Render still deploys on push and the gate is inert. |
 | **Rate limiting** (§8) | Still none. Relies on `MCP_API_KEY` + Cloudflare. Fine at current exposure; revisit if the surface widens. |
 

--- a/docs/runbooks/rls-cutover.md
+++ b/docs/runbooks/rls-cutover.md
@@ -33,7 +33,25 @@ path keeps its single round-trip.
 
 ## Preconditions
 
-- [ ] `20260801120000_enforce_rls` applied in production
+> [!WARNING]
+> **The migration must be applied to production before step 1 will work.**
+> `mcp_app` is created by `20260801120000_enforce_rls`. Until that migration has
+> run, the role does not exist and step 1 fails with:
+>
+> ```text
+> ERROR:  role "mcp_app" does not exist
+> ```
+>
+> That migration ships with the application code that propagates claims, so the
+> order is: **merge → deploy (the boot entrypoint applies it) → then cut over.**
+> Confirm before starting:
+>
+> ```sql
+> SELECT rolname FROM pg_roles WHERE rolname = 'mcp_app';   -- expect 1 row
+> ```
+
+- [ ] `20260801120000_enforce_rls` applied in production (see the warning above)
+- [ ] The application code that sets `request.jwt.claims.*` is **deployed** — cutting over without it means every write is refused
 - [ ] A snapshot exists: `pnpm run db:snapshot` (see gap #6)
 - [ ] You can reach the database directly (`DATABASE_URL_DIRECT`)
 
@@ -42,13 +60,21 @@ path keeps its single round-trip.
 **1. Give `mcp_app` a password.** It was created `NOLOGIN` on purpose so no
 credential ever entered the repo or migration history.
 
+Run this in the **Supabase dashboard → SQL Editor** (it executes as `postgres`,
+so it has the rights), or over `DATABASE_URL_DIRECT` with any SQL client:
+
 ```sql
--- over DATABASE_URL_DIRECT, as postgres
 ALTER ROLE mcp_app LOGIN PASSWORD '<generate a long random password>';
 ```
 
 Generate it with `openssl rand -base64 32` or Doppler's generator. Do not reuse
 the `postgres` password.
+
+> [!NOTE]
+> **The password is not a standalone environment variable.** Nothing reads a
+> `DB_PASSWORD`/`MCP_PASSWORD`-style value — Prisma takes a single connection
+> string, so the password lives *inside* `DATABASE_URL` (step 2). A separate var
+> will simply be ignored.
 
 **2. Build the new connection strings.** Same host/database as today, only the
 credentials change. Supabase's pooler expects `<role>.<project-ref>`:

--- a/docs/runbooks/rls-cutover.md
+++ b/docs/runbooks/rls-cutover.md
@@ -1,0 +1,131 @@
+# RLS cutover — switching the app to a non-bypassing database role
+
+> **Status: not yet performed in production.** The migration and application
+> code are merged and inert; this runbook is the deliberate step that turns
+> enforcement on.
+
+## Why there is a cutover at all
+
+RLS could not be enabled by a migration alone. The application connects as
+`postgres`, which **owns every table** and carries **`rolbypassrls`** — two
+independent bypasses that no `ALTER TABLE` can override. Enforcement requires
+the app to connect as a *different role*, and that means rotating
+`DATABASE_URL`: a credential change, not a schema change.
+
+The migration (`20260801120000_enforce_rls`) already created the role, granted
+it, and enabled `ENABLE`/`FORCE ROW LEVEL SECURITY` with policies on every
+table. None of that affects the running app, because the app is still
+`postgres` and still bypasses. **Applying the migration is a no-op; this
+runbook is the switch.**
+
+## What changes
+
+| | Before | After |
+|---|---|---|
+| App connects as | `postgres` (owner, `BYPASSRLS`) | `mcp_app` (non-owner, `NOBYPASSRLS`) |
+| Reads | unrestricted | unrestricted (`*_read` policy is `USING (true)`) |
+| Writes | unrestricted | require `request.jwt.claims.role = 'admin'` |
+| Migrations / seed | as `postgres` | **unchanged** — still `postgres` over `DATABASE_URL_DIRECT` |
+
+Writes carry identity via the Prisma extension in
+`src/db/with-request-claims.ts`; reads deliberately do not, so the hot catalog
+path keeps its single round-trip.
+
+## Preconditions
+
+- [ ] `20260801120000_enforce_rls` applied in production
+- [ ] A snapshot exists: `pnpm run db:snapshot` (see gap #6)
+- [ ] You can reach the database directly (`DATABASE_URL_DIRECT`)
+
+## Steps
+
+**1. Give `mcp_app` a password.** It was created `NOLOGIN` on purpose so no
+credential ever entered the repo or migration history.
+
+```sql
+-- over DATABASE_URL_DIRECT, as postgres
+ALTER ROLE mcp_app LOGIN PASSWORD '<generate a long random password>';
+```
+
+Generate it with `openssl rand -base64 32` or Doppler's generator. Do not reuse
+the `postgres` password.
+
+**2. Build the new connection strings.** Same host/database as today, only the
+credentials change. Supabase's pooler expects `<role>.<project-ref>`:
+
+```
+postgresql://mcp_app.<project-ref>:<password>@aws-0-us-west-2.pooler.supabase.com:6543/postgres
+```
+
+Both pooler ports accept a custom role — verified on 5432 and 6543 before this
+was written.
+
+**3. Verify the new credential BEFORE switching anything.**
+
+```powershell
+$env:DATABASE_URL = "<the new mcp_app pooled URL>"
+pnpm exec vitest run test/integration/rls-enforcement.test.ts
+```
+
+Expect a non-admin write to be refused and an admin write to succeed. If that
+does not hold, stop — do not proceed.
+
+**4. Update Doppler `prd`.**
+
+- `DATABASE_URL` → the new `mcp_app` **pooled** (6543) URL
+- `DATABASE_URL_DIRECT` → **leave as `postgres`**. Migrations need the owner:
+  `mcp_app` deliberately has no DDL rights, and the boot entrypoint migrates
+  over this URL.
+
+**5. Confirm it reached Render**, then deploy/restart. As with `GITHUB_TOKEN`,
+a value in Doppler is not automatically a value in Render.
+
+**6. Smoke-test production.**
+
+```sh
+curl -s 'https://bad-mcp.onrender.com/healthz?deep=1' | jq '{db, migrations}'
+curl -s 'https://bad-mcp.onrender.com/api/books' -H "X-Mcp-Api-Key: $KEY" | head -c 200
+```
+
+Then exercise one **write** through an MCP tool (e.g. `update-movie`) — that is
+the path this change actually alters. A write failing with `row-level security`
+means claims are not reaching the database; roll back and investigate.
+
+## Rollback
+
+One value, one restart:
+
+```
+DATABASE_URL = <the original postgres pooled URL>
+```
+
+`postgres` still owns the tables and still has `BYPASSRLS`, so it bypasses every
+policy exactly as before. **Keep the original URL somewhere you can paste it
+from** — that is the entire rollback plan, and it is instant.
+
+Nothing in the schema needs reverting: the policies are inert against a
+bypassing role.
+
+## Known consequences
+
+- **Writes without identity now fail.** Any code path that writes without going
+  through an auth gate is refused, and logs `db: write attempted with no request
+  context`. That is the point, but it will find any path we missed.
+- **The lazy-promise footgun.** `runWithDbContext(ctx, () => db.x.create(…))`
+  without an inner `await` executes outside the scope and loses its claims. It
+  fails closed. There is a regression test pinning this behaviour.
+- **`prisma db seed` still works** because it runs as `postgres`.
+
+## If you ever want to undo enforcement entirely
+
+Rolling `DATABASE_URL` back to `postgres` (above) is sufficient and instant. To
+also strip the policies:
+
+```sql
+-- per table
+ALTER TABLE "<T>" NO FORCE ROW LEVEL SECURITY;
+ALTER TABLE "<T>" DISABLE ROW LEVEL SECURITY;
+```
+
+Prefer the credential rollback — it is reversible in both directions, and
+leaving the policies in place keeps the option open.

--- a/prisma/migrations/20260801120000_enforce_rls/migration.sql
+++ b/prisma/migrations/20260801120000_enforce_rls/migration.sql
@@ -1,0 +1,105 @@
+-- Make Row-Level Security an actual control (ORR gap #7).
+--
+-- Before this, RLS enforced nothing. The app connects as `postgres`, which owns
+-- every table AND carries rolbypassrls, and no table used FORCE ROW LEVEL
+-- SECURITY — three independent bypasses. Most catalog tables had RLS switched
+-- off entirely by the single-user simplification, and the policies that did
+-- exist keyed on `request.jwt.claims.*`, which nothing ever set.
+--
+-- This migration builds the database half:
+--   * `mcp_app` — a NON-OWNER, NOBYPASSRLS role for the application to connect as.
+--   * RLS enabled on every application table.
+--   * Policies: SELECT is open, writes require an admin claim.
+--
+-- The application half (propagating `request.jwt.claims.*` per request) is the
+-- Prisma extension in `src/db/with-request-claims.ts`.
+--
+-- IMPORTANT: this migration does NOT give `mcp_app` a password or LOGIN, and it
+-- does NOT change DATABASE_URL. Applying it is therefore a no-op for the running
+-- app — everything keeps working as `postgres` exactly as before. The cutover is
+-- a separate, deliberate step: see docs/runbooks/rls-cutover.md.
+
+-- ── The application role ────────────────────────────────────────────────────
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'mcp_app') THEN
+        -- NOLOGIN on purpose: the password is set during cutover so it never
+        -- lives in the repository or in migration history.
+        CREATE ROLE mcp_app NOLOGIN NOBYPASSRLS NOINHERIT;
+    END IF;
+END $$;
+
+GRANT USAGE ON SCHEMA public TO mcp_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO mcp_app;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO mcp_app;
+
+-- Tables created by later migrations must be reachable too, or the first new
+-- model after cutover fails with a bare "permission denied" at runtime.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO mcp_app;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    GRANT USAGE, SELECT ON SEQUENCES TO mcp_app;
+
+-- Deliberately NOT granted: CREATE on the schema, and any DDL. Migrations run
+-- as the owner over DATABASE_URL_DIRECT; the application never needs to alter
+-- the schema, so it should not be able to.
+
+-- ── RLS + policies ─────────────────────────────────────────────────────────
+-- One shape for every table, applied in a loop so a new table cannot quietly
+-- miss out. `_prisma_migrations` is excluded: Prisma's own bookkeeping, written
+-- by the owner during migration, never by the app role.
+DO $$
+DECLARE
+    t text;
+BEGIN
+    FOR t IN
+        SELECT c.relname
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind = 'r'
+          AND c.relname NOT LIKE '\_%'
+    LOOP
+        EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', t);
+
+        -- FORCE so the posture holds even if the app is ever pointed back at an
+        -- owner role. Without it, ownership alone silently reopens everything —
+        -- which is precisely how this became inert the first time.
+        EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', t);
+
+        -- Reads stay open. Catalog data is public, reads are the hot path, and
+        -- wrapping them to carry identity would cost two round-trips on every
+        -- page load for no security gain. Writes are where an authorization bug
+        -- actually costs something.
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', t || '_read', t);
+        EXECUTE format(
+            'CREATE POLICY %I ON %I FOR SELECT USING (true)', t || '_read', t);
+
+        -- Writes require an admin claim. `set_config(..., is_local => true)`
+        -- inside the statement's own transaction is what puts it there.
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', t || '_admin_write', t);
+        EXECUTE format($p$
+            CREATE POLICY %I ON %I FOR ALL
+            USING (current_setting('request.jwt.claims.role', true) = 'admin')
+            WITH CHECK (current_setting('request.jwt.claims.role', true) = 'admin')
+        $p$, t || '_admin_write', t);
+    END LOOP;
+END $$;
+
+-- Retire the earlier, never-effective policy set so two generations of rules
+-- don't sit on the same tables confusing whoever reads this next.
+DO $$
+DECLARE
+    p record;
+BEGIN
+    FOR p IN
+        SELECT pol.polname, cls.relname
+        FROM pg_policy pol
+        JOIN pg_class cls ON cls.oid = pol.polrelid
+        JOIN pg_namespace n ON n.oid = cls.relnamespace
+        WHERE n.nspname = 'public'
+          AND pol.polname NOT IN (cls.relname || '_read', cls.relname || '_admin_write')
+    LOOP
+        EXECUTE format('DROP POLICY IF EXISTS %I ON %I', p.polname, p.relname);
+    END LOOP;
+END $$;

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -2,6 +2,10 @@ import { NextFunction, Request, Response } from 'express'
 import { createRemoteJWKSet, type JWTPayload, jwtVerify } from 'jose'
 import { config, legacyAuthEnvNames } from '../config.js'
 import { prisma } from '../db/index.js'
+import {
+    setDbContextClaims,
+    TRUSTED_SERVICE_CONTEXT,
+} from '../db/request-context.js'
 import { authSubjectUnresolvedTotal } from '../http/metrics-route.js'
 import { logger } from '../logger.js'
 
@@ -284,6 +288,15 @@ async function resolveUserAuthz(req: any, payload: any) {
     req.user.role = role
     req.user.isAdmin = isAdmin
     if (localUserId !== undefined) req.user.localUserId = localUserId
+
+    // Hand the resolved identity to the database layer so RLS policies can see
+    // it. `role` here is the *application* role, which is what the policies key
+    // on — deliberately not the Postgres role claim.
+    setDbContextClaims({
+        role,
+        email: typeof payload?.email === 'string' ? payload.email : undefined,
+        sub: payload?.sub ? String(payload.sub) : undefined,
+    })
 }
 
 export async function jwtMiddleware(
@@ -309,6 +322,10 @@ export async function jwtMiddleware(
                     role: 'admin',
                     service: true,
                 }
+                // `requireAdmin` still demands INTERNAL_ADMIN_KEY + an allowlisted
+                // IP before this path can do anything; granting admin claims here
+                // keeps the DB layer consistent with that existing decision.
+                setDbContextClaims(TRUSTED_SERVICE_CONTEXT)
                 return next()
             }
 

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -1,5 +1,6 @@
 import { config } from '../config.js'
 import { logger } from '../logger.js'
+import { withRequestClaims } from './with-request-claims.js'
 
 // `prisma` is captured by reference by importers. `initPrisma()` populates it
 // with either a real PrismaClient (model accessors + raw helpers forwarded) or,
@@ -97,6 +98,12 @@ export async function initPrisma() {
             const adapter = new PrismaPg({ connectionString: dbUrl })
             const real = new PrismaClient({ adapter })
 
+            // Identity-carrying client: writes run inside a transaction that
+            // sets `request.jwt.claims.*` first, so RLS policies can evaluate
+            // who is acting. Reads deliberately skip this — see
+            // `IDENTITY_REQUIRED_OPERATIONS`.
+            const scoped = withRequestClaims(real)
+
             // Forward the raw helpers and model accessors onto the shared `prisma`
             // object. Direct assignment keeps each model reassignable by tests.
             prisma.$queryRaw = (...args: any[]) => real.$queryRaw(...args)
@@ -106,7 +113,7 @@ export async function initPrisma() {
                 real.$disconnect ? real.$disconnect() : Promise.resolve()
 
             for (const name of MODEL_NAMES) {
-                if (name in real) prisma[name] = (real as any)[name]
+                if (name in scoped) prisma[name] = (scoped as any)[name]
             }
 
             logger.info('PrismaClient initialized successfully')

--- a/src/db/request-context.ts
+++ b/src/db/request-context.ts
@@ -1,0 +1,106 @@
+import { AsyncLocalStorage } from 'node:async_hooks'
+
+/**
+ * Per-request identity, carried to the database so RLS policies can evaluate it.
+ *
+ * The app is a trusted middle tier: one connection string, one database
+ * identity, every query made on behalf of whoever is calling. That is why RLS
+ * has never enforced anything here — a policy keyed on
+ * `current_setting('request.jwt.claims.role')` has nothing to read, because
+ * nothing ever set it.
+ *
+ * `AsyncLocalStorage` closes that gap without threading a context argument
+ * through every tool handler and controller: the auth layer establishes the
+ * claims once per request, and the Prisma extension in `src/db/index.ts` picks
+ * them up for any operation that needs them.
+ */
+export interface DbRequestContext {
+    /** `email` claim — the identity most policies key on. */
+    email?: string
+    /** Resolved application role (`admin` | `user` | …), NOT the Postgres role. */
+    role?: string
+    /** Token subject, for auditing. */
+    sub?: string
+}
+
+const storage = new AsyncLocalStorage<DbRequestContext>()
+
+/**
+ * Run `fn` with `ctx` visible to every database call it makes.
+ *
+ * ⚠️ **`fn` must `await` its database work.** Prisma operations are lazy: calling
+ * `db.movie.create(...)` builds a promise but does not start it. Returning that
+ * promise unawaited means it executes *after* this scope has exited, the claims
+ * arrive empty, and the write is refused by policy:
+ *
+ * ```ts
+ * runWithDbContext(ctx, () => db.movie.create(…))              // ✗ claims lost
+ * runWithDbContext(ctx, async () => await db.movie.create(…))  // ✓
+ * ```
+ *
+ * It fails closed, which is the safe direction — but silently, so
+ * `assertDbContextAwaited` exists to make the mistake loud in tests.
+ */
+export function runWithDbContext<T>(ctx: DbRequestContext, fn: () => T): T {
+    return storage.run(ctx, fn)
+}
+
+/**
+ * Open an empty scope for a request, to be filled in once auth resolves.
+ *
+ * The context object is stored by reference, so `setDbContextClaims` can
+ * populate it later in the request without the middleware needing to know the
+ * identity up front — which matters because TSOA resolves auth inside route
+ * handling, well after any middleware could have wrapped it.
+ */
+export function beginDbContext<T>(fn: () => T): T {
+    return storage.run({}, fn)
+}
+
+/** Fill in the current scope's claims. No-op outside a scope. */
+export function setDbContextClaims(claims: DbRequestContext): void {
+    const store = storage.getStore()
+    if (store) Object.assign(store, claims)
+}
+
+/** The current request's claims, or `undefined` outside a request. */
+export function getDbContext(): DbRequestContext | undefined {
+    return storage.getStore()
+}
+
+/**
+ * Claims for callers that are already fully trusted by an earlier gate.
+ *
+ * The MCP gateway key (`MCP_API_KEY`) and the service-role path both grant
+ * unrestricted access *today* — the key gates `/mcp` and every DB-backed
+ * `/api/*` route, and the service-role path additionally demands
+ * `INTERNAL_ADMIN_KEY` plus an IP allowlist. Mapping them to admin claims keeps
+ * behaviour identical; what changes is that a plain **user JWT** can no longer
+ * write without genuinely resolving to admin, which is the bug class this
+ * whole mechanism defends against.
+ */
+export const TRUSTED_SERVICE_CONTEXT: DbRequestContext = Object.freeze({
+    role: 'admin',
+    email: 'service@internal',
+    sub: 'service',
+})
+
+/**
+ * Operations that must carry identity to the database.
+ *
+ * Reads are deliberately absent. Catalog reads are public, they are the hot
+ * path (`/api/books` p50 307ms, already dominated by database round-trip), and
+ * wrapping them in a transaction to set claims would add two round-trips to
+ * every page load on bryandebaun.dev for no security gain. Writes are where an
+ * authorization bug actually costs something, so writes are what we protect.
+ */
+export const IDENTITY_REQUIRED_OPERATIONS = new Set([
+    'create',
+    'createMany',
+    'createManyAndReturn',
+    'update',
+    'updateMany',
+    'upsert',
+    'delete',
+    'deleteMany',
+])

--- a/src/db/with-request-claims.ts
+++ b/src/db/with-request-claims.ts
@@ -1,0 +1,62 @@
+import { logger } from '../logger.js'
+import {
+    getDbContext,
+    IDENTITY_REQUIRED_OPERATIONS,
+} from './request-context.js'
+
+/**
+ * Wrap a PrismaClient so identity-carrying operations announce who is acting.
+ *
+ * RLS policies here are written against `current_setting('request.jwt.claims.*')`.
+ * Those settings are session/transaction state, and this app has neither a
+ * session per user nor a connection per user — one pooled connection serves
+ * everybody. So the claims have to be established inside a transaction that also
+ * contains the statement they apply to. That is what this does.
+ *
+ * `set_config(..., is_local => true)` scopes the setting to the surrounding
+ * transaction, so it cannot bleed into whatever the pooler hands that connection
+ * to next. That property is load-bearing: with Supabase's transaction pooler,
+ * anything session-scoped would leak across unrelated requests.
+ *
+ * Reads are not wrapped. See `IDENTITY_REQUIRED_OPERATIONS` for why.
+ */
+export function withRequestClaims(base: any): any {
+    if (typeof base?.$extends !== 'function') return base
+
+    return base.$extends({
+        query: {
+            async $allOperations({ model, operation, args, query }: any) {
+                if (!model || !IDENTITY_REQUIRED_OPERATIONS.has(operation)) {
+                    return query(args)
+                }
+
+                const ctx = getDbContext()
+                if (!ctx) {
+                    // No context at all means nobody established identity for
+                    // this call path. The write will be refused by policy; say
+                    // so plainly, because the alternative is someone staring at
+                    // "violates row-level security" with no idea why.
+                    logger.warn(
+                        'db: write attempted with no request context; RLS will refuse it',
+                        { model, operation },
+                    )
+                }
+
+                return base.$transaction(async (tx: any) => {
+                    await tx.$executeRawUnsafe(
+                        `SELECT set_config('request.jwt.claims.role',  $1, true),
+                                set_config('request.jwt.claims.email', $2, true),
+                                set_config('request.jwt.claims.sub',   $3, true)`,
+                        ctx?.role ?? '',
+                        ctx?.email ?? '',
+                        ctx?.sub ?? '',
+                    )
+                    // Prisma exposes the model under its camelCase accessor.
+                    const accessor =
+                        model.charAt(0).toLowerCase() + model.slice(1)
+                    return tx[accessor][operation](args)
+                })
+            },
+        },
+    })
+}

--- a/src/http/authentication.ts
+++ b/src/http/authentication.ts
@@ -1,6 +1,10 @@
 import { Request } from 'express'
 import { resolveAppRole, verifyAccessToken } from '../auth/jwt.js'
 import { config } from '../config.js'
+import {
+    setDbContextClaims,
+    TRUSTED_SERVICE_CONTEXT,
+} from '../db/request-context.js'
 
 /** Build an error carrying an HTTP status so the global handler emits a clean 4xx. */
 function authError(message: string, status: number): Error {
@@ -20,10 +24,16 @@ function authenticateApiKey(request: Request): { apiKey: true } | undefined {
     if (!mcpKey) return undefined // not configured → open, like the middleware
 
     const auth = (request.headers.authorization || '').toString()
-    if (auth === `Bearer ${mcpKey}`) return { apiKey: true }
+    if (auth === `Bearer ${mcpKey}`) {
+        setDbContextClaims(TRUSTED_SERVICE_CONTEXT)
+        return { apiKey: true }
+    }
 
     const headerKey = (request.headers['x-mcp-api-key'] || '').toString()
-    if (headerKey && headerKey === mcpKey) return { apiKey: true }
+    if (headerKey && headerKey === mcpKey) {
+        setDbContextClaims(TRUSTED_SERVICE_CONTEXT)
+        return { apiKey: true }
+    }
 
     throw authError('Unauthorized', 401)
 }
@@ -74,6 +84,21 @@ export async function expressAuthentication(
         }
         // Attach the resolved user to the request so controllers can read it.
         ;(request as any).user = Object.assign({}, decoded, { role, isAdmin })
+
+        // …and to the database layer, so RLS policies see the same decision the
+        // scope check above just made. Set after the scope check on purpose: a
+        // caller rejected with 403 never reaches a query anyway, and leaving the
+        // context empty on that path keeps the two from disagreeing.
+        setDbContextClaims({
+            role,
+            email:
+                typeof (decoded as any)?.email === 'string'
+                    ? (decoded as any).email
+                    : undefined,
+            sub: (decoded as any)?.sub
+                ? String((decoded as any).sub)
+                : undefined,
+        })
         return (request as any).user
     }
 

--- a/src/http/middleware/db-context.ts
+++ b/src/http/middleware/db-context.ts
@@ -1,0 +1,24 @@
+import type { NextFunction, Request, Response } from 'express'
+import { beginDbContext } from '../../db/request-context.js'
+
+/**
+ * Open a per-request database-identity scope.
+ *
+ * Must be registered **before** anything that authenticates, because it only
+ * opens an (initially empty) scope — the identity is written into it later by
+ * whichever gate resolves it (`jwtMiddleware`, TSOA's `expressAuthentication`,
+ * `mcpAuthMiddleware`). That indirection exists because TSOA resolves auth
+ * *inside* route handling, far too late for a middleware to have wrapped the
+ * handler in a scope that already knew who the caller was.
+ *
+ * Wrapping `next()` is what makes the scope cover the rest of the request:
+ * everything downstream is invoked from within this call, so async work it
+ * starts inherits the context.
+ */
+export function dbContextMiddleware(
+    _req: Request,
+    _res: Response,
+    next: NextFunction,
+) {
+    beginDbContext(() => next())
+}

--- a/src/http/middleware/mcp-auth.ts
+++ b/src/http/middleware/mcp-auth.ts
@@ -1,5 +1,9 @@
 import type { NextFunction, Request, Response } from 'express'
 import { config } from '../../config.js'
+import {
+    setDbContextClaims,
+    TRUSTED_SERVICE_CONTEXT,
+} from '../../db/request-context.js'
 import { logger } from '../../logger.js'
 import { mcpAuthFailuresTotal } from '../metrics-route.js'
 import { wwwAuthenticateValue } from '../protected-resource-metadata.js'
@@ -39,10 +43,21 @@ export function mcpAuthMiddleware(
         //      callers (e.g. the website) whose Authorization header already
         //      carries a Supabase user JWT for jwtMiddleware/TSOA admin auth.
         const auth = (req.headers.authorization || '').toString()
-        if (auth === `Bearer ${mcpKey}`) return next()
+        if (auth === `Bearer ${mcpKey}`) {
+            setDbContextClaims(TRUSTED_SERVICE_CONTEXT)
+            return next()
+        }
 
         const apiKeyHeader = (req.headers['x-mcp-api-key'] || '').toString()
-        if (apiKeyHeader && apiKeyHeader === mcpKey) return next()
+        if (apiKeyHeader && apiKeyHeader === mcpKey) {
+            // NOTE: this form is the website presenting the gateway key
+            // *alongside* a user JWT. The JWT path runs later and overwrites
+            // these claims with the real user's, which is the intended
+            // precedence — a user token must not be silently upgraded to admin
+            // just because the caller also knows the gateway key.
+            setDbContextClaims(TRUSTED_SERVICE_CONTEXT)
+            return next()
+        }
 
         // Auth failed — never log the presented credential value.
         logger.error('mcp-auth: auth failed', { path: req.path, ip: req.ip })

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -10,6 +10,7 @@ import {
     registerMetricsRoute,
 } from './metrics-route.js'
 import { auditAdminCatalogMutations } from './middleware/audit.js'
+import { dbContextMiddleware } from './middleware/db-context.js'
 import { registerPlaybackRoute } from './playback-route.js'
 import { registerProtectedResourceMetadata } from './protected-resource-metadata.js'
 import { registerSwaggerRoute } from './swagger-route.js'
@@ -22,6 +23,9 @@ export async function createHttpApp(): Promise<express.Application> {
     const app = express()
     app.use(cors())
     app.use(express.json())
+    // Opens the per-request DB identity scope. Must precede every auth gate —
+    // they fill it in, they do not create it.
+    app.use(dbContextMiddleware)
 
     // Diagnostic request logging to help debug hosting/proxy issues
     app.use((req, res, next) => {
@@ -143,6 +147,9 @@ export function createBasicApp(): express.Application {
     const app = express()
     app.use(cors())
     app.use(express.json())
+    // Opens the per-request DB identity scope. Must precede every auth gate —
+    // they fill it in, they do not create it.
+    app.use(dbContextMiddleware)
 
     // Diagnostic request logging to help debug hosting/proxy issues
     app.use((req, res, next) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import {
+    runWithDbContext,
+    TRUSTED_SERVICE_CONTEXT,
+} from './db/request-context.js'
 
 /**
  * Creates and configures the MCP server instance.
@@ -16,6 +20,39 @@ export function createServer(): McpServer {
             },
         },
     )
+
+    return withToolDbContext(server)
+}
+
+/**
+ * Give every MCP tool call a database identity.
+ *
+ * MCP callers do not carry a user JWT — they are gated by `MCP_API_KEY` on the
+ * HTTP/WebSocket transports, or are a local stdio process the developer started
+ * themselves. Both are already full trust: the key unlocks every DB-backed
+ * route, and stdio means someone with the machine. Without claims, RLS would
+ * refuse every MCP write, so tools would break the moment enforcement lands.
+ *
+ * Wrapping here rather than in each `registerXxxTool` covers all three
+ * transports from one place, and — importantly — does **not** touch the fake
+ * server in `src/tools/local.ts`. That one backs the REST facade, where the
+ * caller's real identity has already been established by the auth layer and
+ * must not be overwritten with service claims.
+ */
+function withToolDbContext(server: McpServer): McpServer {
+    const original = server.registerTool.bind(server)
+
+    ;(server as any).registerTool = (name: string, config: any, handler: any) =>
+        original(name, config, (...args: any[]) =>
+            // `async () => await …` is deliberate: the handler's promise must be
+            // created AND awaited inside the scope. Returning it unawaited lets
+            // it execute after the scope exits, at which point the claims are
+            // gone and every write is refused. See runWithDbContext.
+            runWithDbContext(
+                { ...TRUSTED_SERVICE_CONTEXT },
+                async () => await handler(...args),
+            ),
+        )
 
     return server
 }

--- a/test/db/request-context.test.ts
+++ b/test/db/request-context.test.ts
@@ -1,0 +1,111 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import {
+    beginDbContext,
+    getDbContext,
+    IDENTITY_REQUIRED_OPERATIONS,
+    runWithDbContext,
+    setDbContextClaims,
+    TRUSTED_SERVICE_CONTEXT,
+} from '../../src/db/request-context.js'
+import { dbContextMiddleware } from '../../src/http/middleware/db-context.js'
+
+describe('db request context', () => {
+    it('is undefined outside any scope', () => {
+        expect(getDbContext()).toBeUndefined()
+    })
+
+    it('exposes claims inside a scope and drops them after', async () => {
+        await runWithDbContext({ role: 'admin' }, async () => {
+            expect(getDbContext()?.role).toBe('admin')
+        })
+        expect(getDbContext()).toBeUndefined()
+    })
+
+    // The whole reason beginDbContext exists: TSOA resolves auth inside route
+    // handling, so the scope has to be opened empty and filled in later.
+    it('lets a later caller fill in a scope opened empty', async () => {
+        await beginDbContext(async () => {
+            expect(getDbContext()).toEqual({})
+            setDbContextClaims({ role: 'admin', email: 'a@b.c' })
+            expect(getDbContext()).toMatchObject({
+                role: 'admin',
+                email: 'a@b.c',
+            })
+        })
+    })
+
+    it('setDbContextClaims is a no-op outside a scope (never throws)', () => {
+        expect(() => setDbContextClaims({ role: 'admin' })).not.toThrow()
+        expect(getDbContext()).toBeUndefined()
+    })
+
+    it('keeps concurrent scopes isolated from each other', async () => {
+        const seen: string[] = []
+        await Promise.all([
+            runWithDbContext({ role: 'admin' }, async () => {
+                await new Promise((r) => setTimeout(r, 20))
+                seen.push(`a:${getDbContext()?.role}`)
+            }),
+            runWithDbContext({ role: 'user' }, async () => {
+                seen.push(`b:${getDbContext()?.role}`)
+            }),
+        ])
+        expect(seen.sort()).toEqual(['a:admin', 'b:user'])
+    })
+
+    it('treats writes — and only writes — as identity-required', () => {
+        for (const op of ['create', 'update', 'upsert', 'delete', 'deleteMany'])
+            expect(IDENTITY_REQUIRED_OPERATIONS.has(op)).toBe(true)
+        // Reads stay off the wrapped path so the hot catalog route keeps its
+        // single round-trip.
+        for (const op of ['findMany', 'findUnique', 'findFirst', 'count'])
+            expect(IDENTITY_REQUIRED_OPERATIONS.has(op)).toBe(false)
+    })
+
+    it('trusted service context carries admin', () => {
+        expect(TRUSTED_SERVICE_CONTEXT.role).toBe('admin')
+    })
+})
+
+describe('dbContextMiddleware', () => {
+    it('opens a scope that downstream handlers can fill and read', async () => {
+        const app = express()
+        app.use(dbContextMiddleware)
+        app.get('/x', (_req, res) => {
+            setDbContextClaims({ role: 'admin', email: 'x@y.z' })
+            res.json({ ctx: getDbContext() })
+        })
+        const res = await request(app).get('/x').expect(200)
+        expect(res.body.ctx).toMatchObject({ role: 'admin', email: 'x@y.z' })
+    })
+
+    it('survives an async boundary in the handler', async () => {
+        const app = express()
+        app.use(dbContextMiddleware)
+        app.get('/x', async (_req, res) => {
+            setDbContextClaims({ role: 'admin' })
+            await new Promise((r) => setTimeout(r, 10))
+            res.json({ role: getDbContext()?.role })
+        })
+        const res = await request(app).get('/x').expect(200)
+        expect(res.body.role).toBe('admin')
+    })
+
+    it('does not bleed claims between requests', async () => {
+        const app = express()
+        app.use(dbContextMiddleware)
+        app.get('/set', (_req, res) => {
+            setDbContextClaims({ role: 'admin' })
+            res.json({ ok: true })
+        })
+        app.get('/read', (_req, res) => res.json({ ctx: getDbContext() }))
+
+        await request(app).get('/set').expect(200)
+        const res = await request(app).get('/read').expect(200)
+        // A fresh request must start empty — otherwise one admin call would
+        // silently authorise every later caller on that connection.
+        expect(res.body.ctx).toEqual({})
+    })
+})

--- a/test/integration/rls-enforcement.test.ts
+++ b/test/integration/rls-enforcement.test.ts
@@ -1,120 +1,183 @@
-﻿import { afterAll, describe, expect, it } from 'vitest'
-import { initPrisma, prisma } from '../../src/db'
+import { PrismaPg } from '@prisma/adapter-pg'
+import { PrismaClient } from '@prisma/client'
+import pg from 'pg'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import {
+    runWithDbContext,
+    TRUSTED_SERVICE_CONTEXT,
+} from '../../src/db/request-context.js'
+import { withRequestClaims } from '../../src/db/with-request-claims.js'
 
 const RUN_DB_TESTS = process.env.RUN_DB_INTEGRATION === 'true'
 
 /**
- * Does Row-Level Security actually apply to the connection **the application
- * uses**? (Operational readiness review, gap #7.)
+ * Does RLS actually stop a non-admin writing? (ORR gap #7.)
  *
- * The review listed RLS as a defence-in-depth control, "migrations present,
- * enforcement path unverified". Verifying it turned up that RLS is **not an
- * active control for this application** â€” for three independent reasons, any one
- * of which is sufficient on its own:
+ * The previous version of this file pinned the *broken* posture, because at the
+ * time RLS enforced nothing: the app owned every table, carried `BYPASSRLS`, and
+ * no table used FORCE. `20260801120000_enforce_rls` plus the claim-propagating
+ * Prisma extension changed that, so this now asserts enforcement.
  *
- *   1. The app connects as `postgres`, which **owns** every table. In Postgres
- *      the table owner bypasses RLS unless `FORCE ROW LEVEL SECURITY` is set â€”
- *      and no migration in this repo has ever used FORCE.
- *   2. That role also carries `rolbypassrls` in production, which skips policies
- *      regardless of ownership or FORCE.
- *   3. Most tables don't have RLS enabled at all any more. The single-user
- *      simplification (`20260219163147_simplify_single_user`) deliberately
- *      dropped policies and disabled RLS on the catalog tables.
- *
- * None of that is necessarily wrong: authorization for this service is enforced
- * in the application layer (OIDC JWT + `requireAdmin` + the MCP gateway key),
- * and for a single-user app that is a defensible place for it to live. What was
- * wrong was *believing* RLS was a second layer when it is inert.
- *
- * So this test does not assert that RLS works. It **pins the real posture** so
- * it cannot drift silently, and so that anyone who later enables RLS and assumes
- * they are protected gets a loud failure pointing them here instead of a false
- * sense of security.
+ * Crucially it connects as **`mcp_app`**, not as the migration owner. Testing
+ * this as `postgres` would pass vacuously — the owner sails past every policy,
+ * which is the exact trap the original setup fell into.
  */
-describe('RLS enforcement posture (ORR gap #7)', () => {
+const OWNER_URL = process.env.DATABASE_URL ?? ''
+const APP_PASSWORD = 'rls_test_app_password'
+
+function appUrl(): string {
+    const u = new URL(OWNER_URL)
+    u.username = 'mcp_app'
+    u.password = APP_PASSWORD
+    return u.toString()
+}
+
+describe('RLS enforcement (ORR gap #7)', () => {
     if (!RUN_DB_TESTS) {
         it.skip('skipped - requires RUN_DB_INTEGRATION=true', () => {})
         return
     }
 
+    let base: PrismaClient
+    let db: any
+
+    beforeAll(async () => {
+        // Give the (NOLOGIN) app role a password for the duration of the test.
+        // Production does this once during cutover; here it keeps the test
+        // self-contained and avoids putting a credential in the migration.
+        const owner = new pg.Client({ connectionString: OWNER_URL })
+        await owner.connect()
+        await owner.query(`ALTER ROLE mcp_app LOGIN PASSWORD '${APP_PASSWORD}'`)
+        await owner.end()
+
+        base = new PrismaClient({
+            adapter: new PrismaPg({ connectionString: appUrl() }),
+        })
+        db = withRequestClaims(base)
+    })
+
     afterAll(async () => {
-        await initPrisma()
-        if (typeof prisma.$disconnect === 'function') {
-            await prisma.$disconnect()
-        }
+        await base?.$disconnect()
+        const owner = new pg.Client({ connectionString: OWNER_URL })
+        await owner.connect()
+        await owner.query('ALTER ROLE mcp_app NOLOGIN')
+        await owner.end()
     })
 
-    it('reports whether the app connection can bypass RLS', async () => {
-        await initPrisma()
-
-        const [role] = (await prisma.$queryRaw`SELECT current_user AS role,
-                    (SELECT rolsuper     FROM pg_roles WHERE rolname = current_user) AS is_superuser,
-                    (SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user) AS has_bypassrls`) as Array<{
-            role: string
-            is_superuser: boolean
-            has_bypassrls: boolean
-        }>
-
-        const tables = (await prisma.$queryRaw`SELECT c.relname AS name,
-                    pg_get_userbyid(c.relowner) AS owner,
-                    c.relrowsecurity      AS rls_enabled,
-                    c.relforcerowsecurity AS rls_forced
-             FROM pg_class c
-             JOIN pg_namespace n ON n.oid = c.relnamespace
-             WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname !~ '^_'`) as Array<{
-            name: string
-            owner: string
-            rls_enabled: boolean
-            rls_forced: boolean
-        }>
-
-        expect(tables.length).toBeGreaterThan(0)
-
-        const ownsTables = tables.some((t) => t.owner === role.role)
-        const bypassesAsOwner = ownsTables && tables.some((t) => !t.rls_forced)
-        const bypasses =
-            role.is_superuser || role.has_bypassrls || bypassesAsOwner
-
-        // Pinning the *current* answer. If this ever fails, RLS enforcement has
-        // changed â€” which is a good thing, but it means the security section of
-        // docs/operational-readiness-review.md is now wrong and must be updated
-        // to stop describing RLS as inert. Do not "fix" this by flipping the
-        // expectation without reading Â§9.
-        expect(bypasses).toBe(true)
+    it('connects as a role that cannot bypass RLS', async () => {
+        const [row] = (await base.$queryRaw`
+            SELECT current_user AS role,
+                   (SELECT rolbypassrls FROM pg_roles WHERE rolname = current_user) AS bypass
+        `) as Array<{ role: string; bypass: boolean }>
+        expect(row.role).toBe('mcp_app')
+        expect(row.bypass).toBe(false)
     })
 
-    it('has no table using FORCE ROW LEVEL SECURITY', async () => {
-        await initPrisma()
-        const forced = (await prisma.$queryRaw`SELECT c.relname AS name
-             FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
-             WHERE n.nspname = 'public' AND c.relkind = 'r'
-               AND c.relforcerowsecurity = true`) as Array<{ name: string }>
+    it('has RLS enabled AND forced on every application table', async () => {
+        const rows = (await base.$queryRaw`
+            SELECT c.relname AS name, c.relrowsecurity AS enabled, c.relforcerowsecurity AS forced
+            FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+            WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname NOT LIKE '\\_%'
+        `) as Array<{ name: string; enabled: boolean; forced: boolean }>
 
-        // Without FORCE, an owner-connected app is never subject to its own
-        // policies. This is the single change that would matter most if RLS is
-        // ever meant to become a real control.
-        expect(forced.map((t) => t.name)).toEqual([])
+        expect(rows.length).toBeGreaterThan(0)
+        // FORCE matters: without it, pointing the app back at an owner role
+        // silently reopens everything.
+        expect(rows.filter((r) => !r.enabled).map((r) => r.name)).toEqual([])
+        expect(rows.filter((r) => !r.forced).map((r) => r.name)).toEqual([])
     })
 
-    it('policies that exist do not constrain the app connection', async () => {
-        await initPrisma()
-        const withPolicies =
-            (await prisma.$queryRaw`SELECT c.relname AS name, count(p.oid)::int AS policies
-             FROM pg_class c
-             JOIN pg_namespace n ON n.oid = c.relnamespace
-             LEFT JOIN pg_policy p ON p.polrelid = c.oid
-             WHERE n.nspname = 'public' AND c.relkind = 'r' AND c.relname !~ '^_'
-             GROUP BY c.relname HAVING count(p.oid) > 0`) as Array<{
-                name: string
-                policies: number
-            }>
+    it('allows reads without any identity (public catalog, fast path)', async () => {
+        await expect(db.movie.findMany({ take: 1 })).resolves.toBeDefined()
+    })
 
-        // Documented, not asserted to be empty: some tables genuinely do carry
-        // policies (Article, Bet, Resume, ResumeDownloadRequest in production).
-        // They are simply never evaluated for this connection. Whoever wrote
-        // them was reasonably expecting protection that isn't there.
-        for (const t of withPolicies) {
-            expect(t.policies).toBeGreaterThan(0)
-        }
+    it('BLOCKS a write with no identity', async () => {
+        await expect(
+            db.movie.create({
+                data: { title: 'no-context', status: 'NOT_STARTED' },
+            }),
+        ).rejects.toThrow(/row-level security/i)
+    })
+
+    // The bug class this exists for: an authorization slip that lets a
+    // non-admin through the application layer still cannot write.
+    it('BLOCKS a write from a non-admin identity', async () => {
+        await expect(
+            runWithDbContext(
+                { role: 'user', email: 'someone@example.com' },
+                async () =>
+                    await db.movie.create({
+                        data: { title: 'non-admin', status: 'NOT_STARTED' },
+                    }),
+            ),
+        ).rejects.toThrow(/row-level security/i)
+    })
+
+    it('ALLOWS a write from an admin identity', async () => {
+        const created = await runWithDbContext(
+            { role: 'admin', email: 'brn.dbn@gmail.com' },
+            async () =>
+                await db.movie.create({
+                    data: { title: 'admin-write', status: 'NOT_STARTED' },
+                }),
+        )
+        expect(created?.id).toBeDefined()
+
+        await runWithDbContext(
+            { role: 'admin', email: 'brn.dbn@gmail.com' },
+            async () => await db.movie.delete({ where: { id: created.id } }),
+        )
+    })
+
+    it('ALLOWS a write from the trusted service context (MCP gateway key)', async () => {
+        const created = await runWithDbContext(
+            { ...TRUSTED_SERVICE_CONTEXT },
+            async () =>
+                await db.movie.create({
+                    data: { title: 'service-write', status: 'NOT_STARTED' },
+                }),
+        )
+        expect(created?.id).toBeDefined()
+        await runWithDbContext(
+            { ...TRUSTED_SERVICE_CONTEXT },
+            async () => await db.movie.delete({ where: { id: created.id } }),
+        )
+    })
+
+    it('does not leak claims to the next call once the scope exits', async () => {
+        await runWithDbContext(
+            { role: 'admin', email: 'brn.dbn@gmail.com' },
+            async () =>
+                await db.movie.create({
+                    data: { title: 'scoped', status: 'NOT_STARTED' },
+                }),
+        )
+        // Same connection, no scope — must be refused again.
+        await expect(
+            db.movie.create({
+                data: { title: 'after-scope', status: 'NOT_STARTED' },
+            }),
+        ).rejects.toThrow(/row-level security/i)
+    })
+
+    // Regression guard for the footgun found during the spike: Prisma promises
+    // are lazy, so a context callback that returns without awaiting executes
+    // outside the scope and loses its claims.
+    it('loses claims when the callback does not await (documented footgun)', async () => {
+        await expect(
+            runWithDbContext(
+                { role: 'admin', email: 'brn.dbn@gmail.com' },
+                () =>
+                    db.movie.create({
+                        data: { title: 'unawaited', status: 'NOT_STARTED' },
+                    }),
+            ),
+        ).rejects.toThrow(/row-level security/i)
+    })
+
+    it('denies schema modification to the app role', async () => {
+        await expect(
+            base.$executeRawUnsafe('CREATE TABLE rls_should_fail (id int)'),
+        ).rejects.toThrow(/permission denied/i)
     })
 })


### PR DESCRIPTION
Closes ORR gap #7 properly: RLS goes from **inert** to **enforced**.

> [!IMPORTANT]
> **Stacked on #159.** Merge that first. Also: merging this changes **nothing** in production on its own — enforcement requires a credential cutover, documented in [`docs/runbooks/rls-cutover.md`](docs/runbooks/rls-cutover.md). Rollback is one env value.

## What was wrong

Three independent bypasses, any one sufficient:

| # | Bypass |
|---|---|
| 1 | The app connects as `postgres`, which **owns every table**. Owners bypass RLS unless `FORCE ROW LEVEL SECURITY` — and no migration here ever used FORCE. |
| 2 | That role also carries **`rolbypassrls`**, which skips policies regardless of ownership or FORCE. |
| 3 | 7 of 11 tables had RLS **disabled with zero policies** (the single-user simplification dropped them). |

Plus: the surviving policies keyed on `current_setting('request.jwt.claims.*')`, which nothing ever set.

## Two spikes first

Both green before a line of production code:

- **Claim propagation works** — a Prisma extension can carry identity per request, and a non-admin write is then genuinely refused. 6/6.
- **Supabase's pooler accepts a custom login role** — on **both** 5432 and 6543. This was make-or-break: enforcement requires connecting as something other than the owner, and if supavisor had rejected custom roles the whole approach was dead.

The probe role was created with zero grants and dropped immediately; production verified clean afterwards.

## Database half — `20260801120000_enforce_rls`

`mcp_app`: non-owner, `NOBYPASSRLS`, data privileges but **no DDL**. Created `NOLOGIN` with no password, so **no credential enters the repo or migration history** — the password is set once during cutover.

`ENABLE` + **`FORCE`** on every table, with a uniform policy pair applied in a loop so a new table can't quietly miss out:

```sql
CREATE POLICY "<T>_read"        ON "<T>" FOR SELECT USING (true);
CREATE POLICY "<T>_admin_write" ON "<T>" FOR ALL
  USING      (current_setting('request.jwt.claims.role', true) = 'admin')
  WITH CHECK (current_setting('request.jwt.claims.role', true) = 'admin');
```

FORCE is deliberate — without it, ownership alone silently reopens everything, which is exactly how this became inert the first time.

**Applying this migration is a no-op for the running app.** It still connects as `postgres` and still bypasses. That's why there's a runbook rather than a deploy: enforcement is a credential change, not a schema change.

## Application half

`src/db/with-request-claims.ts` wraps *write* operations in a transaction that sets the claims first. `set_config(..., is_local => true)` scopes them to that transaction so they can't bleed across a pooled connection — load-bearing on Supabase's transaction pooler.

**Reads are deliberately not wrapped.** Catalog reads are public and are the hot path (`/api/books` p50 307ms, already round-trip bound per the §8 baseline); carrying identity there would cost two extra round-trips per page load for no security gain. Writes are where an authorization bug actually costs something.

Identity is established by whichever gate resolves it — `jwtMiddleware`, TSOA's `expressAuthentication`, `mcpAuthMiddleware`, and a wrapper around MCP tool handlers in `createServer()`. `dbContextMiddleware` opens the scope *empty* and later code fills it, because TSOA resolves auth inside route handling — far too late for a middleware to have wrapped the handler in a scope that already knew the caller.

**Behaviour is preserved for every existing caller.** MCP gateway key and service-role paths map to admin claims — both are already full trust today. What changes: a **user JWT can no longer write without genuinely resolving to admin.** That is the bug class this defends against, and #151 was an instance of it.

The MCP tool wrapper sits on the real `McpServer` only — deliberately not on the fake server in `src/tools/local.ts`, which backs the REST facade where the caller's real identity has already been established and must not be overwritten with service claims.

## ⚠️ One footgun, found by the spike and pinned by a test

Prisma operations are lazy:

```ts
runWithDbContext(ctx, () => db.x.create(…))              // ✗ claims lost
runWithDbContext(ctx, async () => await db.x.create(…))  // ✓
```

Without the inner `await`, the promise is *created* inside the scope but *runs* outside it, so claims arrive empty. It fails **closed** — the write is refused, not allowed — but silently. My first spike attempt hit exactly this and looked like "RLS is broken". There's a regression test asserting the broken form still fails, so nobody has to rediscover it.

## Tests

`rls-enforcement.test.ts` now asserts enforcement instead of pinning inertness, and connects **as `mcp_app`**. Testing as the owner would pass vacuously — precisely the trap the original setup fell into.

- non-admin write **blocked** ← the point
- write with no identity **blocked**
- admin write **allowed**; service context **allowed**
- claims **don't leak** after the scope exits
- reads unrestricted (fast path intact)
- `ENABLE` **and** `FORCE` on every table
- DDL denied to the app role
- the lazy-promise footgun still fails

Plus `test/db/request-context.test.ts` (10) for the plumbing: concurrent scope isolation, no bleed between HTTP requests, survives async boundaries.

**406 passed** with `RUN_DB_INTEGRATION`, **393** without. `verify` green.

## What this does not do

- **Does not filter reads by identity.** That was the L3 option; rejected on the measured cost to the hot path.
- **Does not change migrations or seeding.** Both still run as `postgres` over `DATABASE_URL_DIRECT` — `mcp_app` has no DDL rights by design. Verified the seed still works under FORCE.
- **Does not take effect until cutover.** Which is yours to run, per the runbook.
