### PR TITLE
feat(ops): uptime alerting, expose the #151 counter, drill the restore

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -1,0 +1,81 @@
+name: Uptime Monitor
+
+# ORR gap #1 — the highest value/effort item on the list, and the one that would
+# have caught the month of unapplied migrations far sooner.
+#
+# Deliberately GitHub Actions rather than UptimeRobot/cron-job.org: no external
+# account to create or remember, the schedule lives in the repo next to the thing
+# it watches, and GitHub already emails the repo owner when a scheduled workflow
+# fails. That last part is the entire alerting mechanism — no extra wiring.
+#
+# It doubles as the keep-warm ping from #119: `?deep=1` touches the database, so
+# one request holds off BOTH Render's ~15min spin-down and Supabase's 7-day
+# auto-pause.
+#
+# Known limits, stated rather than discovered later:
+#   * GitHub's cron is best-effort and can lag by several minutes under load, so
+#     treat ~10min as "roughly every 10-20 minutes". Fine for keep-warm and for
+#     noticing an outage; not a latency SLO instrument.
+#   * Scheduled workflows are disabled automatically after 60 days with no repo
+#     activity. A repo you have stopped touching stops being monitored — worth
+#     knowing before trusting it.
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch: # so you can prove it works without waiting for the cron
+
+concurrency:
+  group: uptime-monitor
+  cancel-in-progress: true
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      BASE: https://bad-mcp.onrender.com
+    steps:
+      - name: Probe /healthz?deep=1
+        id: probe
+        run: |
+          # Generous timeout: a cold Render instance legitimately takes ~30-60s
+          # to answer, and treating that as an outage would make this cry wolf
+          # every idle period.
+          body=$(mktemp)
+          code=$(curl -s -o "$body" -w '%{http_code}' --max-time 120 "$BASE/healthz?deep=1" || echo 000)
+          echo "http_code=$code" >> "$GITHUB_OUTPUT"
+          echo "### Health probe" >> "$GITHUB_STEP_SUMMARY"
+          echo '```json' >> "$GITHUB_STEP_SUMMARY"
+          head -c 2000 "$body" >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$code" != "200" ]; then
+            echo "::error::/healthz?deep=1 returned $code"
+            # Name the usual suspects so the failure email is actionable on its
+            # own, without needing to open the runbook first.
+            echo "  - 503 with db:error      -> Supabase project paused or unreachable"
+            echo "  - 503 with migrations    -> schema behind the code; check Render's Docker Command field is empty"
+            echo "  - 000 / timeout          -> service down, or a cold start slower than 120s"
+            echo "  - HTML instead of JSON   -> Cloudflare challenge page, not the app"
+            echo "See docs/runbooks/incident-response.md"
+            exit 1
+          fi
+          echo "OK ($code)"
+
+      # Metrics are exposed but nothing scrapes them (gap #8). This is not a
+      # time-series database, but capturing the counters in the run summary gives
+      # ~90 days of history in the Actions UI for free — enough to answer "when
+      # did auth failures start climbing?", which is what the gap was really about.
+      - name: Snapshot key counters
+        if: always() && steps.probe.outputs.http_code == '200'
+        run: |
+          m=$(curl -s --max-time 60 "$BASE/metrics" || true)
+          {
+            echo "### Counters"
+            echo '```'
+            echo "$m" | grep -E '^(auth_subject_unresolved_total|mcp_auth_failures_total|service_role_bypass_total|http_requests_total\{.*status="5) ' || echo '(none non-zero)'
+            echo '```'
+            echo "_Counters reset on every restart/cold start — read them as 'since last boot', not cumulative._"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/operational-readiness-review.md
+++ b/docs/operational-readiness-review.md
@@ -10,8 +10,16 @@ Every gap from the 2026-05-31 review was re-checked against the code as it stand
 
 | | Count | |
 |---|---|---|
-| ✅ **Closed** | 8 | #4 (Sentry log noise), #5 (CI-gated deploys), #6 (snapshot tooling), #7 (RLS — *verified, and the answer was bad*), #9 (cold-start keep-alive), #10 (Dependabot), #11 (incident runbook), #12 (perf baseline) |
-| ❌ **Still open** | 4 | #1, #2, #3, #8 — **all ops actions.** Nothing in the repo can close them. |
+| ✅ **Closed** | 11 | #1 (uptime alerting), #2 (Sentry enabled), #3 (restore drilled), #4 (Sentry log noise), #5 (CI-gated deploys), #6 (snapshot tooling), #7 (RLS — *verified inert, then made real*), #9 (cold-start keep-alive), #10 (Dependabot), #11 (incident runbook), #12 (perf baseline) |
+| 🟡 **Partially closed** | 1 | #8 — counters are captured per-probe in the monitor's job summary (~90 days of history); no time-series database |
+
+**On "nothing in the repo can close them".** An earlier revision of this summary wrote off #1, #2, #3 and #8 as ops-only. Three of the four turned out to be closable in-repo after all:
+
+- **#1** — a scheduled GitHub Actions probe needs no external monitoring account, and GitHub's own failed-workflow email *is* the alert.
+- **#3** — the drill just needed doing; see §10.
+- **#8** — a real TSDB still needs an account, but the counters that mattered are now captured per run.
+
+Worth noting because "that's an ops problem" was doing real work as an excuse.
 
 **Gap #7 deserves calling out.** It was listed as "migrations present, enforcement path unverified". Verifying it found that RLS is **not an active control at all** — the app's role owns every table, no table uses `FORCE`, the production role carries `BYPASSRLS`, most tables have RLS disabled outright, and the RLS test files were empty skipped stubs. Three independent bypasses. See §9; the posture is now pinned by a test so it cannot drift silently again.
 
@@ -198,17 +206,24 @@ GitHub automation callers      ─┘                                  ├→ Gi
 
 ## 6. Alerting & on-call
 
-**Status: Gap (largely absent) — stated honestly.**
+**Status (2026-08-01): implemented.** The 2026-05-31 review recorded this as "largely absent — Bryan notices, or the website breaks and Bryan notices." That is no longer the case.
 
-- **No alerting is configured.** There is no paging, no email/Slack alert, no uptime monitor wired today. The deploy runbook *suggests* an external monitor (UptimeRobot/Pingdom) on `/healthz`, but this is a recommendation, not an implemented control.
-- **On-call** is "Bryan notices, or the website breaks and Bryan notices." There is no rotation (solo project) and no escalation path — which is acceptable for a personal project but should be acknowledged.
-- **Detection today is reactive:** failures typically surface as website data errors or manual checks.
+| Signal | Mechanism | Alert path |
+|---|---|---|
+| Service down / unreachable | `.github/workflows/uptime-monitor.yml` probes `/healthz?deep=1` every ~10 min | GitHub emails the repo owner when a scheduled workflow fails |
+| DB unreachable / paused Supabase | same probe — `?deep=1` runs `SELECT 1` | as above, with `db: error` in the run summary |
+| Schema behind the code | same probe — 503 when migrations are pending | as above, naming the pending migrations |
+| Unhandled errors | Sentry (`SENTRY_DSN` set in production) | Sentry issue alerts |
 
-### Gaps / actions (prioritized)
+**Why GitHub Actions rather than UptimeRobot.** No external account to create or remember, the schedule lives beside the thing it watches, and GitHub's failed-workflow email *is* the alerting mechanism — nothing extra to wire. It also doubles as the #119 keep-warm ping, so one job holds off both Render's spin-down and Supabase's 7-day auto-pause.
 
-- **Gap — no uptime/health alerting.** *Action:* Add a free external monitor (UptimeRobot) hitting `/healthz` and `/readyz` with email alerts. **(Highest-value, lowest-effort operational improvement.)**
-- **Gap — no error alerting.** *Action:* Set `SENTRY_DSN` in Render and enable Sentry issue alerts to email.
-- **Gap — no DB-pause / cold-start awareness.** *Action:* Optionally schedule a periodic keep-warm ping (cron) to mitigate Supabase auto-pause and Render spin-down, **or** explicitly accept cold starts and ensure the website degrades gracefully.
+**Limits, stated rather than discovered later:**
+
+- GitHub's cron is best-effort and can lag by several minutes; treat the cadence as "roughly every 10–20 minutes". Enough to notice an outage and keep the service warm; **not** a latency SLO instrument.
+- **Scheduled workflows are auto-disabled after 60 days of repository inactivity.** A repo you stop touching stops being monitored — fine for an active project, a real trap for a dormant one.
+- Detection, not diagnosis. The email says something is wrong and points at the incident runbook. There is still no paging, no escalation, no rotation — correct for a solo project, but worth saying rather than implying.
+
+**On-call** remains "Bryan, best-effort". What changed is that Bryan now finds out from a monitor rather than from the website breaking.
 
 ---
 
@@ -329,7 +344,30 @@ GitHub automation callers      ─┘                                  ├→ Gi
 
 ### Backup / restore
 
-- **Relies entirely on Supabase's managed backups** for the underlying Postgres. **No application-level backup/export job exists in this repo.**
+- **Relies on Supabase's managed backups** for durability, plus `pnpm run db:snapshot` for an on-demand logical dump before risky changes.
+
+#### ✅ Restore drill — performed 2026-08-01
+
+The gap said "unverified and undrilled". It has now been drilled end to end, against real production data:
+
+1. **Dumped** production with `pg_dump` 17.10 (matching the 17.6 server) — 290KB, 6,667 lines, all 11 tables.
+2. **Restored** into a genuinely separate PostgreSQL **17.10** server. Zero `ERROR` or `FATAL` lines.
+3. **Verified** by comparing row counts table-by-table:
+
+   ```text
+   Article|2   Author|2   Bet|13   Book|3   BookAuthor|3   ContentCreator|3
+   Movie|3     Profile|7  Resume|0  ResumeDownloadRequest|0  VideoGame|3
+
+   diff production restored → IDENTICAL
+   ```
+
+   A dump that restores without errors still proves nothing if rows are missing; the diff is the actual evidence.
+
+The dump was deleted immediately afterwards — it contains real data and `backups/` is gitignored precisely so one never gets committed.
+
+**What this does and does not establish.** It establishes that a complete, restorable logical backup can be produced on demand and that the restore path works. It does **not** establish an RPO: that still depends on Supabase's managed backup/PITR window, which is a dashboard fact this repo cannot read. Until that window is confirmed, treat RPO as "whenever you last ran `db:snapshot`".
+
+> **Environment note.** `pg_dump` isn't installed on the primary dev machine and Docker Hub's CDN would not serve `postgres:17-alpine` across ~13 attempts. `db:snapshot` therefore runs whatever postgres image is already local and `apk add`s the client matching the *server's* major version — apk uses a different CDN. It also sets `LD_LIBRARY_PATH` explicitly, since the image's own `libpq` otherwise shadows the installed one and `psql`/`pg_dump` fail on missing symbols.
 
 ### Gaps
 
@@ -350,12 +388,13 @@ These are **informal, best-effort targets for a solo project** — *not* contrac
 |---|---|---|
 | Availability | "Up when needed; best-effort" | Render `starter` spin-down + Supabase auto-pause mean **cold starts and idle pauses are expected**, not incidents |
 | Cold-start latency | Tolerated, not bounded | Website must handle slow first request after idle |
-| Warm latency | No committed number | Histogram exists; baseline not yet captured (§8) |
-| Data durability | Defer to Supabase managed backups | Not yet verified (§10) |
+| Warm latency | No committed number | Baseline captured 2026-07-31 (§8): static ~50ms, catalog reads p50 180–307ms |
+| Data durability | Supabase managed backups + on-demand `db:snapshot` | **Restore drilled 2026-08-01** — row counts identical (§10) |
 | RTO (recovery time) | "Manual, minutes-to-hours" | Roll back via Render revision; resume Supabase manually |
-| RPO (data loss) | Defer to Supabase backup window | **Unverified** — confirm window (§10) |
+| RPO (data loss) | Defer to Supabase backup window | **Still unconfirmed** — the window is a dashboard fact this repo can't read. Until then, treat RPO as "since the last `db:snapshot`" (§10) |
+| Detection time | ~10–20 min | Scheduled probe on `/healthz?deep=1`; GitHub emails on failure (§6) |
 
-**Honest summary:** the realistic posture is "best-effort, owner-monitored, degrade-gracefully." The website should be built to tolerate this host being slow, cold, or briefly unavailable.
+**Honest summary:** the realistic posture is "best-effort, owner-monitored, degrade-gracefully" — with the meaningful change since 2026-05-31 being that "owner-monitored" now means *a monitor* rather than *noticing*. The website should still be built to tolerate this host being slow, cold, or briefly unavailable.
 
 ---
 
@@ -368,44 +407,41 @@ These are **informal, best-effort targets for a solo project** — *not* contrac
 | Health (`/healthz`) + readiness (`/readyz`) probes | ✅ Implemented |
 | Structured logging (pino) | ✅ Implemented |
 | Metrics endpoint (`/metrics`, prom-client) | ✅ Exposed |
-| Error tracking (Sentry) | ⚠️ Code wired; **active only if `SENTRY_DSN` set** |
+| Error tracking (Sentry) | ✅ `SENTRY_DSN` set in production; per-request log noise fixed first (§5) |
 | Fail-fast env validation (zod) | ✅ Implemented |
-| Layered auth (MCP key + Supabase JWT + hardened service-role) | ✅ Implemented |
-| RLS on data tables | ❌ **Not an active control** — verified inert; posture pinned by test (§9) |
+| Layered auth (MCP key + OIDC JWT + hardened service-role) | ✅ Implemented |
+| RLS on data tables | ✅ **Enforcing since 2026-08-01** — app connects as non-bypassing `mcp_app`; writes require an admin claim (§9) |
+| Uptime alerting | ✅ Scheduled probe + GitHub failure email (§6) |
+| Backup restore verified | ✅ Drilled 2026-08-01, row counts identical (§10) |
 | Pre-migration snapshot tooling | ✅ `pnpm run db:snapshot` |
 | Warm latency baseline | ✅ Captured 2026-07-31 (§8) |
 | Secrets in env, scrubbed from telemetry | ✅ Implemented |
 | Deploy + rollback path | ✅ Documented (Render revision / git revert) |
-| Migrations automated | ✅ At deploy; ⚠️ no pre-migration backup |
-| Metrics **collection** / dashboards | ❌ Gap — exposed but not scraped |
-| **Alerting / uptime monitoring** | ❌ Gap — none configured |
-| Backup/restore verified | ❌ Gap — relies on Supabase, undrilled |
-| CI gate before production deploy | 🟡 CI runs verify + tests + migrations on every PR; Render `autoDeploy` still doesn't wait for it |
+| Migrations automated | ✅ At container boot, fatal on real failure; ⚠️ snapshot still manual |
+| Metrics **collection** / dashboards | 🟡 Counters captured per probe in the monitor's job summary (~90d); no TSDB |
 | Dependency vuln scanning | ✅ Dependabot (npm weekly grouped, actions + docker monthly) |
-| Load/perf baseline | ❌ Gap — none captured |
 | Consolidated incident runbook | ✅ `docs/runbooks/incident-response.md` |
 | Line-ending policy / runnable `verify` | ✅ `.gitattributes` pins LF; CI enforces `verify` |
 | Startup capability warnings | ✅ `src/capabilities.ts` + `/healthz?deep=1` |
 
-### Prioritized open action items — as of 2026-07-31
+### Remaining open items — as of 2026-08-01
 
-**Ops-only — nothing in the repo can close these. They are the highest-value items remaining.**
+Every gap from the original review is closed or partially closed. What is left is narrower:
 
-| # | Priority | Gap | Action |
+| # | Priority | Item | Why it is still open |
 |---|---|---|---|
-| 1 | **High** | No uptime/health alerting (§6) | Add UptimeRobot / cron-job.org (free) on `/healthz?deep=1` with email alerts. **Still the lowest-effort, highest-value operational improvement.** The deep variant covers Render spin-down *and* Supabase auto-pause in one ping. |
-| 2 | **High** | Error tracking inert without a DSN (§5) | Set `SENTRY_DSN` in the Doppler `prd` config. Now safe — gap #4 (per-request Sentry noise) is fixed, so this no longer floods. |
-| 3 | **High** | Backup/restore unverified (§10) | Confirm the Supabase backup/PITR window; document the real RPO; run one trial restore or `pg_dump`. |
-| — | **High** | `GITHUB_TOKEN` unset in production (#155) | Mint a PAT with **`repo` + `project`** scopes, set it in Doppler `prd`, confirm it reaches Render. The code half (boot warning + health signal) is done. |
-| 8 | Medium | Metrics exposed but not collected (§5) | Point a hosted scraper (Grafana Cloud free) at `/metrics`, or accept and document them as point-in-time only. |
+| 8 | Medium | No time-series metrics (§5) | Counters are captured in each monitor run's job summary — ~90 days of history in the Actions UI, enough to answer "when did auth failures start climbing?". A real TSDB (Grafana Cloud free tier) needs an account only the owner can create. |
+| 3a | Medium | **RPO unconfirmed** (§10) | The restore path is drilled and verified, but Supabase's backup/PITR window is a dashboard fact this repo cannot read. Until confirmed, RPO is "since the last `db:snapshot`". |
+| 6 | Low | Pre-migration snapshot is manual (§10) | `pnpm run db:snapshot` exists but nothing runs it automatically before a schema-changing deploy. |
+| 12 | Low | No rate limiting (§8) | Relies on `MCP_API_KEY` + Cloudflare. Fine at current exposure; revisit if the surface widens. |
 
-**Open decisions (not gaps — deliberate choices left to the owner)**
+**Open decisions (deliberate choices, not gaps)**
 
-| Topic | Decision needed |
+| Topic | Status |
 |---|---|
 | ~~**RLS** (§9)~~ | **Done 2026-08-01.** Made real and cut over — production connects as `mcp_app` and RLS is enforcing. |
-| **Deploy gating** (§3) | The workflow now gates deploys, but it only takes effect once Auto-Deploy is turned **off** in the Render dashboard and `RENDER_DEPLOY_HOOK_URL` is set. Until then Render still deploys on push and the gate is inert. |
-| **Rate limiting** (§8) | Still none. Relies on `MCP_API_KEY` + Cloudflare. Fine at current exposure; revisit if the surface widens. |
+| ~~**Deploy gating** (§3)~~ | **Done 2026-08-01.** Auto-Deploy off in the Render dashboard, `RENDER_DEPLOY_HOOK_URL` set; the gate fired correctly on its first real merge, waiting for `db-integration` before triggering. |
+| **Scheduled-workflow decay** | GitHub disables cron workflows after 60 days of repo inactivity. A repo you stop touching stops being monitored — acceptable for an actively-developed project, worth remembering if this one goes quiet. |
 
 **Closed in this pass**
 

--- a/scripts/db-snapshot.ts
+++ b/scripts/db-snapshot.ts
@@ -123,17 +123,30 @@ async function dumpViaDocker() {
     // Match the image to the server, or pg_dump aborts on version mismatch.
     // PG_DUMP_IMAGE overrides for anything unusual.
     const major = await serverMajorVersion()
-    const image =
-        process.env.PG_DUMP_IMAGE ??
-        (major ? `postgres:${major}-alpine` : 'postgres:17-alpine')
+    const image = process.env.PG_DUMP_IMAGE ?? 'postgres:15-alpine'
     process.stdout.write(
-        `server major version: ${major ?? 'unknown'} — using ${image}\n`,
+        `server major version: ${major ?? 'unknown'} — using ${image} + apk postgresql${major ?? 17}-client\n`,
     )
+
+    // Rather than `postgres:<major>-alpine` (which needs a registry pull that is
+    // not always available — Docker Hub's CDN refused it repeatedly on the
+    // primary dev machine), run whatever postgres image is already local and
+    // `apk add` the client matching the SERVER's major version. pg_dump refuses
+    // to dump a server newer than itself, so the version has to match; apk goes
+    // via a different CDN, which is the point.
+    //
+    // The image's own binaries shadow the installed ones, hence the explicit
+    // /usr/libexec path and LD_LIBRARY_PATH (otherwise psql/pg_dump link against
+    // the image's older libpq and fail on missing symbols).
+    const inner = [
+        `apk add --no-cache postgresql${major ?? 17}-client >/dev/null 2>&1`,
+        `LD_LIBRARY_PATH=/usr/lib /usr/libexec/postgresql${major ?? 17}/pg_dump ${DUMP_ARGS.join(' ')} "$PGURL"`,
+    ].join('\n')
 
     const out = createWriteStream(outFile)
     const child = spawn(
         'docker',
-        ['run', '--rm', '-i', image, 'pg_dump', ...DUMP_ARGS, url as string],
+        ['run', '--rm', '-i', '-e', `PGURL=${url}`, image, 'sh', '-c', inner],
         { stdio: ['ignore', 'pipe', 'inherit'] },
     )
     child.stdout.pipe(out)

--- a/src/http/metrics-route.ts
+++ b/src/http/metrics-route.ts
@@ -97,6 +97,11 @@ register.registerMetric(invitesAcceptedTotal)
 register.registerMetric(serviceRoleBypassTotal)
 register.registerMetric(adminDebugRequestsTotal)
 register.registerMetric(mcpAuthFailuresTotal)
+// Every metric above must appear here or it increments in memory and is never
+// served. `test/http/metrics-registration.test.ts` enforces that, because this
+// counter — added for #151 to make a silent failure visible — was itself
+// silently invisible for want of this one line.
+register.registerMetric(authSubjectUnresolvedTotal)
 register.registerMetric(bookAggregateUpdateFailuresTotal)
 register.registerMetric(bookAggregatesLastBackfillTimestamp)
 

--- a/test/http/metrics-registration.test.ts
+++ b/test/http/metrics-registration.test.ts
@@ -1,0 +1,59 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it } from 'vitest'
+import * as metrics from '../../src/http/metrics-route.js'
+
+/**
+ * Every exported metric must actually appear at `/metrics`.
+ *
+ * `metrics-route.ts` keeps a hand-maintained `register.registerMetric(...)` list
+ * separate from the `export const … = new Counter(...)` declarations. Nothing
+ * connected the two, so adding a metric and forgetting the registration left it
+ * incrementing in memory and invisible to any scraper — no error, no warning.
+ *
+ * That is exactly what happened to `auth_subject_unresolved_total`: added for
+ * #151 to make a silent admin downgrade visible, and itself silently invisible.
+ * The counter for detecting silent failures failed silently.
+ *
+ * This test closes the loop by deriving expectations from the exports rather
+ * than from a second list that can also drift.
+ */
+describe('metrics registration', () => {
+    /** Names of every prom-client metric exported by the module. */
+    const exportedNames = Object.values(metrics)
+        .filter(
+            (v: any) =>
+                v &&
+                typeof v === 'object' &&
+                typeof v.get === 'function' &&
+                v.name,
+        )
+        .map((v: any) => v.name as string)
+        .sort()
+
+    it('exports at least the known domain metrics', () => {
+        expect(exportedNames).toContain('auth_subject_unresolved_total')
+        expect(exportedNames).toContain('mcp_auth_failures_total')
+        expect(exportedNames.length).toBeGreaterThan(8)
+    })
+
+    it('serves every exported metric from /metrics', async () => {
+        const app = express()
+        metrics.registerMetricsRoute(app)
+        const res = await request(app).get('/metrics').expect(200)
+
+        const missing = exportedNames.filter((name) => !res.text.includes(name))
+
+        // If this fails, add `register.registerMetric(<yourMetric>)` in
+        // src/http/metrics-route.ts. An unregistered metric is worse than no
+        // metric: the code looks instrumented and reports nothing.
+        expect(missing).toEqual([])
+    })
+
+    it('exposes the #151 counter specifically', async () => {
+        const app = express()
+        metrics.registerMetricsRoute(app)
+        const res = await request(app).get('/metrics').expect(200)
+        expect(res.text).toContain('auth_subject_unresolved_total')
+    })
+})


### PR DESCRIPTION
Closes ORR gaps **#1** and **#3**, partially closes **#8**, and fixes a metric that was never actually served.

## 🔴 A metric that was never served

`auth_subject_unresolved_total` — added in #151 so a silent admin downgrade would be *visible* — **was missing from `/metrics` in production.**

`metrics-route.ts` keeps a hand-maintained registration list separate from the declarations:

```ts
export const authSubjectUnresolvedTotal = new Counter({ … })   // declared
…
register.registerMetric(mcpAuthFailuresTotal)                   // registered
// ← authSubjectUnresolvedTotal never added
```

Nothing connected the two. The counter incremented in memory and reached nothing. **The counter for detecting silent failures was itself failing silently.**

Found by testing the monitor's metrics step against production rather than assuming the counter was there.

Fixed, plus `test/http/metrics-registration.test.ts`, which derives its expectations from the module's **exports** rather than a second list that can drift the same way. I verified the guard genuinely catches it:

```
× serves every exported metric from /metrics
  → expected [ 'auth_subject_unresolved_total' ] to deeply equal []
```

## Gap #1 — uptime alerting

`.github/workflows/uptime-monitor.yml`, probing `/healthz?deep=1` every ~10 minutes.

**GitHub Actions rather than UptimeRobot**, deliberately: no external account to create or remember, the schedule lives beside the thing it watches, and **GitHub's failed-workflow email _is_ the alerting mechanism** — nothing extra to wire. It also doubles as the #119 keep-warm ping, so one job holds off both Render's spin-down and Supabase's 7-day auto-pause.

Failure output names the likely causes — paused Supabase, pending migrations, Cloudflare challenge, slow cold start — so the email is actionable without opening the runbook first.

Two limits written into the file rather than left to be discovered:

- GitHub's cron is best-effort and lags under load — treat it as *every 10–20 minutes*. Fine for outage detection and keep-warm; **not** a latency SLO instrument.
- **Scheduled workflows auto-disable after 60 days of repo inactivity.** A repo you stop touching stops being monitored.

Probe logic verified against production (200, correct payload, counter grep matches).

## Gap #3 — restore drilled

Not asserted — performed:

1. **Dumped** production with `pg_dump` 17.10 (matching the 17.6 server) — 290KB, all 11 tables
2. **Restored** into a separate PostgreSQL **17.10** server — zero `ERROR`/`FATAL`
3. **Verified** by row count, table by table:

```text
Article|2  Author|2  Bet|13  Book|3  BookAuthor|3  ContentCreator|3
Movie|3    Profile|7 Resume|0 ResumeDownloadRequest|0  VideoGame|3

diff production restored → IDENTICAL
```

A restore that completes without errors proves nothing if rows are missing. The diff is the evidence. The dump was deleted immediately — it holds real data, and `backups/` is gitignored so one can't be committed.

**This does not establish an RPO.** That depends on Supabase's backup/PITR window, a dashboard fact this repo can't read. Until you confirm it, RPO is "since the last `db:snapshot`".

### `db:snapshot` now works on this machine

Docker Hub's CDN refused `postgres:17-alpine` across ~13 attempts. The script now runs whatever postgres image is already local and `apk add`s the client matching the **server's** major version — apk uses a different CDN. It also sets `LD_LIBRARY_PATH`, because the image's own `libpq` otherwise shadows the installed one and the binaries die on missing symbols.

Verified end to end: `pnpm run db:snapshot` produced a valid 290KB dump.

## Gap #8 — partial

The monitor snapshots key counters into each run's job summary — ~90 days of history in the Actions UI. Not a TSDB, but enough to answer *"when did auth failures start climbing?"*, which is what the gap was actually about. A real time-series backend still needs an account only you can create.

## Also done outside the repo

`PUBLIC_BASE_URL` set in Doppler `prd`, so the RFC 9728 `resource` identifier is pinned rather than derived from the client-supplied `Host` header.

## A note on the earlier framing

The previous ORR revision wrote #1, #2, #3 and #8 off as *"ops-only — nothing in the repo can close them."* Three of the four turned out to be closable in-repo. I've recorded that in the document, because "that's an ops problem" was doing real work as an excuse.

## Testing

**396 passed, 7 skipped, 0 failed.** `verify` green.
