### PR TITLE
feat(auth): UserDirectory port + Logto test-user provisioning (#154)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,11 +94,26 @@ SPOTIFY_POLL_INTERVAL_MS=15000        # Polling interval in ms (default 15000)
 ODDS_API_KEY=                         # the-odds-api.com key; odds tools degrade gracefully when unset
 ODDS_API_BASE=https://api.the-odds-api.com/v4
 
+# ── Logto (test-user provisioning — ADR 0001 Stage 2, #154) ───────────────────
+# Management-API side only. Token *verification* uses the provider-neutral
+# OIDC_* vars above — ADR 0001 rules out an identity abstraction because OIDC
+# discovery already is one. Provisioning is the sanctioned exception.
+#
+# LOGTO_TENANT_ID=e02ms0                    # issuer/API URLs are derived from this
+# LOGTO_ISSUER=                             # optional override (custom domains)
+# LOGTO_M2M_CLIENT_ID=                      # machine-to-machine app
+# LOGTO_M2M_CLIENT_SECRET=
+# Client application — required only for minting user tokens in E2E tests. The
+# M2M app cannot do token exchange; Logto rejects it.
+# LOGTO_WEB_CLIENT_ID=
+# LOGTO_WEB_CLIENT_SECRET=
+
 # ── GitHub ────────────────────────────────────────────────────────────────────
 GITHUB_TOKEN=ghp_changeme             # Personal access token for Issues/Projects API
 
 # ── Test / CI flags ───────────────────────────────────────────────────────────
 # RUN_DB_INTEGRATION=true             # Uncomment to run real-DB integration tests
+# RUN_LOGTO_INTEGRATION=true          # Real Logto tenant tests (needs LOGTO_* above)
 # RUN_GITHUB_PROJECTS_INTEGRATION=true
 # GITHUB_TEST_OWNER=your-username
 # GITHUB_TEST_REPO=your-repo

--- a/docs/runbooks/logto-test-users.md
+++ b/docs/runbooks/logto-test-users.md
@@ -1,0 +1,98 @@
+# Logto test users
+
+Provisioning and cleaning up test users against the Logto tenant (ADR 0001
+Stage 2, #154).
+
+## Why this exists
+
+Testing authenticated paths used to mean either hand-made fixtures or a shared
+account nobody wanted to touch. Logto's Management API gives us programmatic
+create / role / delete, and the `UserDirectory` port wraps it thinly.
+
+**It runs against a shared hosted tenant, not a clean local database.** The free
+tier does allow a second tenant, but that tenant cannot hold API resources
+(confirmed in #153), so a separate "dev" tenant is useless for us. Two
+consequences follow, and they drive the whole design:
+
+1. A run cannot assume a fresh slate → **everything is idempotent.**
+2. A crashed run leaks users into the real tenant → **everything is namespaced**,
+   so orphans stay identifiable and removable later.
+
+## Setup
+
+Credentials live in Doppler `bad-mcp/dev` and never in the repo:
+
+| Var | For |
+|---|---|
+| `LOGTO_TENANT_ID` | issuer + Management API URLs are derived from this |
+| `LOGTO_M2M_CLIENT_ID` / `_SECRET` | machine-to-machine app with "Logto Management API access" |
+| `LOGTO_WEB_CLIENT_ID` / `_SECRET` | client application — **only** needed to mint user tokens |
+
+```powershell
+pnpm run env:pull        # or run commands under `doppler run --`
+```
+
+## Commands
+
+```powershell
+pnpm run logto:users seed [runId]      # create a roled test user
+pnpm run logto:users teardown <runId>  # delete that run's user
+pnpm run logto:users list              # every test user in the tenant
+pnpm run logto:users cleanup [--dry]   # delete ALL orphaned test users
+```
+
+`seed` prints the generated password **once**. It is never stored, and a re-run
+cannot reproduce it — seed a fresh `runId` rather than trying to recover one.
+
+## The namespace, and why cleanup is safe
+
+Test users are `test_<runId>` / `test+<runId>@bad-mcp.test`. `cleanup` only ever
+deletes users matching that namespace, so **a real account can never match** —
+that is the property that makes it safe to run unattended against a tenant
+holding live accounts. `isTestUser` is unit-tested against `brn.dbn@gmail.com`
+and against near-misses like `contest+x@example.com` specifically to keep that
+guarantee honest.
+
+## Running the integration test
+
+```powershell
+$env:RUN_LOGTO_INTEGRATION='true'
+pnpm exec vitest run test/integration/logto-user-directory.test.ts
+```
+
+It provisions a user, assigns `admin`, mints a token with no browser, and drives
+that token through the **real** auth stack — `jwtMiddleware` → `verifyAccessToken`
+(live JWKS) → `resolveAppRole` → `requireAdmin` — then tears the user down. The
+default suite skips it, so no tenant is needed for ordinary work.
+
+## Token minting has two prerequisites
+
+Both were discovered the hard way during the #153 spike:
+
+- **The client application performs the exchange, not the M2M app.** Attempting
+  it as the M2M app returns `requested grant type is not allowed for this client`.
+- **"Allow token exchange" is off by default** on new applications. Console →
+  Applications → *(the client app)* → Token exchange.
+
+## Tenant prerequisites
+
+The port deliberately does **not** create roles or API resources — those are
+configuration, not something a test should invent. They must exist first:
+
+- API resource `mcp-server`, indicator `https://bad-mcp.onrender.com/mcp` (the
+  same string the RFC 9728 document advertises, so audiences match end to end)
+- A permission named **`admin`** on that resource
+- A role named **`admin`** holding that permission
+
+`assignRole` fails with a pointed message if the role is missing, rather than
+silently provisioning an unroled user.
+
+## Gotchas
+
+- **Logto resource tokens carry no `email` claim.** Identity resolution is
+  `(issuer, externalId)` only — the #90 email fallback cannot fire. Any Profile
+  you expect to match must have `externalId` populated.
+- **`OIDC_ROLE_CLAIM_PATH=scope` is load-bearing** under Logto. Without it, an
+  admin resolves as a non-admin.
+- Logto ids are 12-character lowercase alphanumeric, **not UUIDs**. Nothing may
+  assume a shape — see #151.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "prisma:generate": "prisma generate",
         "db:deploy": "prisma migrate deploy && node dist/seed.js",
         "db:snapshot": "tsx scripts/db-snapshot.ts",
+        "logto:users": "tsx scripts/logto-test-users.ts",
         "env:pull": "doppler secrets download --no-file --format env > .env.local"
     },
     "keywords": [

--- a/scripts/logto-test-users.ts
+++ b/scripts/logto-test-users.ts
@@ -1,0 +1,119 @@
+/**
+ * Provision and clean up namespaced Logto test users.
+ *
+ *   pnpm run logto:users seed [runId]     create a roled test user
+ *   pnpm run logto:users teardown <runId> delete that run's user
+ *   pnpm run logto:users list             show every test user in the tenant
+ *   pnpm run logto:users cleanup [--dry]  delete ALL orphaned test users
+ *
+ * Credentials come from the environment (Doppler `bad-mcp/dev`), never the repo:
+ *   LOGTO_TENANT_ID, LOGTO_M2M_CLIENT_ID, LOGTO_M2M_CLIENT_SECRET
+ *
+ * `cleanup` only ever touches users inside the test namespace, so it cannot
+ * remove a real account — that is what makes it safe to run unattended against
+ * the shared tenant ADR 0001 commits us to.
+ */
+import { LogtoDirectory } from '../src/auth/user-directory/logto.js'
+import {
+    cleanupOrphanedTestUsers,
+    findTestUserByRunId,
+    newRunId,
+    seedTestUser,
+} from '../src/auth/user-directory/seed.js'
+import { isTestUser } from '../src/auth/user-directory/types.js'
+import { config } from '../src/config.js'
+
+const out = (s: string) => process.stdout.write(`${s}\n`)
+const die = (s: string): never => {
+    process.stderr.write(`${s}\n`)
+    process.exit(1)
+}
+
+async function main() {
+    const [command, ...rest] = process.argv.slice(2)
+
+    if (!config.logto.enabled) {
+        die(
+            'Logto is not configured.\n' +
+                'Set LOGTO_TENANT_ID, LOGTO_M2M_CLIENT_ID and LOGTO_M2M_CLIENT_SECRET.\n' +
+                'Locally: pnpm run env:pull  (or run under `doppler run --`).',
+        )
+    }
+    const directory = LogtoDirectory.fromConfig()
+
+    switch (command) {
+        case 'seed': {
+            const runId = rest[0] ?? newRunId()
+            const user = await seedTestUser(directory, {
+                runId,
+                role: 'admin',
+            })
+            out(`${user.created ? 'created' : 'already existed'}`)
+            out(`  runId    : ${runId}`)
+            out(`  id       : ${user.id}`)
+            out(`  username : ${user.username}`)
+            out(`  email    : ${user.email}`)
+            out(`  role     : admin`)
+            if (user.password) {
+                // Printed once, never stored. A re-run cannot reproduce it —
+                // seed a fresh runId instead of trying to recover this.
+                out(`  password : ${user.password}`)
+            } else {
+                out('  password : (unchanged — user already existed)')
+            }
+            out(`\nteardown with: pnpm run logto:users teardown ${runId}`)
+            break
+        }
+
+        case 'teardown': {
+            const runId = rest[0] ?? die('usage: teardown <runId>')
+            const user = await findTestUserByRunId(directory, runId)
+            if (!user) {
+                out(`no test user for runId ${runId} (nothing to do)`)
+                break
+            }
+            await directory.deleteUser(user.id)
+            out(`deleted ${user.username} (${user.id})`)
+            break
+        }
+
+        case 'list': {
+            const users = (await directory.listUsers()).filter(isTestUser)
+            if (!users.length) {
+                out('no test users in the tenant')
+                break
+            }
+            out(`${users.length} test user(s):`)
+            for (const u of users) {
+                out(`  ${String(u.id).padEnd(14)} ${u.username ?? '-'}`)
+            }
+            break
+        }
+
+        case 'cleanup': {
+            const dryRun = rest.includes('--dry')
+            const removed = await cleanupOrphanedTestUsers(directory, {
+                dryRun,
+            })
+            if (!removed.length) {
+                out('no orphaned test users')
+                break
+            }
+            out(`${dryRun ? 'would delete' : 'deleted'} ${removed.length}:`)
+            for (const u of removed) {
+                out(`  ${String(u.id).padEnd(14)} ${u.username ?? '-'}`)
+            }
+            break
+        }
+
+        default:
+            die(
+                'usage: pnpm run logto:users <seed [runId] | teardown <runId> | list | cleanup [--dry]>',
+            )
+    }
+}
+
+main().catch((e) => {
+    process.stderr.write(`${e?.stack ?? e}\n`)
+    process.exit(1)
+})

--- a/src/auth/user-directory/in-memory.ts
+++ b/src/auth/user-directory/in-memory.ts
@@ -1,0 +1,97 @@
+import {
+    type CreateUserInput,
+    type DirectoryUser,
+    UserAlreadyExistsError,
+    type UserDirectory,
+} from './types.js'
+
+/**
+ * In-memory `UserDirectory` for tests.
+ *
+ * This is the second *genuine* implementation that makes the port honest rather
+ * than speculative — an interface with one implementation is just indirection.
+ * It also lets the seed script and anything built on the port be tested without
+ * a network, a tenant, or credentials.
+ *
+ * Ids deliberately mimic Logto's shape: 12-character lowercase alphanumeric,
+ * **not** UUIDs. A fake that hands out UUIDs would let UUID assumptions creep
+ * back in unnoticed — which is exactly the defect #151 fixed.
+ */
+export class InMemoryDirectory implements UserDirectory {
+    private readonly users = new Map<string, DirectoryUser>()
+    private readonly roles = new Map<string, Set<string>>()
+    private counter = 0
+
+    /** Deterministic, Logto-shaped ids so tests can assert on them. */
+    private nextId(): string {
+        this.counter += 1
+        return `mem${String(this.counter).padStart(9, '0')}`
+    }
+
+    async createUser(input: CreateUserInput): Promise<DirectoryUser> {
+        if (!input.username && !input.email) {
+            throw new Error('createUser requires a username or an email')
+        }
+        const clash = [...this.users.values()].find(
+            (u) =>
+                (input.username && u.username === input.username) ||
+                (input.email && u.email === input.email),
+        )
+        if (clash) {
+            // Same TYPE Logto's adapter throws, so the seed script's idempotence
+            // path is exercised identically here and against the real tenant.
+            throw new UserAlreadyExistsError(
+                (input.username ?? input.email) as string,
+            )
+        }
+
+        const user: DirectoryUser = {
+            id: this.nextId(),
+            username: input.username,
+            email: input.email,
+            name: input.name,
+        }
+        this.users.set(user.id, user)
+        return { ...user }
+    }
+
+    async deleteUser(id: string): Promise<void> {
+        // Idempotent by contract — absence is not an error.
+        this.users.delete(id)
+        this.roles.delete(id)
+    }
+
+    async assignRole(userId: string, roleName: string): Promise<void> {
+        if (!this.users.has(userId)) {
+            throw new Error(`no such user: ${userId}`)
+        }
+        const set = this.roles.get(userId) ?? new Set<string>()
+        set.add(roleName) // Set membership gives idempotence for free.
+        this.roles.set(userId, set)
+    }
+
+    async findByExternalId(id: string): Promise<DirectoryUser | null> {
+        const u = this.users.get(id)
+        return u ? { ...u } : null
+    }
+
+    // ── Test affordances (not part of the port) ────────────────────────────
+
+    /** Roles currently held by a user. */
+    rolesOf(userId: string): string[] {
+        return [...(this.roles.get(userId) ?? [])].sort()
+    }
+
+    /** Every user currently held. */
+    list(): DirectoryUser[] {
+        return [...this.users.values()].map((u) => ({ ...u }))
+    }
+
+    /** Find by username or email — used by the seed script's idempotence check. */
+    findByHandle(handle: string): DirectoryUser | null {
+        const u = [...this.users.values()].find(
+            (x) => x.username === handle || x.email === handle,
+        )
+        return u ? { ...u } : null
+    }
+}

--- a/src/auth/user-directory/index.ts
+++ b/src/auth/user-directory/index.ts
@@ -1,0 +1,12 @@
+export { InMemoryDirectory } from './in-memory.js'
+export { LogtoDirectory } from './logto.js'
+export {
+    type CreateUserInput,
+    type DirectoryUser,
+    isTestUser,
+    TEST_USER_PREFIX,
+    testEmail,
+    testUsername,
+    UserAlreadyExistsError,
+    type UserDirectory,
+} from './types.js'

--- a/src/auth/user-directory/logto.ts
+++ b/src/auth/user-directory/logto.ts
@@ -1,0 +1,303 @@
+import { config } from '../../config.js'
+import { logger } from '../../logger.js'
+import {
+    type CreateUserInput,
+    type DirectoryUser,
+    UserAlreadyExistsError,
+    type UserDirectory,
+} from './types.js'
+
+interface LogtoUser {
+    id: string
+    username?: string | null
+    primaryEmail?: string | null
+    name?: string | null
+}
+
+const toDirectoryUser = (u: LogtoUser): DirectoryUser => ({
+    id: u.id,
+    username: u.username ?? undefined,
+    email: u.primaryEmail ?? undefined,
+    name: u.name ?? undefined,
+})
+
+/**
+ * `UserDirectory` backed by Logto's Management API.
+ *
+ * Reached by a machine-to-machine app holding the built-in "Logto Management API
+ * access" role, via a `client_credentials` grant. Every mechanism here was
+ * verified against the live tenant during the #153 spike rather than taken from
+ * documentation.
+ */
+export class LogtoDirectory implements UserDirectory {
+    private cachedToken?: { value: string; expiresAt: number }
+
+    constructor(
+        private readonly opts: {
+            issuer: string
+            managementApi: string
+            clientId: string
+            clientSecret: string
+        },
+    ) {}
+
+    /** Build from config; throws with a specific message when unconfigured. */
+    static fromConfig(): LogtoDirectory {
+        const c = config.logto
+        if (!c.enabled || !c.issuer || !c.managementApi) {
+            throw new Error(
+                'Logto is not configured. Set LOGTO_TENANT_ID, LOGTO_M2M_CLIENT_ID and LOGTO_M2M_CLIENT_SECRET.',
+            )
+        }
+        return new LogtoDirectory({
+            issuer: c.issuer,
+            managementApi: c.managementApi,
+            clientId: c.m2mClientId as string,
+            clientSecret: c.m2mClientSecret as string,
+        })
+    }
+
+    /**
+     * Management API access token, cached until shortly before expiry.
+     *
+     * Tokens last an hour; the 60s margin avoids handing out one that expires
+     * mid-flight. Cheap, and it keeps a seed run from minting a token per call.
+     */
+    private async token(): Promise<string> {
+        if (this.cachedToken && Date.now() < this.cachedToken.expiresAt) {
+            return this.cachedToken.value
+        }
+
+        const basic = Buffer.from(
+            `${this.opts.clientId}:${this.opts.clientSecret}`,
+        ).toString('base64')
+
+        const res = await fetch(`${this.opts.issuer}/token`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Basic ${basic}`,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                grant_type: 'client_credentials',
+                resource: this.opts.managementApi,
+                scope: 'all',
+            }),
+        })
+        if (!res.ok) {
+            throw new Error(
+                `Logto token request failed (${res.status}): ${await res.text()}`,
+            )
+        }
+        const json = (await res.json()) as {
+            access_token: string
+            expires_in: number
+        }
+        this.cachedToken = {
+            value: json.access_token,
+            expiresAt: Date.now() + (json.expires_in - 60) * 1000,
+        }
+        return json.access_token
+    }
+
+    private async request<T>(
+        path: string,
+        init: RequestInit = {},
+    ): Promise<{ status: number; body: T | undefined }> {
+        const res = await fetch(`${this.opts.managementApi}${path}`, {
+            ...init,
+            headers: {
+                Authorization: `Bearer ${await this.token()}`,
+                'Content-Type': 'application/json',
+                ...(init.headers ?? {}),
+            },
+        })
+        // 204 (and any empty body) must not be fed to JSON.parse.
+        const text = await res.text()
+        const body = text ? (JSON.parse(text) as T) : undefined
+        return { status: res.status, body }
+    }
+
+    private async requireOk<T>(
+        path: string,
+        init: RequestInit,
+        what: string,
+    ): Promise<T> {
+        const { status, body } = await this.request<T>(path, init)
+        if (status >= 400) {
+            throw new Error(
+                `Logto ${what} failed (${status}): ${JSON.stringify(body)}`,
+            )
+        }
+        return body as T
+    }
+
+    async createUser(input: CreateUserInput): Promise<DirectoryUser> {
+        if (!input.username && !input.email) {
+            throw new Error('createUser requires a username or an email')
+        }
+        const { status, body } = await this.request<
+            LogtoUser & { code?: string }
+        >('/users', {
+            method: 'POST',
+            body: JSON.stringify({
+                username: input.username,
+                primaryEmail: input.email,
+                password: input.password,
+                name: input.name,
+            }),
+        })
+
+        // Logto reports a duplicate as 422 with a `user.*_already_in_use` code.
+        // Translate it to the port's typed error so callers never have to match
+        // on a provider's wording — which is exactly how the first version of
+        // the seed script broke.
+        if (status === 422 && /already_in_use/.test(String(body?.code))) {
+            throw new UserAlreadyExistsError(
+                (input.username ?? input.email) as string,
+            )
+        }
+        if (status >= 400) {
+            throw new Error(
+                `Logto createUser failed (${status}): ${JSON.stringify(body)}`,
+            )
+        }
+        return toDirectoryUser(body as LogtoUser)
+    }
+
+    async deleteUser(id: string): Promise<void> {
+        const { status, body } = await this.request(`/users/${id}`, {
+            method: 'DELETE',
+        })
+        // 404 means the goal state already holds. Teardown after a partial
+        // failure must not itself fail, or cleanup becomes the thing that needs
+        // cleaning up.
+        if (status === 404) return
+        if (status >= 400) {
+            throw new Error(
+                `Logto deleteUser failed (${status}): ${JSON.stringify(body)}`,
+            )
+        }
+    }
+
+    async assignRole(userId: string, roleName: string): Promise<void> {
+        const roles = await this.requireOk<Array<{ id: string; name: string }>>(
+            '/roles',
+            { method: 'GET' },
+            'listRoles',
+        )
+        const role = roles.find((r) => r.name === roleName)
+        if (!role) {
+            throw new Error(
+                `Logto role not found: ${roleName}. Create it in the console first — roles are configuration, not something a test should invent.`,
+            )
+        }
+
+        const { status, body } = await this.request(`/users/${userId}/roles`, {
+            method: 'POST',
+            body: JSON.stringify({ roleIds: [role.id] }),
+        })
+        // Logto returns 422 when the user already holds the role. The port
+        // promises idempotence, so that is success.
+        if (status === 422) {
+            logger.debug('logto: role already assigned', { userId, roleName })
+            return
+        }
+        if (status >= 400) {
+            throw new Error(
+                `Logto assignRole failed (${status}): ${JSON.stringify(body)}`,
+            )
+        }
+    }
+
+    async findByExternalId(id: string): Promise<DirectoryUser | null> {
+        const { status, body } = await this.request<LogtoUser>(`/users/${id}`)
+        if (status === 404) return null
+        if (status >= 400) {
+            throw new Error(
+                `Logto findByExternalId failed (${status}): ${JSON.stringify(body)}`,
+            )
+        }
+        return body ? toDirectoryUser(body) : null
+    }
+
+    // ── Beyond the port ────────────────────────────────────────────────────
+    // Provider-specific, and deliberately NOT on `UserDirectory`. Callers here
+    // have knowingly opted into Logto; the port stays a directory.
+
+    /** Every user, paged through. Used by orphan cleanup. */
+    async listUsers(pageSize = 100): Promise<DirectoryUser[]> {
+        const out: DirectoryUser[] = []
+        for (let page = 1; ; page++) {
+            const batch = await this.requireOk<LogtoUser[]>(
+                `/users?page=${page}&page_size=${pageSize}`,
+                { method: 'GET' },
+                'listUsers',
+            )
+            if (!batch?.length) break
+            out.push(...batch.map(toDirectoryUser))
+            if (batch.length < pageSize) break
+        }
+        return out
+    }
+
+    /**
+     * Mint a real access token for a user, with no browser.
+     *
+     * Management API subject token → RFC 8693 token exchange. This is what makes
+     * authenticated E2E tests possible without a login flow or `storageState`
+     * (#153 question 3).
+     *
+     * Two prerequisites, both discovered the hard way during the spike:
+     *   - the exchange must be performed by the **client** application, not the
+     *     M2M app, which Logto rejects with "requested grant type is not
+     *     allowed for this client";
+     *   - "Allow token exchange" is **off by default** on new applications.
+     */
+    async mintUserToken(args: {
+        userId: string
+        resource: string
+        scope?: string
+    }): Promise<string> {
+        const { webClientId, webClientSecret } = config.logto
+        if (!webClientId || !webClientSecret) {
+            throw new Error(
+                'Token exchange needs LOGTO_WEB_CLIENT_ID and LOGTO_WEB_CLIENT_SECRET (the client application — the M2M app is not permitted this grant).',
+            )
+        }
+
+        const { subjectToken } = await this.requireOk<{
+            subjectToken: string
+        }>(
+            '/subject-tokens',
+            { method: 'POST', body: JSON.stringify({ userId: args.userId }) },
+            'subjectToken',
+        )
+
+        const basic = Buffer.from(`${webClientId}:${webClientSecret}`).toString(
+            'base64',
+        )
+
+        const res = await fetch(`${this.opts.issuer}/token`, {
+            method: 'POST',
+            headers: {
+                Authorization: `Basic ${basic}`,
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            body: new URLSearchParams({
+                grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+                subject_token: subjectToken,
+                subject_token_type:
+                    'urn:ietf:params:oauth:token-type:access_token',
+                resource: args.resource,
+                ...(args.scope ? { scope: args.scope } : {}),
+            }),
+        })
+        if (!res.ok) {
+            throw new Error(
+                `Logto token exchange failed (${res.status}): ${await res.text()}`,
+            )
+        }
+        return ((await res.json()) as { access_token: string }).access_token
+    }
+}

--- a/src/auth/user-directory/seed.ts
+++ b/src/auth/user-directory/seed.ts
@@ -1,0 +1,154 @@
+import { randomBytes } from 'node:crypto'
+import { logger } from '../../logger.js'
+import {
+    type DirectoryUser,
+    isTestUser,
+    testEmail,
+    testUsername,
+    UserAlreadyExistsError,
+    type UserDirectory,
+} from './types.js'
+
+/**
+ * Seed and tear down namespaced test users.
+ *
+ * Written against the `UserDirectory` port rather than Logto directly, so the
+ * whole thing is testable with `InMemoryDirectory` — no tenant, no network, no
+ * credentials. That is the payoff for the port existing at all.
+ *
+ * ADR 0001: this runs against a **shared hosted tenant**, not a clean local
+ * database. So it cannot assume a fresh slate (hence idempotence) and a crashed
+ * run must leave something identifiable behind (hence the namespace).
+ */
+
+export interface SeededUser extends DirectoryUser {
+    /** The generated password, when one was set. Never logged. */
+    password?: string
+    /** True when this run created the user; false when it already existed. */
+    created: boolean
+}
+
+/** Short, filesystem- and email-safe run identifier. */
+export function newRunId(): string {
+    return randomBytes(5).toString('hex')
+}
+
+/** A password meeting Logto's complexity rules without being guessable. */
+function generatePassword(): string {
+    return `Aa1!${randomBytes(16).toString('base64url')}`
+}
+
+/**
+ * Ensure a roled test user exists for `runId`.
+ *
+ * **Idempotent**: running it twice with the same `runId` returns the existing
+ * user rather than failing on the duplicate. `assignRole` is idempotent by the
+ * port's contract, so re-running re-asserts the role harmlessly.
+ */
+export async function seedTestUser(
+    directory: UserDirectory,
+    opts: { runId: string; role?: string; emailDomain?: string } = {
+        runId: newRunId(),
+    },
+): Promise<SeededUser> {
+    const username = testUsername(opts.runId)
+    const email = testEmail(opts.runId, opts.emailDomain)
+    const password = generatePassword()
+
+    let user: DirectoryUser
+    let created = true
+    try {
+        user = await directory.createUser({
+            username,
+            email,
+            password,
+            name: `Test user ${opts.runId}`,
+        })
+    } catch (err: unknown) {
+        // A duplicate is the expected outcome of a re-run, not a failure. Any
+        // other error is real and must propagate — swallowing everything here
+        // would turn a broken tenant into a silently empty seed.
+        //
+        // Checked by TYPE, not by message. Matching on `/already exist/i` is
+        // what the first version did, and it passed against the fake while
+        // failing against Logto's "username_already_in_use".
+        if (!(err instanceof UserAlreadyExistsError)) throw err
+
+        const existing = await findTestUserByRunId(directory, opts.runId)
+        if (!existing) throw err
+        user = existing
+        created = false
+        logger.debug('seed: test user already present', { runId: opts.runId })
+    }
+
+    if (opts.role) await directory.assignRole(user.id, opts.role)
+
+    return { ...user, password: created ? password : undefined, created }
+}
+
+/** Locate a run's user without knowing its id. */
+export async function findTestUserByRunId(
+    directory: UserDirectory,
+    runId: string,
+): Promise<DirectoryUser | null> {
+    const users = await listAll(directory)
+    const username = testUsername(runId)
+    return (
+        users.find(
+            (u) => u.username === username || u.email?.includes(`+${runId}@`),
+        ) ?? null
+    )
+}
+
+/** Remove a run's user. Safe to call when nothing was created. */
+export async function teardownTestUser(
+    directory: UserDirectory,
+    userId: string | undefined,
+): Promise<void> {
+    if (!userId) return
+    await directory.deleteUser(userId)
+}
+
+/**
+ * Delete test users left behind by earlier runs.
+ *
+ * The reason the namespace exists: a crashed run leaks a user into a shared
+ * tenant, and without a way to recognise it later those accumulate forever.
+ * Only touches users matching the test namespace — a real account can never
+ * match, which is the safety property that makes this runnable unattended.
+ */
+export async function cleanupOrphanedTestUsers(
+    directory: UserDirectory,
+    opts: { keepRunId?: string; dryRun?: boolean } = {},
+): Promise<DirectoryUser[]> {
+    const users = await listAll(directory)
+    const keepUsername = opts.keepRunId ? testUsername(opts.keepRunId) : null
+
+    const orphans = users.filter(
+        (u) => isTestUser(u) && u.username !== keepUsername,
+    )
+
+    if (!opts.dryRun) {
+        for (const u of orphans) await directory.deleteUser(u.id)
+    }
+    return orphans
+}
+
+/**
+ * List every user, via whichever affordance the implementation offers.
+ *
+ * Listing is deliberately absent from the port — it is not part of provisioning
+ * and would push the interface toward being a general identity facade. Both
+ * implementations expose it in their own way, so this narrows to that.
+ */
+async function listAll(directory: UserDirectory): Promise<DirectoryUser[]> {
+    const anyDir = directory as unknown as {
+        listUsers?: () => Promise<DirectoryUser[]>
+        list?: () => DirectoryUser[]
+    }
+    if (typeof anyDir.listUsers === 'function') return anyDir.listUsers()
+    if (typeof anyDir.list === 'function') return anyDir.list()
+    throw new Error(
+        'directory cannot enumerate users; cleanup and idempotence need listUsers()/list()',
+    )
+}

--- a/src/auth/user-directory/types.ts
+++ b/src/auth/user-directory/types.ts
@@ -1,0 +1,101 @@
+/**
+ * `UserDirectory` — the one identity abstraction ADR 0001 sanctions.
+ *
+ * The ADR explicitly rules out an `IIdentityProvider` wrapper over token
+ * verification: OIDC discovery + JWKS + standard claims already *is* the
+ * vendor-neutral interface, and wrapping it would re-abstract something already
+ * abstract. **Provisioning is the exception**, because that is where lock-in
+ * actually bites — `/api/users` is Logto's own shape, not a standard — and
+ * because it has two genuine implementations rather than one plus a hypothetical.
+ *
+ * Deliberately four methods. It is a *directory*, not an identity facade: no
+ * token minting, no session handling, no profile sync. Resist growing it —
+ * `LogtoDirectory` may expose provider-specific extras beyond this contract for
+ * callers that have knowingly opted into Logto (integration tests do), but those
+ * do not belong on the port.
+ */
+
+/**
+ * Thrown when a user with the same handle already exists.
+ *
+ * A **typed** error rather than a message convention on purpose. The seed
+ * script's idempotence hinges on telling "already provisioned" apart from "the
+ * tenant is broken", and the first version matched on `/already exist/i` —
+ * which `InMemoryDirectory` satisfied and Logto did not (it says
+ * `user.username_already_in_use`). The fake agreed with the code and reality
+ * disagreed with both; only the integration test caught it. Implementations now
+ * have to throw the same type, so the fake cannot drift from the contract.
+ */
+export class UserAlreadyExistsError extends Error {
+    constructor(handle: string) {
+        super(`user already exists: ${handle}`)
+        this.name = 'UserAlreadyExistsError'
+    }
+}
+
+/** A user as this codebase cares about it — deliberately not Logto's shape. */
+export interface DirectoryUser {
+    /**
+     * The identity-provider subject. **Opaque** — Logto issues 12-character
+     * lowercase alphanumeric ids, Supabase issues UUIDs, and nothing may assume
+     * a shape. This is what lands in `Profile.externalId` (#151).
+     */
+    id: string
+    username?: string
+    email?: string
+    name?: string
+}
+
+export interface CreateUserInput {
+    username?: string
+    email?: string
+    /** Omit to create a user who cannot password-authenticate. */
+    password?: string
+    name?: string
+}
+
+/**
+ * Provisioning operations. Every method is expected to throw on transport or
+ * authorization failure — callers are scripts and tests that should fail loudly,
+ * not degrade.
+ */
+export interface UserDirectory {
+    createUser(input: CreateUserInput): Promise<DirectoryUser>
+
+    /** Idempotent: deleting an already-absent user must not throw. */
+    deleteUser(id: string): Promise<void>
+
+    /** Idempotent: assigning an already-held role must not throw. */
+    assignRole(userId: string, roleName: string): Promise<void>
+
+    /** `null` when no such user exists — absence is not an error. */
+    findByExternalId(id: string): Promise<DirectoryUser | null>
+}
+
+/**
+ * Namespace for provisioned test users.
+ *
+ * ADR 0001 notes these run against a **shared hosted tenant**, not a clean local
+ * database. Two consequences drive this prefix: a run cannot assume a fresh
+ * slate, and an orphan left by a crashed run must be identifiable later. Both
+ * are solved by making test users obviously test users.
+ */
+export const TEST_USER_PREFIX = 'test_'
+
+/** `test_<runId>` — the username stem for one run's users. */
+export function testUsername(runId: string, suffix = ''): string {
+    return `${TEST_USER_PREFIX}${runId}${suffix}`
+}
+
+/** `test+<runId>@…` — the email form the issue specifies. */
+export function testEmail(runId: string, domain = 'bad-mcp.test'): string {
+    return `test+${runId}@${domain}`
+}
+
+/** True for anything this project provisioned as a test user. */
+export function isTestUser(user: DirectoryUser): boolean {
+    return (
+        String(user.username ?? '').startsWith(TEST_USER_PREFIX) ||
+        String(user.email ?? '').startsWith('test+')
+    )
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -169,8 +169,24 @@ const envSchema = z.object({
             return Number.isFinite(n) && n >= 0 && n <= 1 ? n : 0
         }),
 
+    // ── Logto (user provisioning — ADR 0001 Stage 2, #154) ────────────────
+    // Only the Management-API side lives here. Token *verification* stays on
+    // the provider-neutral OIDC_* vars above: ADR 0001 rules out an identity
+    // abstraction because OIDC discovery already is one. Provisioning is the
+    // sanctioned exception, because that is where lock-in actually bites.
+    LOGTO_TENANT_ID: z.string().optional(),
+    LOGTO_ISSUER: z.string().url().optional(),
+    LOGTO_M2M_CLIENT_ID: z.string().optional(),
+    LOGTO_M2M_CLIENT_SECRET: z.string().optional(),
+    // The client application that performs impersonation token exchange. The
+    // M2M app cannot: Logto rejects it with "requested grant type is not
+    // allowed for this client" (#153).
+    LOGTO_WEB_CLIENT_ID: z.string().optional(),
+    LOGTO_WEB_CLIENT_SECRET: z.string().optional(),
+
     // ── Test / CI flags ───────────────────────────────────────────────────
     RUN_DB_INTEGRATION: boolFlag,
+    RUN_LOGTO_INTEGRATION: boolFlag,
     RUN_GITHUB_PROJECTS_INTEGRATION: boolFlag,
     GITHUB_TEST_OWNER: z.string().optional(),
     GITHUB_TEST_REPO: z.string().optional(),
@@ -360,6 +376,32 @@ export const config = {
         scopesSupported: env.OAUTH_SCOPES_SUPPORTED,
     },
 
+    // Logto user provisioning (#154). `enabled` is true only when everything a
+    // Management API call needs is present, so callers can degrade cleanly
+    // instead of discovering a missing secret mid-request.
+    logto: {
+        tenantId: env.LOGTO_TENANT_ID,
+        // Derivable from the tenant id — verified against the discovery
+        // document during the #153 spike — but overridable for custom domains.
+        issuer:
+            env.LOGTO_ISSUER ??
+            (env.LOGTO_TENANT_ID
+                ? `https://${env.LOGTO_TENANT_ID}.logto.app/oidc`
+                : undefined),
+        managementApi: env.LOGTO_TENANT_ID
+            ? `https://${env.LOGTO_TENANT_ID}.logto.app/api`
+            : undefined,
+        m2mClientId: env.LOGTO_M2M_CLIENT_ID,
+        m2mClientSecret: env.LOGTO_M2M_CLIENT_SECRET,
+        webClientId: env.LOGTO_WEB_CLIENT_ID,
+        webClientSecret: env.LOGTO_WEB_CLIENT_SECRET,
+        enabled: Boolean(
+            env.LOGTO_TENANT_ID &&
+                env.LOGTO_M2M_CLIENT_ID &&
+                env.LOGTO_M2M_CLIENT_SECRET,
+        ),
+    },
+
     github: {
         token: env.GITHUB_TOKEN,
     },
@@ -373,6 +415,7 @@ export const config = {
 
     ci: {
         runDbIntegration: env.RUN_DB_INTEGRATION,
+        runLogtoIntegration: env.RUN_LOGTO_INTEGRATION,
         runGithubProjectsIntegration: env.RUN_GITHUB_PROJECTS_INTEGRATION,
         githubTestOwner: env.GITHUB_TEST_OWNER,
         githubTestRepo: env.GITHUB_TEST_REPO,

--- a/test/auth/user-directory.test.ts
+++ b/test/auth/user-directory.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import { InMemoryDirectory } from '../../src/auth/user-directory/in-memory.js'
+import {
+    cleanupOrphanedTestUsers,
+    findTestUserByRunId,
+    newRunId,
+    seedTestUser,
+    teardownTestUser,
+} from '../../src/auth/user-directory/seed.js'
+import {
+    isTestUser,
+    testEmail,
+    testUsername,
+    UserAlreadyExistsError,
+} from '../../src/auth/user-directory/types.js'
+
+describe('InMemoryDirectory', () => {
+    it('creates a user and returns an opaque, non-UUID id', async () => {
+        const d = new InMemoryDirectory()
+        const u = await d.createUser({ username: 'alice' })
+        expect(u.id).toBeTruthy()
+        // The fake mimics Logto's shape on purpose: a UUID-issuing fake would
+        // let UUID assumptions creep back in — the exact defect #151 fixed.
+        expect(u.id).not.toMatch(/^[0-9a-fA-F-]{36}$/)
+        expect(u.username).toBe('alice')
+    })
+
+    it('rejects a create with neither username nor email', async () => {
+        const d = new InMemoryDirectory()
+        await expect(d.createUser({})).rejects.toThrow(/username or an email/i)
+    })
+
+    // Asserts the TYPE, not the message. The first version of this test checked
+    // for /already exists/i, which the fake satisfied and Logto did not — it
+    // says "username_already_in_use". The fake agreed with the code while
+    // reality disagreed with both, and only the integration test caught it.
+    it('rejects duplicates with the typed error the port promises', async () => {
+        const d = new InMemoryDirectory()
+        await d.createUser({ username: 'bob' })
+        await expect(d.createUser({ username: 'bob' })).rejects.toBeInstanceOf(
+            UserAlreadyExistsError,
+        )
+    })
+
+    it('treats a duplicate email as a conflict too', async () => {
+        const d = new InMemoryDirectory()
+        await d.createUser({ username: 'a', email: 'x@y.z' })
+        await expect(
+            d.createUser({ username: 'b', email: 'x@y.z' }),
+        ).rejects.toBeInstanceOf(UserAlreadyExistsError)
+    })
+
+    it('finds by external id and returns null for absent ones', async () => {
+        const d = new InMemoryDirectory()
+        const u = await d.createUser({ username: 'carol' })
+        expect(await d.findByExternalId(u.id)).toMatchObject({
+            username: 'carol',
+        })
+        expect(await d.findByExternalId('nope')).toBeNull()
+    })
+
+    // Contract: absence is not an error. Teardown after a partial failure must
+    // not itself fail.
+    it('deleteUser is idempotent', async () => {
+        const d = new InMemoryDirectory()
+        const u = await d.createUser({ username: 'dave' })
+        await d.deleteUser(u.id)
+        await expect(d.deleteUser(u.id)).resolves.toBeUndefined()
+        expect(await d.findByExternalId(u.id)).toBeNull()
+    })
+
+    it('assignRole is idempotent and rejects unknown users', async () => {
+        const d = new InMemoryDirectory()
+        const u = await d.createUser({ username: 'erin' })
+        await d.assignRole(u.id, 'admin')
+        await d.assignRole(u.id, 'admin')
+        expect(d.rolesOf(u.id)).toEqual(['admin'])
+        await expect(d.assignRole('ghost', 'admin')).rejects.toThrow(
+            /no such user/i,
+        )
+    })
+
+    it('returns copies, so callers cannot mutate internal state', async () => {
+        const d = new InMemoryDirectory()
+        const u = await d.createUser({ username: 'frank' })
+        u.username = 'tampered'
+        expect((await d.findByExternalId(u.id))?.username).toBe('frank')
+    })
+})
+
+describe('test-user namespacing', () => {
+    it('builds namespaced handles', () => {
+        expect(testUsername('abc123')).toBe('test_abc123')
+        expect(testEmail('abc123')).toBe('test+abc123@bad-mcp.test')
+    })
+
+    it('recognises test users by either handle', () => {
+        expect(isTestUser({ id: '1', username: 'test_x' })).toBe(true)
+        expect(isTestUser({ id: '1', email: 'test+x@bad-mcp.test' })).toBe(true)
+    })
+
+    // The safety property that makes unattended cleanup acceptable: a real
+    // account can never match the namespace.
+    it('does not mistake a real account for a test user', () => {
+        expect(
+            isTestUser({
+                id: '1',
+                username: 'bryan',
+                email: 'brn.dbn@gmail.com',
+            }),
+        ).toBe(false)
+        expect(isTestUser({ id: '1', email: 'contest+x@example.com' })).toBe(
+            false,
+        )
+    })
+
+    it('generates distinct run ids', () => {
+        expect(newRunId()).not.toBe(newRunId())
+    })
+})
+
+describe('seedTestUser', () => {
+    it('creates a roled user', async () => {
+        const d = new InMemoryDirectory()
+        const runId = 'run001'
+        const u = await seedTestUser(d, { runId, role: 'admin' })
+        expect(u.created).toBe(true)
+        expect(u.username).toBe('test_run001')
+        expect(u.password).toBeTruthy()
+        expect(d.rolesOf(u.id)).toEqual(['admin'])
+    })
+
+    // The acceptance criterion: running it twice is safe.
+    it('is idempotent — a second run returns the same user, not an error', async () => {
+        const d = new InMemoryDirectory()
+        const runId = 'run002'
+        const first = await seedTestUser(d, { runId, role: 'admin' })
+        const second = await seedTestUser(d, { runId, role: 'admin' })
+
+        expect(second.created).toBe(false)
+        expect(second.id).toBe(first.id)
+        expect(d.list()).toHaveLength(1)
+        // No password is returned the second time — we don't know the original,
+        // and inventing one would be worse than admitting that.
+        expect(second.password).toBeUndefined()
+        expect(d.rolesOf(second.id)).toEqual(['admin'])
+    })
+
+    // A duplicate is expected on re-run; anything else is real and must surface.
+    it('propagates non-duplicate failures instead of swallowing them', async () => {
+        const d = new InMemoryDirectory()
+        const boom = Object.assign(Object.create(Object.getPrototypeOf(d)), d, {
+            createUser: async () => {
+                throw new Error('tenant unreachable')
+            },
+        })
+        await expect(seedTestUser(boom, { runId: 'run003' })).rejects.toThrow(
+            /tenant unreachable/,
+        )
+    })
+
+    it('finds a seeded user by run id', async () => {
+        const d = new InMemoryDirectory()
+        await seedTestUser(d, { runId: 'run004' })
+        expect(await findTestUserByRunId(d, 'run004')).toMatchObject({
+            username: 'test_run004',
+        })
+        expect(await findTestUserByRunId(d, 'absent')).toBeNull()
+    })
+})
+
+describe('teardown and orphan cleanup', () => {
+    it('tears down a seeded user and tolerates undefined', async () => {
+        const d = new InMemoryDirectory()
+        const u = await seedTestUser(d, { runId: 'run005' })
+        await teardownTestUser(d, u.id)
+        expect(d.list()).toHaveLength(0)
+        await expect(teardownTestUser(d, undefined)).resolves.toBeUndefined()
+    })
+
+    // Why the namespace exists: a crashed run leaks users into a shared tenant.
+    it('removes orphans from earlier runs but never real accounts', async () => {
+        const d = new InMemoryDirectory()
+        await seedTestUser(d, { runId: 'old1' })
+        await seedTestUser(d, { runId: 'old2' })
+        await d.createUser({ username: 'bryan', email: 'brn.dbn@gmail.com' })
+
+        const removed = await cleanupOrphanedTestUsers(d)
+
+        expect(removed.map((u) => u.username).sort()).toEqual([
+            'test_old1',
+            'test_old2',
+        ])
+        expect(d.list().map((u) => u.username)).toEqual(['bryan'])
+    })
+
+    it('keeps the current run when asked', async () => {
+        const d = new InMemoryDirectory()
+        await seedTestUser(d, { runId: 'old' })
+        const keep = await seedTestUser(d, { runId: 'current' })
+
+        const removed = await cleanupOrphanedTestUsers(d, {
+            keepRunId: 'current',
+        })
+
+        expect(removed.map((u) => u.username)).toEqual(['test_old'])
+        expect(await d.findByExternalId(keep.id)).not.toBeNull()
+    })
+
+    it('dryRun reports without deleting', async () => {
+        const d = new InMemoryDirectory()
+        await seedTestUser(d, { runId: 'old' })
+        const would = await cleanupOrphanedTestUsers(d, { dryRun: true })
+        expect(would).toHaveLength(1)
+        expect(d.list()).toHaveLength(1)
+    })
+})

--- a/test/integration/logto-user-directory.test.ts
+++ b/test/integration/logto-user-directory.test.ts
@@ -1,0 +1,168 @@
+import express from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { __resetAuthCaches, jwtMiddleware } from '../../src/auth/jwt.js'
+import { requireAdmin } from '../../src/auth/requireAdmin.js'
+import { LogtoDirectory } from '../../src/auth/user-directory/logto.js'
+import {
+    cleanupOrphanedTestUsers,
+    newRunId,
+    seedTestUser,
+} from '../../src/auth/user-directory/seed.js'
+import { config } from '../../src/config.js'
+import { prisma } from '../../src/db/index.js'
+
+const RUN = process.env.RUN_LOGTO_INTEGRATION === 'true'
+
+/**
+ * End-to-end against the real Logto tenant (#154).
+ *
+ * Provisions a user, gives it the admin role, mints a token for it with no
+ * browser, and drives that token through **our actual auth stack** —
+ * `jwtMiddleware` → `verifyAccessToken` (real JWKS) → `resolveAppRole` →
+ * `requireAdmin`. Then tears the user down.
+ *
+ * This is the acceptance criterion "an authenticated E2E test runs green
+ * against a provisioned user". It is a vitest integration test rather than
+ * Playwright because this repo has no browser surface — `mcp-server` is an API.
+ * The browser-level equivalent belongs in `bryandebaun.dev` (#126), and the
+ * spike established it can use this same headless minting rather than
+ * `storageState`.
+ *
+ * Gated on RUN_LOGTO_INTEGRATION so the default suite needs no tenant.
+ */
+const MCP_RESOURCE = 'https://bad-mcp.onrender.com/mcp'
+
+describe('Logto user provisioning, end to end', () => {
+    if (!RUN) {
+        it.skip('skipped - requires RUN_LOGTO_INTEGRATION=true', () => {})
+        return
+    }
+
+    let directory: LogtoDirectory
+    let runId: string
+    let userId: string | undefined
+
+    const saved = {
+        discoveryBase: config.auth.oidc.discoveryBase,
+        issuer: config.auth.oidc.issuer,
+        audience: config.auth.oidc.audience,
+        jwksFromEnv: config.auth.oidc.jwksUrlFromEnv,
+        issuerFromEnv: config.auth.oidc.issuerFromEnv,
+        roleClaimPaths: config.auth.oidc.roleClaimPaths,
+    }
+
+    beforeAll(async () => {
+        directory = LogtoDirectory.fromConfig()
+        runId = newRunId()
+
+        // Point verification at Logto via discovery — exactly the Stage 2
+        // configuration, and no code change, which is what #150 bought.
+        config.auth.oidc.discoveryBase = config.logto.issuer
+        config.auth.oidc.jwksUrlFromEnv = false
+        config.auth.oidc.issuerFromEnv = false
+        config.auth.oidc.audience = MCP_RESOURCE
+        config.auth.oidc.roleClaimPaths = ['scope']
+        __resetAuthCaches()
+
+        // No database in this test: identity comes entirely from the token, so
+        // the Profile lookup must never be what grants admin.
+        ;(prisma as any).profile = {
+            findMany: async () => [],
+            findUnique: async () => null,
+        }
+    })
+
+    afterAll(async () => {
+        if (userId) await directory.deleteUser(userId)
+        Object.assign(config.auth.oidc, {
+            discoveryBase: saved.discoveryBase,
+            issuer: saved.issuer,
+            audience: saved.audience,
+            jwksUrlFromEnv: saved.jwksFromEnv,
+            issuerFromEnv: saved.issuerFromEnv,
+            roleClaimPaths: saved.roleClaimPaths,
+        })
+        __resetAuthCaches()
+    })
+
+    it('provisions a roled test user', async () => {
+        const user = await seedTestUser(directory, { runId, role: 'admin' })
+        userId = user.id
+
+        expect(user.created).toBe(true)
+        expect(user.username).toBe(`test_${runId}`)
+        // Opaque, non-UUID — the #151 premise, confirmed against the real API.
+        expect(user.id).not.toMatch(/^[0-9a-fA-F-]{36}$/)
+
+        const found = await directory.findByExternalId(user.id)
+        expect(found?.id).toBe(user.id)
+    })
+
+    it('re-seeding the same runId is safe', async () => {
+        const again = await seedTestUser(directory, { runId, role: 'admin' })
+        expect(again.created).toBe(false)
+        expect(again.id).toBe(userId)
+    })
+
+    // The acceptance criterion.
+    it('grants admin through the real auth stack using a minted token', async () => {
+        const token = await directory.mintUserToken({
+            userId: userId as string,
+            resource: MCP_RESOURCE,
+            scope: 'admin',
+        })
+
+        const app = express()
+        app.get('/admin', jwtMiddleware, requireAdmin, (req, res) =>
+            res.json({ ok: true, user: (req as any).user }),
+        )
+
+        const res = await request(app)
+            .get('/admin')
+            .set('Authorization', `Bearer ${token}`)
+
+        expect(res.status).toBe(200)
+        expect(res.body.user.isAdmin).toBe(true)
+        expect(res.body.user.role).toBe('admin')
+        // Identity is the Logto subject, not an email — Logto resource tokens
+        // carry no email claim, so `(issuer, externalId)` is the only path.
+        expect(res.body.user.sub).toBe(userId)
+    })
+
+    it('rejects a token minted without the admin scope', async () => {
+        const token = await directory.mintUserToken({
+            userId: userId as string,
+            resource: MCP_RESOURCE,
+        })
+
+        const app = express()
+        app.get('/admin', jwtMiddleware, requireAdmin, (_req, res) =>
+            res.json({ ok: true }),
+        )
+
+        const res = await request(app)
+            .get('/admin')
+            .set('Authorization', `Bearer ${token}`)
+
+        // Authenticated but not authorized — and with no Profile to fall back
+        // on, this is precisely the `unresolvedSubject` path from #151.
+        expect(res.status).toBe(403)
+    })
+
+    it('tears the user down, and teardown is idempotent', async () => {
+        await directory.deleteUser(userId as string)
+        expect(await directory.findByExternalId(userId as string)).toBeNull()
+        await expect(
+            directory.deleteUser(userId as string),
+        ).resolves.toBeUndefined()
+        userId = undefined
+    })
+
+    it('leaves no orphaned test users behind', async () => {
+        const remaining = await cleanupOrphanedTestUsers(directory, {
+            dryRun: true,
+        })
+        expect(remaining.map((u) => u.username)).not.toContain(`test_${runId}`)
+    })
+})


### PR DESCRIPTION
Closes #154. ADR 0001 Stage 2.

## The port

Four methods — `createUser`, `deleteUser`, `assignRole`, `findByExternalId`. A *directory*, not an identity facade.

This is the one identity abstraction ADR 0001 sanctions: token verification stays on the provider-neutral `OIDC_*` seam, because OIDC discovery already *is* that abstraction. Provisioning is the exception — `/api/users` is Logto's own shape, not a standard.

| Implementation | Role |
|---|---|
| `LogtoDirectory` | Management API via `client_credentials` |
| `InMemoryDirectory` | the **second genuine** implementation, which is what makes the interface honest rather than speculative |

`LogtoDirectory` exposes `listUsers` and `mintUserToken` *beyond* the contract, for callers that have knowingly opted into Logto. Those deliberately don't sit on the port — the ADR's instruction was to resist growing it.

The fake issues 12-char lowercase alphanumeric ids like Logto does. A UUID-issuing fake would let UUID assumptions creep back in — the exact defect #151 fixed.

## Seed and teardown

```powershell
pnpm run logto:users seed [runId] | teardown <runId> | list | cleanup [--dry]
```

Idempotent and namespaced, because ADR 0001 commits us to a **shared** hosted tenant — the free tier's second tenant can't hold API resources (#153), so a separate dev tenant is useless. A run can't assume a fresh slate, and a crashed run must leave something identifiable behind.

`cleanup` only ever touches the test namespace, so **it cannot remove a real account.** `isTestUser` is tested against `brn.dbn@gmail.com` and near-misses like `contest+x@example.com` specifically to keep that guarantee honest — it's the property that makes unattended cleanup acceptable.

All of it is written against the port, so it's unit-tested with the fake: no tenant, no network, no credentials.

## 🔴 A bug the fake hid

`seedTestUser` first detected duplicates with `/already exist/i`. The fake threw `"already exists"`, so the unit tests passed. Logto says:

```json
{"code":"user.username_already_in_use","message":"This username is already in use."}
```

Re-seeding failed against the real tenant, caught only by the integration test. **The fake agreed with the code while reality disagreed with both** — same class as the `$queryRawUnsafe` bug earlier in this audit: a mock that confirms the implementation rather than the contract.

Fixed with a typed `UserAlreadyExistsError` that both implementations throw, so the idempotence path can never again hinge on a provider's wording. The unit test now asserts the *type*, not the message.

## The acceptance test

`test/integration/logto-user-directory.test.ts` provisions a user, assigns `admin`, mints a token **with no browser**, and drives it through the **real** auth stack — `jwtMiddleware` → `verifyAccessToken` (live JWKS) → `resolveAppRole` → `requireAdmin` — then tears the user down. It also asserts a token minted *without* the admin scope gets **403**.

A vitest integration test rather than Playwright because **this repo has no browser surface** — `mcp-server` is an API. The browser-level equivalent belongs in `bryandebaun.dev` (#126), and per #153 it can use this same headless minting rather than `storageState`.

Gated on `RUN_LOGTO_INTEGRATION`, so the default suite needs no tenant.

## Verification

- **6/6 integration** against the live tenant
- **CLI exercised end to end** — seed → re-seed (idempotent) → list → teardown → cleanup, leaving the tenant clean
- Full suite **423 passed, 8 skipped**; `verify` green

## Acceptance criteria

- [x] `UserDirectory` port with `LogtoDirectory` + `InMemoryDirectory`
- [x] Seed script creates and tears down a roled test user; running it twice is safe
- [x] Orphaned test users from a failed run are recoverable (namespaced cleanup)
- [x] An authenticated E2E test runs green against a provisioned user
- [x] M2M credentials are not in the repo — Doppler `bad-mcp/dev`, `.env.example` documents names only

## Tenant prerequisites

The port deliberately does **not** create roles or API resources — those are configuration, not something a test should invent. `assignRole` fails with a pointed message if the role is missing rather than silently provisioning an unroled user. Documented in [`docs/runbooks/logto-test-users.md`](docs/runbooks/logto-test-users.md), along with the two token-exchange prerequisites the spike found the hard way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
