### PR TITLE
chore(deps): pin @types/node to the runtime major + Dependabot guards

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,13 @@ updates:
       # deliberate, tested change rather than an automated one.
       - dependency-name: '@tsoa/runtime'
       - dependency-name: tsoa
+      # @types/node tracks the Dockerfile's Node major, not npm's latest.
+      # Types AHEAD of the runtime are the dangerous direction: tsc accepts an
+      # API that does not exist on the deployed Node, every gate passes, and it
+      # throws in production. The type layer is the only thing that could have
+      # known, so nothing else catches it. Move this with the Dockerfile.
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
     # Majors still arrive as individual PRs — those genuinely need reading.
 
   - package-ecosystem: github-actions
@@ -52,3 +59,12 @@ updates:
     labels:
       - 'project:mcp-server'
       - 'type:chore'
+    ignore:
+      # The Node major is an LTS-cadence decision, not an automated bump.
+      # Odd-numbered lines are never LTS: Dependabot proposed node:25-alpine in
+      # #162, which had been end-of-life since 2026-06-01. It also has to move
+      # in lockstep with the `node-version` pins in every workflow, or the
+      # container runs a major that CI never tested.
+      # v24 is supported until 2028-04-30; v26 becomes LTS on 2026-10-28.
+      - dependency-name: node
+        update-types: ['version-update:semver-major']

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "license": "MIT",
     "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
     "engines": {
-        "node": ">=20.0.0",
+        "node": ">=20.19.0",
         "pnpm": ">=11.0.0"
     },
     "dependencies": {
@@ -78,7 +78,7 @@
         "@types/express": "^4.17.17",
         "@types/express-serve-static-core": "^4.19.8",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.0.0",
+        "@types/node": "^24.13.3",
         "@types/pg": "^8.20.0",
         "@types/supertest": "^2.0.12",
         "@types/swagger-ui-express": "^4.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: ^30.0.0
         version: 30.0.0
       '@types/node':
-        specifier: ^20.0.0
-        version: 20.19.30
+        specifier: ^24.13.3
+        version: 24.13.3
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
@@ -107,7 +107,7 @@ importers:
         version: 3.4.2
       '@vitest/coverage-v8':
         specifier: ^3.2.6
-        version: 3.2.6(vitest@3.2.4(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+        version: 3.2.6(vitest@3.2.4(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -122,7 +122,7 @@ importers:
         version: 6.3.4
       ts-node:
         specifier: ^10.9.1
-        version: 10.9.2(@types/node@20.19.30)(typescript@5.9.3)
+        version: 10.9.2(@types/node@24.13.3)(typescript@5.9.3)
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -131,7 +131,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+        version: 3.2.4(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -1930,8 +1930,8 @@ packages:
   '@types/nanoid@2.1.0':
     resolution: {integrity: sha512-xdkn/oRTA0GSNPLIKZgHWqDTWZsVrieKomxJBOQUK9YDD+zfSgmwD5t4WJYra5S7XyhTw7tfvwznW+pFexaepQ==}
 
-  '@types/node@20.19.30':
-    resolution: {integrity: sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==}
+  '@types/node@24.13.3':
+    resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
   '@types/pg@8.20.0':
     resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
@@ -4235,8 +4235,8 @@ packages:
     resolution: {integrity: sha512-60m9IVGbavD6jholbxt0jVBXZkEB/HsMZq7Tyaghseve2/Sf0zQRAIfWsD34sde+DKP2tBxJS2wP88ZM0D1FhA==}
     engines: {node: '>=14'}
 
-  undici-types@6.21.0:
-    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
@@ -5447,7 +5447,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       jest-regex-util: 30.0.1
 
   '@jest/schemas@30.0.5':
@@ -5460,7 +5460,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -6187,12 +6187,12 @@ snapshots:
 
   '@types/accepts@1.3.7':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/chai@5.2.3':
     dependencies:
@@ -6201,7 +6201,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/content-disposition@0.5.9': {}
 
@@ -6212,11 +6212,11 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/express': 4.17.25
       '@types/keygrip': 1.0.6
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/cors@2.8.19':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/d3-array@3.0.3': {}
 
@@ -6256,7 +6256,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.8':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       '@types/qs': 6.14.0
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -6304,7 +6304,7 @@ snapshots:
       '@types/http-errors': 2.0.5
       '@types/keygrip': 1.0.6
       '@types/koa-compose': 3.2.9
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/lodash@4.17.24': {}
 
@@ -6318,15 +6318,15 @@ snapshots:
 
   '@types/nanoid@2.1.0':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
-  '@types/node@20.19.30':
+  '@types/node@24.13.3':
     dependencies:
-      undici-types: 6.21.0
+      undici-types: 7.18.2
 
   '@types/pg@8.20.0':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       pg-protocol: 1.15.0
       pg-types: 2.2.0
 
@@ -6341,16 +6341,16 @@ snapshots:
   '@types/send@0.17.6':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/serve-static@1.15.10':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       '@types/send': 0.17.6
 
   '@types/stack-utils@2.0.3': {}
@@ -6359,7 +6359,7 @@ snapshots:
     dependencies:
       '@types/cookiejar': 2.1.5
       '@types/methods': 1.1.4
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       form-data: 4.0.5
 
   '@types/supertest@2.0.16':
@@ -6373,7 +6373,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -6616,7 +6616,7 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitest/coverage-v8@3.2.6(vitest@3.2.4(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitest/coverage-v8@3.2.6(vitest@3.2.4(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6631,7 +6631,7 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vitest: 3.2.4(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6643,13 +6643,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -7843,7 +7843,7 @@ snapshots:
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       jest-util: 30.2.0
 
   jest-regex-util@30.0.1: {}
@@ -7851,7 +7851,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -8421,7 +8421,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       long: 5.3.2
 
   protobufjs@8.6.4:
@@ -8901,14 +8901,14 @@ snapshots:
 
   ts-deepmerge@7.0.3: {}
 
-  ts-node@10.9.2(@types/node@20.19.30)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@24.13.3)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
@@ -8956,7 +8956,7 @@ snapshots:
 
   unbash@4.0.4: {}
 
-  undici-types@6.21.0: {}
+  undici-types@7.18.2: {}
 
   undici@7.28.0: {}
 
@@ -8990,13 +8990,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9011,7 +9011,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.2(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vite@7.3.2(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -9020,17 +9020,17 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@3.2.4(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
+  vitest@3.2.4(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9048,11 +9048,11 @@ snapshots:
       tinyglobby: 0.2.16
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.2(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@20.19.30)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 20.19.30
+      '@types/node': 24.13.3
     transitivePeerDependencies:
       - jiti
       - less


### PR DESCRIPTION
Closes #167. Follow-up to the closed #162.

`@types/node` sat on **20** while the Dockerfile and all three workflows run **Node 24** — so Node 22/24 APIs were untyped. That's a real gap worth closing. Dependabot's answer was 26, which overshoots.

| | Node major |
|---|---|
| Dockerfile (build + runtime) | 24 |
| CI, all three workflows | 24 |
| `@types/node` before | 20 — behind |
| #167 proposed | 26 — ahead |
| **this PR** | **24 — matched** |

Behind is merely incomplete. **Ahead is the dangerous direction**: `tsc` accepts an API that doesn't exist on the deployed Node, every gate passes, and it throws in production. The type layer is the only thing that could have known, so nothing else catches it. That's the same silent-failure shape as the Render Docker Command override and the unregistered metric.

## Dependabot guards

Two `ignore` rules, so the bot stops proposing the bumps that have to be human decisions:

- **`@types/node` majors** — these move with the Dockerfile, not with npm's latest.
- **The `node` Docker image major** — odd-numbered lines are never LTS. #162 proposed `node:25-alpine`, EOL since **2026-06-01**. It also has to move in lockstep with the `node-version` pins in every workflow, or the container runs a major CI never tested.

Both rules only block **majors**; patch and minor still flow.

## engines

`>=20.0.0` → `>=20.19.0`. Nothing tests 20.0–20.18, and yargs 18 (#168, approved) requires `^20.19.0` — so the old floor becomes actively wrong the moment that merges.

## When this changes again

Node 24 is supported until **2028-04-30**. **Node 26 becomes LTS on 2026-10-28** — that's the moment to move the Dockerfile, `engines`, the three workflow pins, and these types together, in one PR.

## Verification

```
lint       ✓ 255 files
typecheck  ✓
tests      ✓ 423 passed | 8 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
