### PR TITLE
chore(deps): zod 4 + snapshot coverage for MCP tool schemas

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.16/schema.json",
 	"vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-	"files": { "includes": ["**", "!!**/dist"] },
+	"files": { "includes": ["**", "!!**/dist", "!!**/__snapshots__"] },
 	"formatter": { "enabled": true, "indentStyle": "space", "indentWidth": 4 },
 	"linter": {
 		"enabled": true,

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "swagger-ui-express": "^5.0.1",
         "tsoa": "^7.0.0-alpha.0",
         "ws": "^8.21.1",
-        "zod": "^3.23.0"
+        "zod": "^4.4.3"
     },
     "devDependencies": {
         "@biomejs/biome": "^2.5.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
-        version: 1.30.0(zod@3.25.76)
+        version: 1.30.0(zod@4.4.3)
       '@octokit/graphql':
         specifier: ^9.0.3
         version: 9.0.3
@@ -66,8 +66,8 @@ importers:
         specifier: ^8.21.1
         version: 8.21.1
       zod:
-        specifier: ^3.23.0
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.5.6
@@ -4486,9 +4486,6 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -5508,7 +5505,7 @@ snapshots:
 
   '@js-sdsl/ordered-map@4.4.2': {}
 
-  '@modelcontextprotocol/sdk@1.30.0(zod@3.25.76)':
+  '@modelcontextprotocol/sdk@1.30.0(zod@4.4.3)':
     dependencies:
       '@hono/node-server': 2.0.12(hono@4.12.33)
       ajv: 8.20.0
@@ -5525,8 +5522,8 @@ snapshots:
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
-      zod: 3.25.76
-      zod-to-json-schema: 3.25.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9168,10 +9165,8 @@ snapshots:
       grammex: 3.1.13
       graphmatch: 1.1.1
 
-  zod-to-json-schema@3.25.2(zod@3.25.76):
+  zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
-      zod: 3.25.76
-
-  zod@3.25.76: {}
+      zod: 4.4.3
 
   zod@4.4.3: {}

--- a/src/tools/github-projects/schemas.ts
+++ b/src/tools/github-projects/schemas.ts
@@ -111,7 +111,7 @@ export const BulkSetProjectFieldValuesInputSchema = {
                     .positive()
                     .describe('Issue number'),
                 fields: z
-                    .record(z.union([z.string(), z.number()]))
+                    .record(z.string(), z.union([z.string(), z.number()]))
                     .describe('Map of field names to values'),
             }),
         )

--- a/test/tools/__snapshots__/tool-schemas.json
+++ b/test/tools/__snapshots__/tool-schemas.json
@@ -9,14 +9,13 @@
           "description": "Request id to approve"
         },
         "adminNote": {
-          "type": "string",
-          "description": "Optional internal admin note"
+          "description": "Optional internal admin note",
+          "type": "string"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -26,18 +25,19 @@
       "type": "object",
       "properties": {
         "source": {
+          "description": "Restrict to one source",
           "type": "string",
           "enum": [
             "INTUITION",
             "AI_ASSISTED"
-          ],
-          "description": "Restrict to one source"
+          ]
         },
         "sport": {
-          "type": "string",
-          "description": "Restrict to one sport"
+          "description": "Restrict to one sport",
+          "type": "string"
         },
         "market": {
+          "description": "Restrict to one market",
           "type": "string",
           "enum": [
             "moneyline",
@@ -45,19 +45,17 @@
             "total",
             "prop",
             "parlay"
-          ],
-          "description": "Restrict to one market"
+          ]
         },
         "from": {
-          "type": "string",
-          "description": "Only bets placed on/after (ISO 8601)"
+          "description": "Only bets placed on/after (ISO 8601)",
+          "type": "string"
         },
         "to": {
-          "type": "string",
-          "description": "Only bets placed on/before (ISO 8601)"
+          "description": "Only bets placed on/before (ISO 8601)",
+          "type": "string"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -67,36 +65,34 @@
       "type": "object",
       "properties": {
         "legs": {
+          "minItems": 2,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "label": {
-                "type": "string",
-                "description": "Leg label (e.g. \"Celtics ML\")"
+                "description": "Leg label (e.g. \"Celtics ML\")",
+                "type": "string"
               },
               "oddsAmerican": {
                 "type": "number",
                 "description": "Leg American odds"
               },
               "fairProb": {
-                "type": "number",
-                "description": "Fair win prob (0..1) — enables combined EV"
+                "description": "Fair win prob (0..1) — enables combined EV",
+                "type": "number"
               }
             },
             "required": [
               "oddsAmerican"
-            ],
-            "additionalProperties": false
+            ]
           },
-          "minItems": 2,
           "description": "Two or more parlay legs"
         }
       },
       "required": [
         "legs"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -118,9 +114,11 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         },
         "updates": {
+          "minItems": 1,
           "type": "array",
           "items": {
             "type": "object",
@@ -128,14 +126,22 @@
               "issueNumber": {
                 "type": "integer",
                 "exclusiveMinimum": 0,
+                "maximum": 9007199254740991,
                 "description": "Issue number"
               },
               "fields": {
                 "type": "object",
+                "propertyNames": {
+                  "type": "string"
+                },
                 "additionalProperties": {
-                  "type": [
-                    "string",
-                    "number"
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "number"
+                    }
                   ]
                 },
                 "description": "Map of field names to values"
@@ -144,10 +150,8 @@
             "required": [
               "issueNumber",
               "fields"
-            ],
-            "additionalProperties": false
+            ]
           },
-          "minItems": 1,
           "description": "Array of updates, each with issueNumber and fields"
         }
       },
@@ -157,7 +161,6 @@
         "projectNumber",
         "updates"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -174,18 +177,18 @@
         "issueNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Issue number"
         },
         "comment": {
-          "type": "string",
-          "description": "Comment to add before closing"
+          "description": "Comment to add before closing",
+          "type": "string"
         }
       },
       "required": [
         "repo",
         "issueNumber"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -203,31 +206,31 @@
           "description": "Article title"
         },
         "summary": {
-          "type": "string",
-          "description": "Short summary / excerpt"
+          "description": "Short summary / excerpt",
+          "type": "string"
         },
         "body": {
           "type": "string",
           "description": "Article body (Markdown source)"
         },
         "status": {
+          "description": "Publication status (draft | published); defaults to draft",
           "type": "string",
           "enum": [
             "draft",
             "published"
-          ],
-          "description": "Publication status (draft | published); defaults to draft"
+          ]
         },
         "tags": {
+          "description": "Tags",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "Tags"
+          }
         },
         "publishedAt": {
-          "type": "string",
-          "description": "Publication date (ISO 8601); set when publishing"
+          "description": "Publication date (ISO 8601); set when publishing",
+          "type": "string"
         }
       },
       "required": [
@@ -235,7 +238,6 @@
         "title",
         "body"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -249,18 +251,17 @@
           "description": "Author name"
         },
         "bio": {
-          "type": "string",
-          "description": "Author biography"
+          "description": "Author biography",
+          "type": "string"
         },
         "website": {
-          "type": "string",
-          "description": "Author website URL"
+          "description": "Author website URL",
+          "type": "string"
         }
       },
       "required": [
         "name"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -274,8 +275,8 @@
           "description": "Sport (e.g. NBA, NFL)"
         },
         "league": {
-          "type": "string",
-          "description": "League/competition"
+          "description": "League/competition",
+          "type": "string"
         },
         "event": {
           "type": "string",
@@ -297,11 +298,13 @@
           "description": "What was bet (team / over / player prop)"
         },
         "line": {
-          "type": "number",
-          "description": "Spread/total line, if applicable"
+          "description": "Spread/total line, if applicable",
+          "type": "number"
         },
         "oddsAmerican": {
           "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
           "description": "American odds (e.g. -110, +150)"
         },
         "stake": {
@@ -310,8 +313,8 @@
           "description": "Amount risked"
         },
         "book": {
-          "type": "string",
-          "description": "Sportsbook (default DraftKings)"
+          "description": "Sportsbook (default DraftKings)",
+          "type": "string"
         },
         "source": {
           "type": "string",
@@ -322,26 +325,27 @@
           "description": "INTUITION (gut) or AI_ASSISTED"
         },
         "placedAt": {
-          "type": "string",
-          "description": "Placement time (ISO 8601)"
+          "description": "Placement time (ISO 8601)",
+          "type": "string"
         },
         "aiModel": {
-          "type": "string",
-          "description": "AI model, if AI_ASSISTED"
+          "description": "AI model, if AI_ASSISTED",
+          "type": "string"
         },
         "aiRationale": {
-          "type": "string",
-          "description": "AI reasoning captured at decision time"
+          "description": "AI reasoning captured at decision time",
+          "type": "string"
         },
         "aiEstProb": {
-          "type": "number",
-          "description": "AI's estimated win probability (0..1)"
+          "description": "AI's estimated win probability (0..1)",
+          "type": "number"
         },
         "aiEV": {
-          "type": "number",
-          "description": "AI's estimated EV at placement"
+          "description": "AI's estimated EV at placement",
+          "type": "number"
         },
         "legs": {
+          "description": "Parlay legs (market=parlay)",
           "type": "array",
           "items": {
             "type": "object",
@@ -355,25 +359,25 @@
                 "description": "Leg selection"
               },
               "oddsAmerican": {
+                "description": "Leg American odds (optional; SGPs omit it)",
                 "type": "integer",
-                "description": "Leg American odds (optional; SGPs omit it)"
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
               },
               "line": {
-                "type": "number",
-                "description": "Leg line, if applicable"
+                "description": "Leg line, if applicable",
+                "type": "number"
               }
             },
             "required": [
               "event",
               "selection"
-            ],
-            "additionalProperties": false
-          },
-          "description": "Parlay legs (market=parlay)"
+            ]
+          }
         },
         "notes": {
-          "type": "string",
-          "description": "Freeform notes"
+          "description": "Freeform notes",
+          "type": "string"
         }
       },
       "required": [
@@ -385,7 +389,6 @@
         "stake",
         "source"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -399,46 +402,45 @@
           "description": "Book title"
         },
         "status": {
+          "description": "Book status (e.g., Not started, In progress, Completed)",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Book status (e.g., Not started, In progress, Completed)"
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "Book description"
+          "description": "Book description",
+          "type": "string"
         },
         "isbn": {
-          "type": "string",
-          "description": "ISBN (optional, must be unique)"
+          "description": "ISBN (optional, must be unique)",
+          "type": "string"
         },
         "publishedAt": {
-          "type": "string",
-          "description": "Publication date (ISO 8601 format)"
+          "description": "Publication date (ISO 8601 format)",
+          "type": "string"
         },
         "rating": {
-          "type": "number",
-          "description": "Your rating (1-10 scale, optional)"
+          "description": "Your rating (1-10 scale, optional)",
+          "type": "number"
         },
         "review": {
-          "type": "string",
-          "description": "Your review text (optional)"
+          "description": "Your review text (optional)",
+          "type": "string"
         },
         "authorIds": {
+          "description": "Array of author IDs to associate with this book",
           "type": "array",
           "items": {
             "type": "number"
-          },
-          "description": "Array of author IDs to associate with this book"
+          }
         }
       },
       "required": [
         "title"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -452,18 +454,17 @@
           "description": "Content creator name"
         },
         "description": {
-          "type": "string",
-          "description": "Description of content creator"
+          "description": "Description of content creator",
+          "type": "string"
         },
         "website": {
-          "type": "string",
-          "description": "Website URL"
+          "description": "Website URL",
+          "type": "string"
         }
       },
       "required": [
         "name"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -483,35 +484,35 @@
           "description": "Issue title"
         },
         "body": {
-          "type": "string",
-          "description": "Issue body/description (Markdown allowed)"
+          "description": "Issue body/description (Markdown allowed)",
+          "type": "string"
         },
         "bodyFile": {
-          "type": "string",
-          "description": "Path to a Markdown file to use as the issue body"
+          "description": "Path to a Markdown file to use as the issue body",
+          "type": "string"
         },
         "bodyJson": {
           "description": "JSON payload to convert to Markdown for the issue body"
         },
         "labels": {
-          "type": "string",
-          "description": "Comma-separated labels to add"
+          "description": "Comma-separated labels to add",
+          "type": "string"
         },
         "assignees": {
-          "type": "string",
-          "description": "Comma-separated GitHub usernames to assign to the issue"
+          "description": "Comma-separated GitHub usernames to assign to the issue",
+          "type": "string"
         },
         "milestone": {
+          "description": "Milestone number to assign to the issue",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "description": "Milestone number to assign to the issue"
+          "maximum": 9007199254740991
         }
       },
       "required": [
         "repo",
         "title"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -533,6 +534,7 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         },
         "title": {
@@ -541,16 +543,16 @@
           "description": "Issue title"
         },
         "body": {
-          "type": "string",
-          "description": "Issue body (Markdown allowed)"
+          "description": "Issue body (Markdown allowed)",
+          "type": "string"
         },
         "labels": {
-          "type": "string",
-          "description": "Comma-separated labels to add to the issue"
+          "description": "Comma-separated labels to add to the issue",
+          "type": "string"
         },
         "status": {
-          "type": "string",
-          "description": "Status column name to place the issue in (e.g. 'Todo', 'In Progress')"
+          "description": "Status column name to place the issue in (e.g. 'Todo', 'In Progress')",
+          "type": "string"
         }
       },
       "required": [
@@ -559,7 +561,6 @@
         "projectNumber",
         "title"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -573,35 +574,34 @@
           "description": "Movie title"
         },
         "status": {
+          "description": "Movie status (e.g., Not started, In progress, Completed)",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Movie status (e.g., Not started, In progress, Completed)"
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "Movie description"
+          "description": "Movie description",
+          "type": "string"
         },
         "iasn": {
-          "type": "string",
-          "description": "IASN (optional, must be unique)"
+          "description": "IASN (optional, must be unique)",
+          "type": "string"
         },
         "imdbId": {
-          "type": "string",
-          "description": "IMDB ID (optional, must be unique)"
+          "description": "IMDB ID (optional, must be unique)",
+          "type": "string"
         },
         "releasedAt": {
-          "type": "string",
-          "description": "Release date (ISO 8601 format)"
+          "description": "Release date (ISO 8601 format)",
+          "type": "string"
         }
       },
       "required": [
         "title"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -618,6 +618,7 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         },
         "name": {
@@ -637,11 +638,11 @@
           "description": "Field type: TEXT, NUMBER, DATE, SINGLE_SELECT, or ITERATION"
         },
         "options": {
+          "description": "Options for SINGLE_SELECT field (required if dataType is SINGLE_SELECT)",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "Options for SINGLE_SELECT field (required if dataType is SINGLE_SELECT)"
+          }
         }
       },
       "required": [
@@ -650,7 +651,6 @@
         "name",
         "dataType"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -668,15 +668,14 @@
           "description": "Requesting user email"
         },
         "reason": {
-          "type": "string",
-          "description": "Optional note from the user explaining the request"
+          "description": "Optional note from the user explaining the request",
+          "type": "string"
         }
       },
       "required": [
         "userId",
         "userEmail"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -699,32 +698,31 @@
           "description": "Platform (PlayStation, Xbox, PC)"
         },
         "status": {
+          "description": "Status",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Status"
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "Game description"
+          "description": "Game description",
+          "type": "string"
         },
         "igdbId": {
-          "type": "string",
-          "description": "IGDB ID (optional, unique)"
+          "description": "IGDB ID (optional, unique)",
+          "type": "string"
         },
         "releasedAt": {
-          "type": "string",
-          "description": "Release date (ISO 8601)"
+          "description": "Release date (ISO 8601)",
+          "type": "string"
         }
       },
       "required": [
         "title",
         "platform"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -741,7 +739,6 @@
       "required": [
         "slug"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -758,7 +755,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -769,13 +765,14 @@
       "properties": {
         "id": {
           "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
           "description": "Bet ID to delete"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -792,7 +789,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -809,7 +805,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -826,7 +821,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -843,6 +837,7 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         },
         "fieldName": {
@@ -856,7 +851,6 @@
         "projectNumber",
         "fieldName"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -873,7 +867,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -887,14 +880,13 @@
           "description": "Request id to deny"
         },
         "adminNote": {
-          "type": "string",
-          "description": "Optional internal admin note"
+          "description": "Optional internal admin note",
+          "type": "string"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -904,18 +896,17 @@
       "type": "object",
       "properties": {
         "oddsAmerican": {
+          "minItems": 2,
           "type": "array",
           "items": {
             "type": "number"
           },
-          "minItems": 2,
           "description": "American prices for all outcomes of ONE market (e.g. [-110,-110])"
         }
       },
       "required": [
         "oddsAmerican"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -929,18 +920,17 @@
           "description": "Sport key (e.g. basketball_nba)"
         },
         "markets": {
-          "type": "string",
-          "description": "Markets; default h2h"
+          "description": "Markets; default h2h",
+          "type": "string"
         },
         "regions": {
-          "type": "string",
-          "description": "Regions (default us)"
+          "description": "Regions (default us)",
+          "type": "string"
         }
       },
       "required": [
         "sport"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -954,22 +944,21 @@
           "description": "Sport key (e.g. basketball_nba)"
         },
         "markets": {
-          "type": "string",
-          "description": "Markets; default h2h"
+          "description": "Markets; default h2h",
+          "type": "string"
         },
         "regions": {
-          "type": "string",
-          "description": "Regions (default us)"
+          "description": "Regions (default us)",
+          "type": "string"
         },
         "threshold": {
-          "type": "number",
-          "description": "Minimum EV per unit to report (default 0.02 = +2%)"
+          "description": "Minimum EV per unit to report (default 0.02 = +2%)",
+          "type": "number"
         }
       },
       "required": [
         "sport"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -983,19 +972,18 @@
           "description": "Slug of the article to retrieve"
         },
         "status": {
+          "description": "Visibility filter (default published). draft/all require admin context.",
           "type": "string",
           "enum": [
             "draft",
             "published",
             "all"
-          ],
-          "description": "Visibility filter (default published). draft/all require admin context."
+          ]
         }
       },
       "required": [
         "slug"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1012,7 +1000,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1023,13 +1010,14 @@
       "properties": {
         "id": {
           "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
           "description": "Bet ID"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1046,7 +1034,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1063,7 +1050,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1080,6 +1066,7 @@
         "issueNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Issue number"
         }
       },
@@ -1087,7 +1074,6 @@
         "repo",
         "issueNumber"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1104,7 +1090,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1118,22 +1103,21 @@
           "description": "Sport key (e.g. basketball_nba)"
         },
         "markets": {
-          "type": "string",
-          "description": "Comma-separated markets (h2h,spreads,totals); default h2h"
+          "description": "Comma-separated markets (h2h,spreads,totals); default h2h",
+          "type": "string"
         },
         "regions": {
-          "type": "string",
-          "description": "Regions (default us)"
+          "description": "Regions (default us)",
+          "type": "string"
         },
         "eventId": {
-          "type": "string",
-          "description": "Single event id (richer markets/props) instead of all events"
+          "description": "Single event id (richer markets/props) instead of all events",
+          "type": "string"
         }
       },
       "required": [
         "sport"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1148,20 +1132,20 @@
           "description": "Repository in owner/repo format (e.g., 'owner/repo')"
         },
         "labels": {
-          "type": "string",
-          "description": "Comma-separated labels to filter by"
+          "description": "Comma-separated labels to filter by",
+          "type": "string"
         },
         "limit": {
+          "default": 10,
+          "description": "Maximum number of issues to return (default: 10)",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "default": 10,
-          "description": "Maximum number of issues to return (default: 10)"
+          "maximum": 9007199254740991
         }
       },
       "required": [
         "repo"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1178,6 +1162,7 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         }
       },
@@ -1185,7 +1170,6 @@
         "owner",
         "projectNumber"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1202,6 +1186,7 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         }
       },
@@ -1209,7 +1194,6 @@
         "owner",
         "projectNumber"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1219,11 +1203,10 @@
       "type": "object",
       "properties": {
         "includePrivate": {
-          "type": "boolean",
-          "description": "Include basics.privateContact (email/phone). Default false — public reads are stripped."
+          "description": "Include basics.privateContact (email/phone). Default false — public reads are stripped.",
+          "type": "boolean"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1240,7 +1223,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1254,16 +1236,15 @@
           "description": "Sport key (e.g. basketball_nba)"
         },
         "daysFrom": {
+          "description": "Include completed games from the last N days (1-3)",
           "type": "integer",
           "minimum": 1,
-          "maximum": 3,
-          "description": "Include completed games from the last N days (1-3)"
+          "maximum": 3
         }
       },
       "required": [
         "sport"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1273,16 +1254,18 @@
       "type": "object",
       "properties": {
         "id": {
+          "description": "User id",
           "type": "integer",
-          "description": "User id"
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
         },
         "email": {
+          "description": "User email",
           "type": "string",
           "format": "email",
-          "description": "User email"
+          "pattern": "^(?!\\.)(?!.*\\.\\.)([A-Za-z0-9_'+\\-\\.]*)[A-Za-z0-9_+-]@([A-Za-z0-9][A-Za-z0-9\\-]*\\.)+[A-Za-z]{2,}$"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1299,7 +1282,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1309,32 +1291,31 @@
       "type": "object",
       "properties": {
         "status": {
+          "description": "Visibility filter (default published). draft/all require admin context.",
           "type": "string",
           "enum": [
             "draft",
             "published",
             "all"
-          ],
-          "description": "Visibility filter (default published). draft/all require admin context."
+          ]
         },
         "tag": {
-          "type": "string",
-          "description": "Filter by a single tag"
+          "description": "Filter by a single tag",
+          "type": "string"
         },
         "search": {
-          "type": "string",
-          "description": "Search in title and summary"
+          "description": "Search in title and summary",
+          "type": "string"
         },
         "limit": {
-          "type": "number",
-          "description": "Maximum number of results (default 50)"
+          "description": "Maximum number of results (default 50)",
+          "type": "number"
         },
         "offset": {
-          "type": "number",
-          "description": "Number of results to skip (default 0)"
+          "description": "Number of results to skip (default 0)",
+          "type": "number"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1344,19 +1325,18 @@
       "type": "object",
       "properties": {
         "search": {
-          "type": "string",
-          "description": "Search in author name and bio"
+          "description": "Search in author name and bio",
+          "type": "string"
         },
         "limit": {
-          "type": "number",
-          "description": "Maximum number of results (default 50)"
+          "description": "Maximum number of results (default 50)",
+          "type": "number"
         },
         "offset": {
-          "type": "number",
-          "description": "Number of results to skip (default 0)"
+          "description": "Number of results to skip (default 0)",
+          "type": "number"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1366,14 +1346,15 @@
       "type": "object",
       "properties": {
         "source": {
+          "description": "Filter by source",
           "type": "string",
           "enum": [
             "INTUITION",
             "AI_ASSISTED"
-          ],
-          "description": "Filter by source"
+          ]
         },
         "status": {
+          "description": "Filter by status",
           "type": "string",
           "enum": [
             "PENDING",
@@ -1381,14 +1362,14 @@
             "LOST",
             "PUSH",
             "VOID"
-          ],
-          "description": "Filter by status"
+          ]
         },
         "sport": {
-          "type": "string",
-          "description": "Filter by sport"
+          "description": "Filter by sport",
+          "type": "string"
         },
         "market": {
+          "description": "Filter by market",
           "type": "string",
           "enum": [
             "moneyline",
@@ -1396,19 +1377,21 @@
             "total",
             "prop",
             "parlay"
-          ],
-          "description": "Filter by market"
+          ]
         },
         "limit": {
+          "description": "Max results (default 100)",
           "type": "integer",
-          "description": "Max results (default 100)"
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
         },
         "offset": {
+          "description": "Results to skip (default 0)",
           "type": "integer",
-          "description": "Results to skip (default 0)"
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1418,36 +1401,35 @@
       "type": "object",
       "properties": {
         "authorId": {
-          "type": "number",
-          "description": "Filter by author ID"
+          "description": "Filter by author ID",
+          "type": "number"
         },
         "minRating": {
-          "type": "number",
-          "description": "Minimum average rating (1-10)"
+          "description": "Minimum average rating (1-10)",
+          "type": "number"
         },
         "search": {
-          "type": "string",
-          "description": "Search in title and description"
+          "description": "Search in title and description",
+          "type": "string"
         },
         "status": {
+          "description": "Filter by status (Not started, In progress, Completed)",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Filter by status (Not started, In progress, Completed)"
+          ]
         },
         "limit": {
-          "type": "number",
-          "description": "Maximum number of results (default 50)"
+          "description": "Maximum number of results (default 50)",
+          "type": "number"
         },
         "offset": {
-          "type": "number",
-          "description": "Number of results to skip (default 0)"
+          "description": "Number of results to skip (default 0)",
+          "type": "number"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1457,19 +1439,18 @@
       "type": "object",
       "properties": {
         "search": {
-          "type": "string",
-          "description": "Search in name and description"
+          "description": "Search in name and description",
+          "type": "string"
         },
         "limit": {
-          "type": "number",
-          "description": "Maximum number of results (default 50)"
+          "description": "Maximum number of results (default 50)",
+          "type": "number"
         },
         "offset": {
-          "type": "number",
-          "description": "Number of results to skip (default 0)"
+          "description": "Number of results to skip (default 0)",
+          "type": "number"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1486,7 +1467,6 @@
       "required": [
         "sport"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1504,7 +1484,6 @@
       "required": [
         "repo"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1514,32 +1493,31 @@
       "type": "object",
       "properties": {
         "minRating": {
-          "type": "number",
-          "description": "Minimum average rating (1-10)"
+          "description": "Minimum average rating (1-10)",
+          "type": "number"
         },
         "search": {
-          "type": "string",
-          "description": "Search in title and description"
+          "description": "Search in title and description",
+          "type": "string"
         },
         "status": {
+          "description": "Filter by status",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Filter by status"
+          ]
         },
         "limit": {
-          "type": "number",
-          "description": "Maximum number of results (default 50)"
+          "description": "Maximum number of results (default 50)",
+          "type": "number"
         },
         "offset": {
-          "type": "number",
-          "description": "Number of results to skip (default 0)"
+          "description": "Number of results to skip (default 0)",
+          "type": "number"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1556,6 +1534,7 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         }
       },
@@ -1563,7 +1542,6 @@
         "owner",
         "projectNumber"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1573,6 +1551,7 @@
       "type": "object",
       "properties": {
         "status": {
+          "description": "Filter by stored status (default: all)",
           "type": "string",
           "enum": [
             "pending",
@@ -1581,23 +1560,21 @@
             "fulfilled",
             "expired",
             "all"
-          ],
-          "description": "Filter by stored status (default: all)"
+          ]
         },
         "userId": {
-          "type": "string",
-          "description": "Filter to a single user"
+          "description": "Filter to a single user",
+          "type": "string"
         },
         "limit": {
-          "type": "number",
-          "description": "Maximum number of results (default 50)"
+          "description": "Maximum number of results (default 50)",
+          "type": "number"
         },
         "offset": {
-          "type": "number",
-          "description": "Number of results to skip (default 0)"
+          "description": "Number of results to skip (default 0)",
+          "type": "number"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1623,32 +1600,31 @@
       "type": "object",
       "properties": {
         "platform": {
+          "description": "Filter by platform",
           "type": "string",
           "enum": [
             "PlayStation",
             "Xbox",
             "PC"
-          ],
-          "description": "Filter by platform"
+          ]
         },
         "minRating": {
-          "type": "number",
-          "description": "Minimum average rating (1-10)"
+          "description": "Minimum average rating (1-10)",
+          "type": "number"
         },
         "search": {
-          "type": "string",
-          "description": "Search in title and description"
+          "description": "Search in title and description",
+          "type": "string"
         },
         "limit": {
-          "type": "number",
-          "description": "Maximum number of results (default 50)"
+          "description": "Maximum number of results (default 50)",
+          "type": "number"
         },
         "offset": {
-          "type": "number",
-          "description": "Number of results to skip (default 0)"
+          "description": "Number of results to skip (default 0)",
+          "type": "number"
         }
       },
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1662,6 +1638,7 @@
           "description": "Event description (e.g. \"Lakers @ Celtics\")"
         },
         "market": {
+          "description": "Market (defaults to parlay when legs given, else moneyline)",
           "type": "string",
           "enum": [
             "moneyline",
@@ -1669,20 +1646,21 @@
             "total",
             "prop",
             "parlay"
-          ],
-          "description": "Market (defaults to parlay when legs given, else moneyline)"
+          ]
         },
         "selection": {
-          "type": "string",
-          "description": "Selection for a single bet"
+          "description": "Selection for a single bet",
+          "type": "string"
         },
         "line": {
-          "type": "number",
-          "description": "Spread/total line, if applicable"
+          "description": "Spread/total line, if applicable",
+          "type": "number"
         },
         "oddsAmerican": {
+          "description": "Required for a single bet; computed from legs for a parlay",
           "type": "integer",
-          "description": "Required for a single bet; computed from legs for a parlay"
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
         },
         "stake": {
           "type": "number",
@@ -1690,50 +1668,51 @@
           "description": "Amount to risk"
         },
         "legs": {
+          "description": "Parlay legs (≥2) instead of a single selection",
+          "minItems": 2,
           "type": "array",
           "items": {
             "type": "object",
             "properties": {
               "label": {
-                "type": "string",
-                "description": "Leg label"
+                "description": "Leg label",
+                "type": "string"
               },
               "event": {
-                "type": "string",
-                "description": "Leg event"
+                "description": "Leg event",
+                "type": "string"
               },
               "selection": {
-                "type": "string",
-                "description": "Leg selection"
+                "description": "Leg selection",
+                "type": "string"
               },
               "oddsAmerican": {
+                "description": "Leg American odds (optional; SGPs omit it)",
                 "type": "integer",
-                "description": "Leg American odds (optional; SGPs omit it)"
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
               },
               "line": {
                 "type": "number"
               },
               "fairProb": {
-                "type": "number",
-                "description": "Leg fair win prob (0..1) → enables EV"
+                "description": "Leg fair win prob (0..1) → enables EV",
+                "type": "number"
               }
-            },
-            "additionalProperties": false
-          },
-          "minItems": 2,
-          "description": "Parlay legs (≥2) instead of a single selection"
+            }
+          }
         },
         "sport": {
-          "type": "string",
-          "description": "Sport key for the DK link (e.g. basketball_nba)"
+          "description": "Sport key for the DK link (e.g. basketball_nba)",
+          "type": "string"
         },
         "source": {
+          "description": "INTUITION or AI_ASSISTED",
           "type": "string",
           "enum": [
             "INTUITION",
             "AI_ASSISTED"
-          ],
-          "description": "INTUITION or AI_ASSISTED"
+          ]
         },
         "aiModel": {
           "type": "string"
@@ -1745,19 +1724,18 @@
           "type": "number"
         },
         "fairProb": {
-          "type": "number",
-          "description": "Fair win prob for a single bet → enables EV"
+          "description": "Fair win prob for a single bet → enables EV",
+          "type": "number"
         },
         "book": {
-          "type": "string",
-          "description": "Sportsbook (default DraftKings)"
+          "description": "Sportsbook (default DraftKings)",
+          "type": "string"
         }
       },
       "required": [
         "event",
         "stake"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1774,7 +1752,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1796,11 +1773,13 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         },
         "issueNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Issue number"
         },
         "fieldName": {
@@ -1809,9 +1788,13 @@
           "description": "Field name"
         },
         "value": {
-          "type": [
-            "string",
-            "number"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
           ],
           "description": "Field value (string or number)"
         }
@@ -1824,7 +1807,6 @@
         "fieldName",
         "value"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1835,6 +1817,8 @@
       "properties": {
         "id": {
           "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
           "description": "Bet ID"
         },
         "status": {
@@ -1848,15 +1832,14 @@
           "description": "Outcome: WON | LOST | PUSH | VOID"
         },
         "payout": {
-          "type": "number",
-          "description": "Total returned on a win (incl. stake); computed if omitted"
+          "description": "Total returned on a win (incl. stake); computed if omitted",
+          "type": "number"
         }
       },
       "required": [
         "id",
         "status"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1870,45 +1853,44 @@
           "description": "Slug of the article to update"
         },
         "title": {
-          "type": "string",
-          "description": "Article title"
+          "description": "Article title",
+          "type": "string"
         },
         "summary": {
-          "type": "string",
-          "description": "Short summary / excerpt"
+          "description": "Short summary / excerpt",
+          "type": "string"
         },
         "body": {
-          "type": "string",
-          "description": "Article body (Markdown source)"
+          "description": "Article body (Markdown source)",
+          "type": "string"
         },
         "status": {
+          "description": "Publication status (draft | published)",
           "type": "string",
           "enum": [
             "draft",
             "published"
-          ],
-          "description": "Publication status (draft | published)"
+          ]
         },
         "tags": {
+          "description": "Tags",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "Tags"
+          }
         },
         "publishedAt": {
-          "type": "string",
-          "description": "Publication date (ISO 8601)"
+          "description": "Publication date (ISO 8601)",
+          "type": "string"
         },
         "newSlug": {
-          "type": "string",
-          "description": "Rename the slug (must stay unique)"
+          "description": "Rename the slug (must stay unique)",
+          "type": "string"
         }
       },
       "required": [
         "slug"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1922,22 +1904,21 @@
           "description": "Author ID"
         },
         "name": {
-          "type": "string",
-          "description": "Author name"
+          "description": "Author name",
+          "type": "string"
         },
         "bio": {
-          "type": "string",
-          "description": "Author biography"
+          "description": "Author biography",
+          "type": "string"
         },
         "website": {
-          "type": "string",
-          "description": "Author website URL"
+          "description": "Author website URL",
+          "type": "string"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -1948,6 +1929,8 @@
       "properties": {
         "id": {
           "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991,
           "description": "Bet ID"
         },
         "sport": {
@@ -1976,7 +1959,9 @@
           "type": "number"
         },
         "oddsAmerican": {
-          "type": "integer"
+          "type": "integer",
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
         },
         "stake": {
           "type": "number",
@@ -2005,12 +1990,14 @@
           "type": "number"
         },
         "closingLine": {
-          "type": "number",
-          "description": "Closing line (Phase 2 / #129)"
+          "description": "Closing line (Phase 2 / #129)",
+          "type": "number"
         },
         "closingOddsAmerican": {
+          "description": "Closing American odds (for CLV)",
           "type": "integer",
-          "description": "Closing American odds (for CLV)"
+          "minimum": -9007199254740991,
+          "maximum": 9007199254740991
         },
         "legs": {
           "type": "array",
@@ -2026,19 +2013,20 @@
                 "description": "Leg selection"
               },
               "oddsAmerican": {
+                "description": "Leg American odds (optional; SGPs omit it)",
                 "type": "integer",
-                "description": "Leg American odds (optional; SGPs omit it)"
+                "minimum": -9007199254740991,
+                "maximum": 9007199254740991
               },
               "line": {
-                "type": "number",
-                "description": "Leg line, if applicable"
+                "description": "Leg line, if applicable",
+                "type": "number"
               }
             },
             "required": [
               "event",
               "selection"
-            ],
-            "additionalProperties": false
+            ]
           }
         },
         "notes": {
@@ -2048,7 +2036,6 @@
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -2062,50 +2049,49 @@
           "description": "Book ID"
         },
         "title": {
-          "type": "string",
-          "description": "Book title"
+          "description": "Book title",
+          "type": "string"
         },
         "status": {
+          "description": "Book status (e.g., Not started, In progress, Completed)",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Book status (e.g., Not started, In progress, Completed)"
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "Book description"
+          "description": "Book description",
+          "type": "string"
         },
         "rating": {
-          "type": "number",
-          "description": "Your rating (1-10 scale, optional)"
+          "description": "Your rating (1-10 scale, optional)",
+          "type": "number"
         },
         "review": {
-          "type": "string",
-          "description": "Your review text (optional)"
+          "description": "Your review text (optional)",
+          "type": "string"
         },
         "isbn": {
-          "type": "string",
-          "description": "ISBN (must be unique)"
+          "description": "ISBN (must be unique)",
+          "type": "string"
         },
         "publishedAt": {
-          "type": "string",
-          "description": "Publication date (ISO 8601 format)"
+          "description": "Publication date (ISO 8601 format)",
+          "type": "string"
         },
         "authorIds": {
+          "description": "Array of author IDs to associate with this book",
           "type": "array",
           "items": {
             "type": "number"
-          },
-          "description": "Array of author IDs to associate with this book"
+          }
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -2119,22 +2105,21 @@
           "description": "Content creator ID"
         },
         "name": {
-          "type": "string",
-          "description": "Content creator name"
+          "description": "Content creator name",
+          "type": "string"
         },
         "description": {
-          "type": "string",
-          "description": "Description of content creator"
+          "description": "Description of content creator",
+          "type": "string"
         },
         "website": {
-          "type": "string",
-          "description": "Website URL"
+          "description": "Website URL",
+          "type": "string"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -2151,67 +2136,68 @@
         "issueNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Issue number"
         },
         "title": {
-          "type": "string",
-          "description": "New issue title"
+          "description": "New issue title",
+          "type": "string"
         },
         "body": {
-          "type": "string",
-          "description": "New issue body (Markdown allowed)"
+          "description": "New issue body (Markdown allowed)",
+          "type": "string"
         },
         "bodyFile": {
-          "type": "string",
-          "description": "Path to a Markdown file to use as the issue body"
+          "description": "Path to a Markdown file to use as the issue body",
+          "type": "string"
         },
         "bodyJson": {
           "description": "JSON payload to convert to Markdown for the issue body"
         },
         "labels": {
-          "type": "string",
-          "description": "Comma-separated labels to add to the issue"
+          "description": "Comma-separated labels to add to the issue",
+          "type": "string"
         },
         "removeLabels": {
-          "type": "string",
-          "description": "Comma-separated labels to remove from the issue"
+          "description": "Comma-separated labels to remove from the issue",
+          "type": "string"
         },
         "assignees": {
-          "type": "string",
-          "description": "Comma-separated GitHub usernames to assign to the issue"
+          "description": "Comma-separated GitHub usernames to assign to the issue",
+          "type": "string"
         },
         "milestone": {
+          "description": "Milestone number to assign (use 0 to clear)",
           "type": "integer",
           "exclusiveMinimum": 0,
-          "description": "Milestone number to assign (use 0 to clear)"
+          "maximum": 9007199254740991
         },
         "state": {
+          "description": "Set issue state to open or closed",
           "type": "string",
           "enum": [
             "open",
             "closed"
-          ],
-          "description": "Set issue state to open or closed"
+          ]
         },
         "stateReason": {
+          "description": "Reason for closing: completed or not_planned (ignored when opening)",
           "type": "string",
           "enum": [
             "completed",
             "not_planned",
             "reopened"
-          ],
-          "description": "Reason for closing: completed or not_planned (ignored when opening)"
+          ]
         },
         "comment": {
-          "type": "string",
-          "description": "Comment to add to the issue"
+          "description": "Comment to add to the issue",
+          "type": "string"
         }
       },
       "required": [
         "repo",
         "issueNumber"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -2225,39 +2211,38 @@
           "description": "Movie ID"
         },
         "title": {
-          "type": "string",
-          "description": "Movie title"
+          "description": "Movie title",
+          "type": "string"
         },
         "status": {
+          "description": "Movie status (e.g., Not started, In progress, Completed)",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Movie status (e.g., Not started, In progress, Completed)"
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "Movie description"
+          "description": "Movie description",
+          "type": "string"
         },
         "iasn": {
-          "type": "string",
-          "description": "IASN (must be unique)"
+          "description": "IASN (must be unique)",
+          "type": "string"
         },
         "imdbId": {
-          "type": "string",
-          "description": "IMDB ID (must be unique)"
+          "description": "IMDB ID (must be unique)",
+          "type": "string"
         },
         "releasedAt": {
-          "type": "string",
-          "description": "Release date (ISO 8601 format)"
+          "description": "Release date (ISO 8601 format)",
+          "type": "string"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -2274,6 +2259,7 @@
         "projectNumber": {
           "type": "integer",
           "exclusiveMinimum": 0,
+          "maximum": 9007199254740991,
           "description": "Project number (e.g., 2 for Project #2)"
         },
         "fieldName": {
@@ -2282,23 +2268,23 @@
           "description": "Current field name to update"
         },
         "newName": {
+          "description": "New field name",
           "type": "string",
-          "minLength": 1,
-          "description": "New field name"
+          "minLength": 1
         },
         "addOptions": {
+          "description": "Options to add (for SINGLE_SELECT fields)",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "Options to add (for SINGLE_SELECT fields)"
+          }
         },
         "removeOptions": {
+          "description": "Options to remove (for SINGLE_SELECT fields)",
           "type": "array",
           "items": {
             "type": "string"
-          },
-          "description": "Options to remove (for SINGLE_SELECT fields)"
+          }
         }
       },
       "required": [
@@ -2306,7 +2292,6 @@
         "projectNumber",
         "fieldName"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -2335,7 +2320,8 @@
                 },
                 "location": {},
                 "profiles": {
-                  "type": "array"
+                  "type": "array",
+                  "items": {}
                 },
                 "privateContact": {
                   "type": "object",
@@ -2347,38 +2333,41 @@
                       "type": "string"
                     }
                   },
-                  "additionalProperties": true
+                  "additionalProperties": {}
                 }
               },
               "required": [
                 "name"
               ],
-              "additionalProperties": true
+              "additionalProperties": {}
             },
             "work": {
-              "type": "array"
+              "type": "array",
+              "items": {}
             },
             "education": {
-              "type": "array"
+              "type": "array",
+              "items": {}
             },
             "skills": {
-              "type": "array"
+              "type": "array",
+              "items": {}
             },
             "projects": {
-              "type": "array"
+              "type": "array",
+              "items": {}
             }
           },
           "required": [
             "basics"
           ],
-          "additionalProperties": true,
+          "additionalProperties": {},
           "description": "The full JSON Resume document to store (replaces the singleton)."
         }
       },
       "required": [
         "document"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   },
@@ -2392,44 +2381,43 @@
           "description": "Video game ID"
         },
         "title": {
-          "type": "string",
-          "description": "Video game title"
+          "description": "Video game title",
+          "type": "string"
         },
         "status": {
+          "description": "Status",
           "type": "string",
           "enum": [
             "NOT_STARTED",
             "IN_PROGRESS",
             "COMPLETED"
-          ],
-          "description": "Status"
+          ]
         },
         "description": {
-          "type": "string",
-          "description": "Game description"
+          "description": "Game description",
+          "type": "string"
         },
         "platform": {
+          "description": "Platform (PlayStation, Xbox, PC)",
           "type": "string",
           "enum": [
             "PlayStation",
             "Xbox",
             "PC"
-          ],
-          "description": "Platform (PlayStation, Xbox, PC)"
+          ]
         },
         "igdbId": {
-          "type": "string",
-          "description": "IGDB ID (optional, unique)"
+          "description": "IGDB ID (optional, unique)",
+          "type": "string"
         },
         "releasedAt": {
-          "type": "string",
-          "description": "Release date (ISO 8601)"
+          "description": "Release date (ISO 8601)",
+          "type": "string"
         }
       },
       "required": [
         "id"
       ],
-      "additionalProperties": false,
       "$schema": "http://json-schema.org/draft-07/schema#"
     }
   }

--- a/test/tools/__snapshots__/tool-schemas.json
+++ b/test/tools/__snapshots__/tool-schemas.json
@@ -1,0 +1,2436 @@
+[
+  {
+    "name": "approve-resume-download-request",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Request id to approve"
+        },
+        "adminNote": {
+          "type": "string",
+          "description": "Optional internal admin note"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "bet-analytics",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": [
+            "INTUITION",
+            "AI_ASSISTED"
+          ],
+          "description": "Restrict to one source"
+        },
+        "sport": {
+          "type": "string",
+          "description": "Restrict to one sport"
+        },
+        "market": {
+          "type": "string",
+          "enum": [
+            "moneyline",
+            "spread",
+            "total",
+            "prop",
+            "parlay"
+          ],
+          "description": "Restrict to one market"
+        },
+        "from": {
+          "type": "string",
+          "description": "Only bets placed on/after (ISO 8601)"
+        },
+        "to": {
+          "type": "string",
+          "description": "Only bets placed on/before (ISO 8601)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "build-parlay",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "legs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Leg label (e.g. \"Celtics ML\")"
+              },
+              "oddsAmerican": {
+                "type": "number",
+                "description": "Leg American odds"
+              },
+              "fairProb": {
+                "type": "number",
+                "description": "Fair win prob (0..1) — enables combined EV"
+              }
+            },
+            "required": [
+              "oddsAmerican"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 2,
+          "description": "Two or more parlay legs"
+        }
+      },
+      "required": [
+        "legs"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "bulk-set-project-field-values",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository name (just the name, not owner/repo)"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        },
+        "updates": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "issueNumber": {
+                "type": "integer",
+                "exclusiveMinimum": 0,
+                "description": "Issue number"
+              },
+              "fields": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": [
+                    "string",
+                    "number"
+                  ]
+                },
+                "description": "Map of field names to values"
+              }
+            },
+            "required": [
+              "issueNumber",
+              "fields"
+            ],
+            "additionalProperties": false
+          },
+          "minItems": 1,
+          "description": "Array of updates, each with issueNumber and fields"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "projectNumber",
+        "updates"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "close-issue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$",
+          "description": "Repository in owner/repo format (e.g., 'owner/repo')"
+        },
+        "issueNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Issue number"
+        },
+        "comment": {
+          "type": "string",
+          "description": "Comment to add before closing"
+        }
+      },
+      "required": [
+        "repo",
+        "issueNumber"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-article",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string",
+          "description": "URL slug (unique, e.g. \"cptsd\")"
+        },
+        "title": {
+          "type": "string",
+          "description": "Article title"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short summary / excerpt"
+        },
+        "body": {
+          "type": "string",
+          "description": "Article body (Markdown source)"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "published"
+          ],
+          "description": "Publication status (draft | published); defaults to draft"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags"
+        },
+        "publishedAt": {
+          "type": "string",
+          "description": "Publication date (ISO 8601); set when publishing"
+        }
+      },
+      "required": [
+        "slug",
+        "title",
+        "body"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-author",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Author name"
+        },
+        "bio": {
+          "type": "string",
+          "description": "Author biography"
+        },
+        "website": {
+          "type": "string",
+          "description": "Author website URL"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-bet",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sport": {
+          "type": "string",
+          "description": "Sport (e.g. NBA, NFL)"
+        },
+        "league": {
+          "type": "string",
+          "description": "League/competition"
+        },
+        "event": {
+          "type": "string",
+          "description": "Event description (e.g. \"Lakers @ Celtics\")"
+        },
+        "market": {
+          "type": "string",
+          "enum": [
+            "moneyline",
+            "spread",
+            "total",
+            "prop",
+            "parlay"
+          ],
+          "description": "moneyline | spread | total | prop | parlay"
+        },
+        "selection": {
+          "type": "string",
+          "description": "What was bet (team / over / player prop)"
+        },
+        "line": {
+          "type": "number",
+          "description": "Spread/total line, if applicable"
+        },
+        "oddsAmerican": {
+          "type": "integer",
+          "description": "American odds (e.g. -110, +150)"
+        },
+        "stake": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Amount risked"
+        },
+        "book": {
+          "type": "string",
+          "description": "Sportsbook (default DraftKings)"
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "INTUITION",
+            "AI_ASSISTED"
+          ],
+          "description": "INTUITION (gut) or AI_ASSISTED"
+        },
+        "placedAt": {
+          "type": "string",
+          "description": "Placement time (ISO 8601)"
+        },
+        "aiModel": {
+          "type": "string",
+          "description": "AI model, if AI_ASSISTED"
+        },
+        "aiRationale": {
+          "type": "string",
+          "description": "AI reasoning captured at decision time"
+        },
+        "aiEstProb": {
+          "type": "number",
+          "description": "AI's estimated win probability (0..1)"
+        },
+        "aiEV": {
+          "type": "number",
+          "description": "AI's estimated EV at placement"
+        },
+        "legs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "description": "Leg event description"
+              },
+              "selection": {
+                "type": "string",
+                "description": "Leg selection"
+              },
+              "oddsAmerican": {
+                "type": "integer",
+                "description": "Leg American odds (optional; SGPs omit it)"
+              },
+              "line": {
+                "type": "number",
+                "description": "Leg line, if applicable"
+              }
+            },
+            "required": [
+              "event",
+              "selection"
+            ],
+            "additionalProperties": false
+          },
+          "description": "Parlay legs (market=parlay)"
+        },
+        "notes": {
+          "type": "string",
+          "description": "Freeform notes"
+        }
+      },
+      "required": [
+        "sport",
+        "event",
+        "market",
+        "selection",
+        "oddsAmerican",
+        "stake",
+        "source"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-book",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Book title"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Book status (e.g., Not started, In progress, Completed)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Book description"
+        },
+        "isbn": {
+          "type": "string",
+          "description": "ISBN (optional, must be unique)"
+        },
+        "publishedAt": {
+          "type": "string",
+          "description": "Publication date (ISO 8601 format)"
+        },
+        "rating": {
+          "type": "number",
+          "description": "Your rating (1-10 scale, optional)"
+        },
+        "review": {
+          "type": "string",
+          "description": "Your review text (optional)"
+        },
+        "authorIds": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Array of author IDs to associate with this book"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-content-creator",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Content creator name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of content creator"
+        },
+        "website": {
+          "type": "string",
+          "description": "Website URL"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-issue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$",
+          "description": "Repository in owner/repo format (e.g., 'owner/repo')"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Issue title"
+        },
+        "body": {
+          "type": "string",
+          "description": "Issue body/description (Markdown allowed)"
+        },
+        "bodyFile": {
+          "type": "string",
+          "description": "Path to a Markdown file to use as the issue body"
+        },
+        "bodyJson": {
+          "description": "JSON payload to convert to Markdown for the issue body"
+        },
+        "labels": {
+          "type": "string",
+          "description": "Comma-separated labels to add"
+        },
+        "assignees": {
+          "type": "string",
+          "description": "Comma-separated GitHub usernames to assign to the issue"
+        },
+        "milestone": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Milestone number to assign to the issue"
+        }
+      },
+      "required": [
+        "repo",
+        "title"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-issue-in-project",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository name (just the repo name, not owner/repo)"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Issue title"
+        },
+        "body": {
+          "type": "string",
+          "description": "Issue body (Markdown allowed)"
+        },
+        "labels": {
+          "type": "string",
+          "description": "Comma-separated labels to add to the issue"
+        },
+        "status": {
+          "type": "string",
+          "description": "Status column name to place the issue in (e.g. 'Todo', 'In Progress')"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "projectNumber",
+        "title"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-movie",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Movie title"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Movie status (e.g., Not started, In progress, Completed)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Movie description"
+        },
+        "iasn": {
+          "type": "string",
+          "description": "IASN (optional, must be unique)"
+        },
+        "imdbId": {
+          "type": "string",
+          "description": "IMDB ID (optional, must be unique)"
+        },
+        "releasedAt": {
+          "type": "string",
+          "description": "Release date (ISO 8601 format)"
+        }
+      },
+      "required": [
+        "title"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-project-field",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Field name"
+        },
+        "dataType": {
+          "type": "string",
+          "enum": [
+            "TEXT",
+            "NUMBER",
+            "DATE",
+            "SINGLE_SELECT",
+            "ITERATION"
+          ],
+          "description": "Field type: TEXT, NUMBER, DATE, SINGLE_SELECT, or ITERATION"
+        },
+        "options": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Options for SINGLE_SELECT field (required if dataType is SINGLE_SELECT)"
+        }
+      },
+      "required": [
+        "owner",
+        "projectNumber",
+        "name",
+        "dataType"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-resume-download-request",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "userId": {
+          "type": "string",
+          "description": "Requesting user id (Supabase auth UUID / JWT sub)"
+        },
+        "userEmail": {
+          "type": "string",
+          "description": "Requesting user email"
+        },
+        "reason": {
+          "type": "string",
+          "description": "Optional note from the user explaining the request"
+        }
+      },
+      "required": [
+        "userId",
+        "userEmail"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "create-videogame",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Video game title"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "PlayStation",
+            "Xbox",
+            "PC"
+          ],
+          "description": "Platform (PlayStation, Xbox, PC)"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Status"
+        },
+        "description": {
+          "type": "string",
+          "description": "Game description"
+        },
+        "igdbId": {
+          "type": "string",
+          "description": "IGDB ID (optional, unique)"
+        },
+        "releasedAt": {
+          "type": "string",
+          "description": "Release date (ISO 8601)"
+        }
+      },
+      "required": [
+        "title",
+        "platform"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-article",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string",
+          "description": "Slug of the article to delete"
+        }
+      },
+      "required": [
+        "slug"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-author",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Author ID to delete"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-bet",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Bet ID to delete"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-book",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Book ID to delete"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-content-creator",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "ContentCreator ID to delete"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-movie",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Movie ID to delete"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-project-field",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        },
+        "fieldName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Field name to delete"
+        }
+      },
+      "required": [
+        "owner",
+        "projectNumber",
+        "fieldName"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "delete-videogame",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Video game ID to delete"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "deny-resume-download-request",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Request id to deny"
+        },
+        "adminNote": {
+          "type": "string",
+          "description": "Optional internal admin note"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "devig",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "oddsAmerican": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "minItems": 2,
+          "description": "American prices for all outcomes of ONE market (e.g. [-110,-110])"
+        }
+      },
+      "required": [
+        "oddsAmerican"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "find-arbitrage",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sport": {
+          "type": "string",
+          "description": "Sport key (e.g. basketball_nba)"
+        },
+        "markets": {
+          "type": "string",
+          "description": "Markets; default h2h"
+        },
+        "regions": {
+          "type": "string",
+          "description": "Regions (default us)"
+        }
+      },
+      "required": [
+        "sport"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "find-positive-ev",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sport": {
+          "type": "string",
+          "description": "Sport key (e.g. basketball_nba)"
+        },
+        "markets": {
+          "type": "string",
+          "description": "Markets; default h2h"
+        },
+        "regions": {
+          "type": "string",
+          "description": "Regions (default us)"
+        },
+        "threshold": {
+          "type": "number",
+          "description": "Minimum EV per unit to report (default 0.02 = +2%)"
+        }
+      },
+      "required": [
+        "sport"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-article",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string",
+          "description": "Slug of the article to retrieve"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "published",
+            "all"
+          ],
+          "description": "Visibility filter (default published). draft/all require admin context."
+        }
+      },
+      "required": [
+        "slug"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-author",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Author ID to retrieve"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-bet",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Bet ID"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-book",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Book ID to retrieve"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-content-creator",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "ContentCreator ID to retrieve"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-issue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$",
+          "description": "Repository in owner/repo format (e.g., 'owner/repo')"
+        },
+        "issueNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Issue number"
+        }
+      },
+      "required": [
+        "repo",
+        "issueNumber"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-movie",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Movie ID to retrieve"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-odds",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sport": {
+          "type": "string",
+          "description": "Sport key (e.g. basketball_nba)"
+        },
+        "markets": {
+          "type": "string",
+          "description": "Comma-separated markets (h2h,spreads,totals); default h2h"
+        },
+        "regions": {
+          "type": "string",
+          "description": "Regions (default us)"
+        },
+        "eventId": {
+          "type": "string",
+          "description": "Single event id (richer markets/props) instead of all events"
+        }
+      },
+      "required": [
+        "sport"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-open-issues",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$",
+          "description": "Repository in owner/repo format (e.g., 'owner/repo')"
+        },
+        "labels": {
+          "type": "string",
+          "description": "Comma-separated labels to filter by"
+        },
+        "limit": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "default": 10,
+          "description": "Maximum number of issues to return (default: 10)"
+        }
+      },
+      "required": [
+        "repo"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-project-fields",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        }
+      },
+      "required": [
+        "owner",
+        "projectNumber"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-project-status-options",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        }
+      },
+      "required": [
+        "owner",
+        "projectNumber"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-resume",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "includePrivate": {
+          "type": "boolean",
+          "description": "Include basics.privateContact (email/phone). Default false — public reads are stripped."
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-resume-download-request",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Request id"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-scores",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sport": {
+          "type": "string",
+          "description": "Sport key (e.g. basketball_nba)"
+        },
+        "daysFrom": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 3,
+          "description": "Include completed games from the last N days (1-3)"
+        }
+      },
+      "required": [
+        "sport"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-user",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "User id"
+        },
+        "email": {
+          "type": "string",
+          "format": "email",
+          "description": "User email"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "get-videogame",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Video game ID to retrieve"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-articles",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "published",
+            "all"
+          ],
+          "description": "Visibility filter (default published). draft/all require admin context."
+        },
+        "tag": {
+          "type": "string",
+          "description": "Filter by a single tag"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search in title and summary"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results (default 50)"
+        },
+        "offset": {
+          "type": "number",
+          "description": "Number of results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-authors",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Search in author name and bio"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results (default 50)"
+        },
+        "offset": {
+          "type": "number",
+          "description": "Number of results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-bets",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": [
+            "INTUITION",
+            "AI_ASSISTED"
+          ],
+          "description": "Filter by source"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "PENDING",
+            "WON",
+            "LOST",
+            "PUSH",
+            "VOID"
+          ],
+          "description": "Filter by status"
+        },
+        "sport": {
+          "type": "string",
+          "description": "Filter by sport"
+        },
+        "market": {
+          "type": "string",
+          "enum": [
+            "moneyline",
+            "spread",
+            "total",
+            "prop",
+            "parlay"
+          ],
+          "description": "Filter by market"
+        },
+        "limit": {
+          "type": "integer",
+          "description": "Max results (default 100)"
+        },
+        "offset": {
+          "type": "integer",
+          "description": "Results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-books",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "authorId": {
+          "type": "number",
+          "description": "Filter by author ID"
+        },
+        "minRating": {
+          "type": "number",
+          "description": "Minimum average rating (1-10)"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search in title and description"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Filter by status (Not started, In progress, Completed)"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results (default 50)"
+        },
+        "offset": {
+          "type": "number",
+          "description": "Number of results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-content-creators",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "search": {
+          "type": "string",
+          "description": "Search in name and description"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results (default 50)"
+        },
+        "offset": {
+          "type": "number",
+          "description": "Number of results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-events",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "sport": {
+          "type": "string",
+          "description": "Sport key (e.g. basketball_nba) — see list-sports"
+        }
+      },
+      "required": [
+        "sport"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-labels",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$",
+          "description": "Repository in owner/repo format (e.g., 'owner/repo')"
+        }
+      },
+      "required": [
+        "repo"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-movies",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "minRating": {
+          "type": "number",
+          "description": "Minimum average rating (1-10)"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search in title and description"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Filter by status"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results (default 50)"
+        },
+        "offset": {
+          "type": "number",
+          "description": "Number of results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-project-items",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        }
+      },
+      "required": [
+        "owner",
+        "projectNumber"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-resume-download-requests",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": [
+            "pending",
+            "approved",
+            "denied",
+            "fulfilled",
+            "expired",
+            "all"
+          ],
+          "description": "Filter by stored status (default: all)"
+        },
+        "userId": {
+          "type": "string",
+          "description": "Filter to a single user"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results (default 50)"
+        },
+        "offset": {
+          "type": "number",
+          "description": "Number of results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-sports",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-users",
+    "inputSchema": {
+      "type": "object",
+      "properties": {},
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "list-videogames",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "platform": {
+          "type": "string",
+          "enum": [
+            "PlayStation",
+            "Xbox",
+            "PC"
+          ],
+          "description": "Filter by platform"
+        },
+        "minRating": {
+          "type": "number",
+          "description": "Minimum average rating (1-10)"
+        },
+        "search": {
+          "type": "string",
+          "description": "Search in title and description"
+        },
+        "limit": {
+          "type": "number",
+          "description": "Maximum number of results (default 50)"
+        },
+        "offset": {
+          "type": "number",
+          "description": "Number of results to skip (default 0)"
+        }
+      },
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "prepare-bet-slip",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "event": {
+          "type": "string",
+          "description": "Event description (e.g. \"Lakers @ Celtics\")"
+        },
+        "market": {
+          "type": "string",
+          "enum": [
+            "moneyline",
+            "spread",
+            "total",
+            "prop",
+            "parlay"
+          ],
+          "description": "Market (defaults to parlay when legs given, else moneyline)"
+        },
+        "selection": {
+          "type": "string",
+          "description": "Selection for a single bet"
+        },
+        "line": {
+          "type": "number",
+          "description": "Spread/total line, if applicable"
+        },
+        "oddsAmerican": {
+          "type": "integer",
+          "description": "Required for a single bet; computed from legs for a parlay"
+        },
+        "stake": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Amount to risk"
+        },
+        "legs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Leg label"
+              },
+              "event": {
+                "type": "string",
+                "description": "Leg event"
+              },
+              "selection": {
+                "type": "string",
+                "description": "Leg selection"
+              },
+              "oddsAmerican": {
+                "type": "integer",
+                "description": "Leg American odds (optional; SGPs omit it)"
+              },
+              "line": {
+                "type": "number"
+              },
+              "fairProb": {
+                "type": "number",
+                "description": "Leg fair win prob (0..1) → enables EV"
+              }
+            },
+            "additionalProperties": false
+          },
+          "minItems": 2,
+          "description": "Parlay legs (≥2) instead of a single selection"
+        },
+        "sport": {
+          "type": "string",
+          "description": "Sport key for the DK link (e.g. basketball_nba)"
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "INTUITION",
+            "AI_ASSISTED"
+          ],
+          "description": "INTUITION or AI_ASSISTED"
+        },
+        "aiModel": {
+          "type": "string"
+        },
+        "aiRationale": {
+          "type": "string"
+        },
+        "aiEstProb": {
+          "type": "number"
+        },
+        "fairProb": {
+          "type": "number",
+          "description": "Fair win prob for a single bet → enables EV"
+        },
+        "book": {
+          "type": "string",
+          "description": "Sportsbook (default DraftKings)"
+        }
+      },
+      "required": [
+        "event",
+        "stake"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "record-resume-download",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Request id to record a download against"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "set-project-field-value",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "repo": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Repository name (just the name, not owner/repo)"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        },
+        "issueNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Issue number"
+        },
+        "fieldName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Field name"
+        },
+        "value": {
+          "type": [
+            "string",
+            "number"
+          ],
+          "description": "Field value (string or number)"
+        }
+      },
+      "required": [
+        "owner",
+        "repo",
+        "projectNumber",
+        "issueNumber",
+        "fieldName",
+        "value"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "settle-bet",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Bet ID"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "WON",
+            "LOST",
+            "PUSH",
+            "VOID"
+          ],
+          "description": "Outcome: WON | LOST | PUSH | VOID"
+        },
+        "payout": {
+          "type": "number",
+          "description": "Total returned on a win (incl. stake); computed if omitted"
+        }
+      },
+      "required": [
+        "id",
+        "status"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-article",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "slug": {
+          "type": "string",
+          "description": "Slug of the article to update"
+        },
+        "title": {
+          "type": "string",
+          "description": "Article title"
+        },
+        "summary": {
+          "type": "string",
+          "description": "Short summary / excerpt"
+        },
+        "body": {
+          "type": "string",
+          "description": "Article body (Markdown source)"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "draft",
+            "published"
+          ],
+          "description": "Publication status (draft | published)"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Tags"
+        },
+        "publishedAt": {
+          "type": "string",
+          "description": "Publication date (ISO 8601)"
+        },
+        "newSlug": {
+          "type": "string",
+          "description": "Rename the slug (must stay unique)"
+        }
+      },
+      "required": [
+        "slug"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-author",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Author ID"
+        },
+        "name": {
+          "type": "string",
+          "description": "Author name"
+        },
+        "bio": {
+          "type": "string",
+          "description": "Author biography"
+        },
+        "website": {
+          "type": "string",
+          "description": "Author website URL"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-bet",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer",
+          "description": "Bet ID"
+        },
+        "sport": {
+          "type": "string"
+        },
+        "league": {
+          "type": "string"
+        },
+        "event": {
+          "type": "string"
+        },
+        "market": {
+          "type": "string",
+          "enum": [
+            "moneyline",
+            "spread",
+            "total",
+            "prop",
+            "parlay"
+          ]
+        },
+        "selection": {
+          "type": "string"
+        },
+        "line": {
+          "type": "number"
+        },
+        "oddsAmerican": {
+          "type": "integer"
+        },
+        "stake": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "book": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string",
+          "enum": [
+            "INTUITION",
+            "AI_ASSISTED"
+          ]
+        },
+        "aiModel": {
+          "type": "string"
+        },
+        "aiRationale": {
+          "type": "string"
+        },
+        "aiEstProb": {
+          "type": "number"
+        },
+        "aiEV": {
+          "type": "number"
+        },
+        "closingLine": {
+          "type": "number",
+          "description": "Closing line (Phase 2 / #129)"
+        },
+        "closingOddsAmerican": {
+          "type": "integer",
+          "description": "Closing American odds (for CLV)"
+        },
+        "legs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "event": {
+                "type": "string",
+                "description": "Leg event description"
+              },
+              "selection": {
+                "type": "string",
+                "description": "Leg selection"
+              },
+              "oddsAmerican": {
+                "type": "integer",
+                "description": "Leg American odds (optional; SGPs omit it)"
+              },
+              "line": {
+                "type": "number",
+                "description": "Leg line, if applicable"
+              }
+            },
+            "required": [
+              "event",
+              "selection"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "notes": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-book",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Book ID"
+        },
+        "title": {
+          "type": "string",
+          "description": "Book title"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Book status (e.g., Not started, In progress, Completed)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Book description"
+        },
+        "rating": {
+          "type": "number",
+          "description": "Your rating (1-10 scale, optional)"
+        },
+        "review": {
+          "type": "string",
+          "description": "Your review text (optional)"
+        },
+        "isbn": {
+          "type": "string",
+          "description": "ISBN (must be unique)"
+        },
+        "publishedAt": {
+          "type": "string",
+          "description": "Publication date (ISO 8601 format)"
+        },
+        "authorIds": {
+          "type": "array",
+          "items": {
+            "type": "number"
+          },
+          "description": "Array of author IDs to associate with this book"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-content-creator",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Content creator ID"
+        },
+        "name": {
+          "type": "string",
+          "description": "Content creator name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of content creator"
+        },
+        "website": {
+          "type": "string",
+          "description": "Website URL"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-issue",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "repo": {
+          "type": "string",
+          "pattern": "^[^/]+\\/[^/]+$",
+          "description": "Repository in owner/repo format (e.g., 'owner/repo')"
+        },
+        "issueNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Issue number"
+        },
+        "title": {
+          "type": "string",
+          "description": "New issue title"
+        },
+        "body": {
+          "type": "string",
+          "description": "New issue body (Markdown allowed)"
+        },
+        "bodyFile": {
+          "type": "string",
+          "description": "Path to a Markdown file to use as the issue body"
+        },
+        "bodyJson": {
+          "description": "JSON payload to convert to Markdown for the issue body"
+        },
+        "labels": {
+          "type": "string",
+          "description": "Comma-separated labels to add to the issue"
+        },
+        "removeLabels": {
+          "type": "string",
+          "description": "Comma-separated labels to remove from the issue"
+        },
+        "assignees": {
+          "type": "string",
+          "description": "Comma-separated GitHub usernames to assign to the issue"
+        },
+        "milestone": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Milestone number to assign (use 0 to clear)"
+        },
+        "state": {
+          "type": "string",
+          "enum": [
+            "open",
+            "closed"
+          ],
+          "description": "Set issue state to open or closed"
+        },
+        "stateReason": {
+          "type": "string",
+          "enum": [
+            "completed",
+            "not_planned",
+            "reopened"
+          ],
+          "description": "Reason for closing: completed or not_planned (ignored when opening)"
+        },
+        "comment": {
+          "type": "string",
+          "description": "Comment to add to the issue"
+        }
+      },
+      "required": [
+        "repo",
+        "issueNumber"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-movie",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Movie ID"
+        },
+        "title": {
+          "type": "string",
+          "description": "Movie title"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Movie status (e.g., Not started, In progress, Completed)"
+        },
+        "description": {
+          "type": "string",
+          "description": "Movie description"
+        },
+        "iasn": {
+          "type": "string",
+          "description": "IASN (must be unique)"
+        },
+        "imdbId": {
+          "type": "string",
+          "description": "IMDB ID (must be unique)"
+        },
+        "releasedAt": {
+          "type": "string",
+          "description": "Release date (ISO 8601 format)"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-project-field",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "owner": {
+          "type": "string",
+          "minLength": 1,
+          "description": "GitHub username or organization name"
+        },
+        "projectNumber": {
+          "type": "integer",
+          "exclusiveMinimum": 0,
+          "description": "Project number (e.g., 2 for Project #2)"
+        },
+        "fieldName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Current field name to update"
+        },
+        "newName": {
+          "type": "string",
+          "minLength": 1,
+          "description": "New field name"
+        },
+        "addOptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Options to add (for SINGLE_SELECT fields)"
+        },
+        "removeOptions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Options to remove (for SINGLE_SELECT fields)"
+        }
+      },
+      "required": [
+        "owner",
+        "projectNumber",
+        "fieldName"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-resume",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "document": {
+          "type": "object",
+          "properties": {
+            "basics": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "label": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "summary": {
+                  "type": "string"
+                },
+                "location": {},
+                "profiles": {
+                  "type": "array"
+                },
+                "privateContact": {
+                  "type": "object",
+                  "properties": {
+                    "email": {
+                      "type": "string"
+                    },
+                    "phone": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "required": [
+                "name"
+              ],
+              "additionalProperties": true
+            },
+            "work": {
+              "type": "array"
+            },
+            "education": {
+              "type": "array"
+            },
+            "skills": {
+              "type": "array"
+            },
+            "projects": {
+              "type": "array"
+            }
+          },
+          "required": [
+            "basics"
+          ],
+          "additionalProperties": true,
+          "description": "The full JSON Resume document to store (replaces the singleton)."
+        }
+      },
+      "required": [
+        "document"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  },
+  {
+    "name": "update-videogame",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "number",
+          "description": "Video game ID"
+        },
+        "title": {
+          "type": "string",
+          "description": "Video game title"
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "NOT_STARTED",
+            "IN_PROGRESS",
+            "COMPLETED"
+          ],
+          "description": "Status"
+        },
+        "description": {
+          "type": "string",
+          "description": "Game description"
+        },
+        "platform": {
+          "type": "string",
+          "enum": [
+            "PlayStation",
+            "Xbox",
+            "PC"
+          ],
+          "description": "Platform (PlayStation, Xbox, PC)"
+        },
+        "igdbId": {
+          "type": "string",
+          "description": "IGDB ID (optional, unique)"
+        },
+        "releasedAt": {
+          "type": "string",
+          "description": "Release date (ISO 8601)"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "additionalProperties": false,
+      "$schema": "http://json-schema.org/draft-07/schema#"
+    }
+  }
+]

--- a/test/tools/tool-schemas.test.ts
+++ b/test/tools/tool-schemas.test.ts
@@ -1,0 +1,65 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { registerTools } from '../../src/tools/index.js'
+
+/**
+ * `inputSchema` is the contract every MCP client sees.
+ *
+ * The Zod schemas in `src/tools/**\/schemas.ts` are not the interface — the
+ * JSON Schema the SDK *derives* from them is, and that derivation is owned by
+ * whichever Zod major is installed. Nothing tested it. Upgrading zod 3 -> 4
+ * rewrote 69 of 71 tool schemas, dropped `additionalProperties: false` from 78
+ * places to 4, and the entire suite stayed green, because no assertion had ever
+ * looked at the generated output.
+ *
+ * Same shape as the `$queryRawUnsafe` and unregistered-metric bugs: the tests
+ * agreed with the code while neither was looking at the thing that moved.
+ *
+ * So this snapshots the derived schemas. It is deliberately not a test of the
+ * Zod source — a dependency upgrade can rewrite the output without touching a
+ * line of ours, which is precisely the case it exists to catch. When it fails,
+ * read the diff and decide whether the contract change was intended before
+ * running `vitest -u`.
+ */
+describe('MCP tool input schemas', () => {
+    let tools: Array<{ name: string; inputSchema: unknown }>
+
+    beforeAll(async () => {
+        const server = new McpServer({ name: 'schema-test', version: '0.0.0' })
+        registerTools(server)
+
+        const [clientTransport, serverTransport] =
+            InMemoryTransport.createLinkedPair()
+        const client = new Client({ name: 'schema-test', version: '0.0.0' })
+        await Promise.all([
+            server.connect(serverTransport),
+            client.connect(clientTransport),
+        ])
+
+        const listed = await client.listTools()
+        tools = listed.tools
+            .map((t) => ({ name: t.name, inputSchema: t.inputSchema }))
+            .sort((a, b) => a.name.localeCompare(b.name))
+    })
+
+    it('registers every tool with an object input schema', () => {
+        expect(tools.length).toBeGreaterThan(60)
+        const malformed = tools.filter(
+            (t) => (t.inputSchema as { type?: string })?.type !== 'object',
+        )
+        expect(malformed.map((t) => t.name)).toEqual([])
+    })
+
+    it('exposes no duplicate tool names', () => {
+        const names = tools.map((t) => t.name)
+        expect(names).toEqual([...new Set(names)])
+    })
+
+    it('matches the recorded client-facing schemas', async () => {
+        await expect(`${JSON.stringify(tools, null, 2)}\n`).toMatchFileSnapshot(
+            './__snapshots__/tool-schemas.json',
+        )
+    })
+})


### PR DESCRIPTION
Closes #165. Replaces the Dependabot PR.

**Two commits, deliberately.** The first records the client-facing schemas under zod 3; the second upgrades. So the contract change is a reviewable diff in this PR instead of something you'd have found in a client months later.

## The upgrade is one line

```diff
-.record(z.union([z.string(), z.number()]))
+.record(z.string(), z.union([z.string(), z.number()]))
```

That was the entire reported failure — which is exactly what made it dangerous. Apply it and the full suite goes green on zod 4, while the contract every MCP client consumes has been rewritten underneath.

## What the suite couldn't see

`inputSchema` is derived from our Zod objects by the SDK, and that derivation belongs to whichever Zod major is installed. The only test touching it was a gated integration test that skips by default — so **71 client-facing contracts had zero coverage**.

The snapshot in commit 1 makes it visible. Upgrading fails it:

| | zod 3 | zod 4 |
|---|---|---|
| tools changed | — | **69 / 71** |
| `additionalProperties` | **78** | **4** |
| `maximum` | 1 | 32 |
| `propertyNames` | 0 | 1 |

**The guard was verified against the real regression, not a synthetic one** — I recorded the baseline on zod 3, ran the upgrade, and watched it fail before accepting the new snapshot.

## Why `additionalProperties` disappears

`server/zod-json-schema-compat.js` in the SDK branches on the Zod major: v3 goes through the vendored `zod-to-json-schema`, v4 through Zod Mini's native `toJSONSchema`, which emits `additionalProperties: false` **only for strict objects**. Our tools pass raw shapes, so the SDK builds a default (strip) object and the constraint isn't emitted.

**Runtime validation is unchanged** — zod strips unknown keys in both majors. This is not a hole. What loosens is the *advertised* contract, and some clients use `additionalProperties: false` for strict function-calling.

## Why I didn't just restore it

I checked, and it's reachable: `getZodSchemaObject` passes a Zod schema through untouched, so `z.strictObject(shape)` would emit the constraint.

I left it out on purpose. `strictObject` also flips runtime behaviour from *strip unknown keys* to *reject* — across all 71 tools. That's a semantic change to every tool's input handling, and burying it inside a dependency upgrade is how you get a surprise. It deserves its own decision, so I'll file it separately.

## One config change

`biome.json` now excludes `**/__snapshots__`. Biome wanted to reformat the generated snapshot, which would fight `vitest -u` on every update.

## Verification

```
lint       ✓ 256 files
typecheck  ✓
tests      ✓ 426 passed | 8 skipped   (+3 new)
```

## Merge order

Independent of #174 and #175, but all three touch `package.json` / `pnpm-lock.yaml`. Whichever lands last may want a rebase — happy to do it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
